### PR TITLE
Bootstrap Lean to Slang pipeline with first DiffCloth kernel

### DIFF
--- a/.github/workflows/lean-slang.yml
+++ b/.github/workflows/lean-slang.yml
@@ -1,0 +1,90 @@
+name: lean-slang
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    # macos-14 (Apple Silicon) is what curvenet's matching pipeline uses
+    # and what slangc has the cleanest prebuilt assets for. macos-13 Intel
+    # runners are also fine but slower.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache .elan + lake-packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.elan
+            lean/.lake/packages
+            lean/.lake/build
+          key: elan-lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean/lean-toolchain', 'lean/lake-manifest.json') }}
+
+      - name: Install elan / Lean
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Slang toolchain
+        uses: actions/cache@v5
+        with:
+          path: bin/.slang
+          # OS + arch is essential here — slangc is a native binary, so a
+          # cache populated by a Linux runner is unusable on macOS aarch64
+          # and vice versa.
+          key: slang-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('misc/install-slang.sh') }}
+
+      - name: Fetch slangc
+        run: |
+          if [ ! -x bin/.slang/bin/slangc ]; then
+            misc/install-slang.sh
+          fi
+          bin/slangc -v
+
+      - name: Layer 0 — lake build (native_decide pins emitted Slang text)
+        working-directory: lean
+        run: lake build
+
+      - name: Emit every Slang kernel
+        working-directory: lean
+        run: |
+          mkdir -p /tmp/emitted_shaders
+          lake exe emit_shaders /tmp/emitted_shaders
+
+      - name: Layer 1 — slangc -target spirv round-trip on every kernel
+        run: |
+          ok=0; total=0; failed=
+          for f in /tmp/emitted_shaders/*.slang; do
+            total=$((total+1))
+            spv="${f%.slang}.spv"
+            if bin/slangc -target spirv -profile sm_6_5 -stage compute \
+                 -entry main -o "$spv" "$f" 2>/tmp/slangc_err.log; then
+              magic=$(xxd -l 4 -p "$spv")
+              size=$(stat -f%z "$spv")
+              if [ "$magic" = "03022307" ] && [ "$size" -gt 100 ]; then
+                ok=$((ok+1))
+              else
+                failed="$failed $(basename "$f"):bad-spirv"
+              fi
+            else
+              failed="$failed $(basename "$f"):slangc-fail"
+              cat /tmp/slangc_err.log | head -5
+            fi
+          done
+          echo "$ok / $total kernels round-trip to SPIR-V"
+          if [ -n "$failed" ]; then
+            echo "FAILED:$failed"
+            exit 1
+          fi
+
+      - name: Layer 2 — slangc -target cpp + clang + run on known inputs
+        run: make -C tests/slang_validate test

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,14 @@ godot.exe
 .godot/
 
 .DS_Store
+
+# Lean (Lake) build artifacts
+lean/.lake/
+lean/lake-packages/
+lean/build/
+
+# Slang toolchain — fetched by misc/install-slang.sh (~200MB)
+bin/.slang/
+
+# slang_validate harness build dir (emit cpp + test binaries)
+tests/slang_validate/build/

--- a/bin/slangc
+++ b/bin/slangc
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Wrapper that invokes the project-local slangc with all args passed through.
+# The actual binary + dylibs live under bin/.slang/ (gitignored, ~200MB).
+# Refetch with `misc/install-slang.sh` if missing.
+set -euo pipefail
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SELF_DIR/.slang/bin/slangc" "$@"

--- a/lean/Cloth.lean
+++ b/lean/Cloth.lean
@@ -1,0 +1,16 @@
+import Cloth.SlangCodegen
+
+/-!
+# `Cloth` — DiffCloth → Slang compute-shader codegen umbrella
+
+Lean 4 spec + LeanSlang DSL for the V-Sekai DiffCloth fork's GPU
+kernels. Mirrors the structure used by V-Sekai-fire's `Curvenet`
+project (Pixar Profile Curves articulation): per-kernel `native_decide`
+pinning of the emitted Slang source, paired with a `tests/slang_validate/`
+host-diff harness that bit-checks the slangc-cpp-target output against
+a hand-written CPU reference.
+
+Submodules live under `Cloth.SlangCodegen.*`. The first kernel is
+`Cloth.SlangCodegen.SpringProject`, the Projective-Dynamics local step
+for stretch springs (`src/code/simulation/Spring.{h,cpp}`).
+-/

--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -1,0 +1,17 @@
+import Cloth.SlangCodegen.SpringProject
+
+/-!
+# `Cloth.SlangCodegen` — Slang shader codegen umbrella
+
+Each submodule produces a `LeanSlang.SlangShaderModule` for one of
+the GPU kernels the DiffCloth runtime needs. Pinned `native_decide`
+fixtures assert the emission text against a hand-checked reference
+per kernel.
+
+Layout convention: every kernel module exports
+
+- `shader   : SlangShaderModule`
+- `expected : String`
+- two `example` lemmas: `emit shader = expected` and
+  `shader.entryPointName = "main"`.
+-/

--- a/lean/Cloth/SlangCodegen/SpringProject.lean
+++ b/lean/Cloth/SlangCodegen/SpringProject.lean
@@ -1,0 +1,146 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.SpringProject` — DiffCloth PD spring local-step
+
+First kernel ported into the Lean → LeanSlang DSL pipeline. Implements
+the Projective-Dynamics local step for a stretch spring, as defined in
+`src/code/simulation/Spring.cpp:108–113`:
+
+```cpp
+Eigen::VectorXd Spring::project(const VecXd &x_vec) const {
+  Vec3d pos_diff = (p1_vec3(x_vec) - p2_vec3(x_vec));
+  Vec3d dir      = pos_diff.normalized();
+  Vec3d p        = dir * l0;
+  return sqrtConstraintWeight * p;
+}
+```
+
+Per spring `i`, with rest length `l0[i]`, sqrt weight `w[i]`, and
+endpoint indices `(a, b)` into the position buffer:
+
+```
+projected[i] = (w[i] * l0[i] / |p_a − p_b|) · (p_a − p_b)
+```
+
+One thread per spring. The host pads the dispatch to a multiple of
+the group size (64) and seeds unused slots with safe values
+(`p1Idx = 0`, `p2Idx` = any index with a distinct position,
+`restLen = 0`, `sqrtWeight = 0` → output `(0,0,0)`).
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions   length = N_verts
+  1  RWStructuredBuffer<float3> projected   length = N_springs (rounded up)
+  2  StructuredBuffer<uint>     p1Idx       length = N_springs
+  3  StructuredBuffer<uint>     p2Idx       length = N_springs
+  4  StructuredBuffer<float>    restLen     length = N_springs
+  5  StructuredBuffer<float>    sqrtWeight  length = N_springs
+
+Per-spring sqrtWeight (rather than a uniform scalar) keeps the kernel
+extensible to non-uniform stiffness without an ABI change.
+
+The pinned reference text below is asserted by `native_decide`. Any
+drift in `LeanSlang.Emit` that affects this output trips here. The
+matching slangc-cpp host-diff harness lives in
+`tests/slang_validate/spring_project_test.cpp`.
+-/
+
+namespace Cloth.SlangCodegen.SpringProject
+
+open LeanSlang
+
+/-- PD per-spring projection kernel as a Slang shader module. -/
+def shader : SlangShaderModule :=
+  let f3 : SlangType := .vec .float 3
+  let u  : SlangType := .scalar .uint
+  let f  : SlangType := .scalar .float
+  let bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+    { name := name, type := t, semantic := Semantic.none
+    , binding := some n, space := some 0 }
+  let body : List SlangStmt :=
+    [ .declInit u  "i"   (.member (.var "tid") "x")
+    , .declInit u  "a"   (.index (.var "p1Idx") (.var "i"))
+    , .declInit u  "b"   (.index (.var "p2Idx") (.var "i"))
+    , .declInit f3 "p1"  (.index (.var "positions") (.var "a"))
+    , .declInit f3 "p2"  (.index (.var "positions") (.var "b"))
+    , .declInit f  "dx"  (.bin "-" (.member (.var "p1") "x")
+                                   (.member (.var "p2") "x"))
+    , .declInit f  "dy"  (.bin "-" (.member (.var "p1") "y")
+                                   (.member (.var "p2") "y"))
+    , .declInit f  "dz"  (.bin "-" (.member (.var "p1") "z")
+                                   (.member (.var "p2") "z"))
+    , .declInit f  "len2"
+        (.bin "+"
+          (.bin "+" (.bin "*" (.var "dx") (.var "dx"))
+                    (.bin "*" (.var "dy") (.var "dy")))
+          (.bin "*" (.var "dz") (.var "dz")))
+    , .declInit f  "len" (.call "sqrt" [.var "len2"])
+    , .declInit f  "scale"
+        (.bin "/"
+          (.bin "*" (.index (.var "sqrtWeight") (.var "i"))
+                    (.index (.var "restLen") (.var "i")))
+          (.var "len"))
+    , .assign (.index (.var "projected") (.var "i"))
+        (.call "float3"
+          [ .bin "*" (.var "scale") (.var "dx")
+          , .bin "*" (.var "scale") (.var "dy")
+          , .bin "*" (.var "scale") (.var "dz") ])
+    ]
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "projected"  (.rwBuf f3)
+      , bnd 2 "p1Idx"      (.roBuf u)
+      , bnd 3 "p2Idx"      (.roBuf u)
+      , bnd 4 "restLen"    (.roBuf f)
+      , bnd 5 "sqrtWeight" (.roBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+/-- Pinned reference emission. Drift in `LeanSlang.Emit` trips
+    `native_decide` below. Update both this string and the kernel
+    in lockstep. -/
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+RWStructuredBuffer<float3> projected;
+[[vk::binding(2, 0)]]
+StructuredBuffer<uint> p1Idx;
+[[vk::binding(3, 0)]]
+StructuredBuffer<uint> p2Idx;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> restLen;
+[[vk::binding(5, 0)]]
+StructuredBuffer<float> sqrtWeight;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  uint a = p1Idx[i];
+  uint b = p2Idx[i];
+  float3 p1 = positions[a];
+  float3 p2 = positions[b];
+  float dx = (p1.x - p2.x);
+  float dy = (p1.y - p2.y);
+  float dz = (p1.z - p2.z);
+  float len2 = (((dx * dx) + (dy * dy)) + (dz * dz));
+  float len = sqrt(len2);
+  float scale = ((sqrtWeight[i] * restLen[i]) / len);
+  projected[i] = float3((scale * dx), (scale * dy), (scale * dz));
+}"
+
+/-- The pretty-printer matches the pinned reference. -/
+example : LeanSlang.emit shader = expected := by native_decide
+
+/-- The kernel's entry-point name is `main`. -/
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.SpringProject

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -1,0 +1,31 @@
+import LeanSlang
+import Cloth.SlangCodegen
+
+/-!
+# `emit_shaders` — Lake exe dumping every Slang shader to disk
+
+For each `Cloth.SlangCodegen.*` kernel, writes the emitted Slang
+source to `<outDir>/<name>.slang`. Used as input to slangc for
+syntactic / semantic validation beyond the `native_decide` text
+fixtures (see `tests/slang_validate/Makefile`).
+
+Usage:
+
+    lake exe emit_shaders /path/to/output/dir
+-/
+
+open Cloth.SlangCodegen
+open LeanSlang
+
+private def kernels : List (String × SlangShaderModule) :=
+  [ ("spring_project", SpringProject.shader)
+  ]
+
+def main (args : List String) : IO UInt32 := do
+  let outDir := args.headD "."
+  IO.FS.createDirAll outDir
+  for (name, m) in kernels do
+    let path := outDir ++ "/" ++ name ++ ".slang"
+    IO.FS.writeFile path (LeanSlang.emit m ++ "\n")
+    IO.println s!"wrote {path}"
+  return 0

--- a/lean/lake-manifest.json
+++ b/lean/lake-manifest.json
@@ -1,0 +1,15 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"url": "https://github.com/V-Sekai-fire/lean-slang.git",
+   "type": "git",
+   "subDir": null,
+   "scope": "",
+   "rev": "813d6c62b298bcd3f7177264179a7e1d16bd87cd",
+   "name": "LeanSlang",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "v0.0.5",
+   "inherited": false,
+   "configFile": "lakefile.toml"}],
+ "name": "Cloth",
+ "lakeDir": ".lake"}

--- a/lean/lakefile.lean
+++ b/lean/lakefile.lean
@@ -1,0 +1,12 @@
+import Lake
+open Lake DSL
+
+package Cloth where
+
+require LeanSlang from git
+  "https://github.com/V-Sekai-fire/lean-slang.git" @ "v0.0.5"
+
+@[default_target] lean_lib Cloth where
+
+lean_exe emit_shaders where
+  root := `EmitShaders

--- a/lean/lean-toolchain
+++ b/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.29.1

--- a/misc/install-slang.sh
+++ b/misc/install-slang.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fetch the upstream Slang shader compiler into bin/.slang/ for use by
+# the bin/slangc wrapper. Run from the repo root.
+#
+# Why this isn't a brew install: brew has no Slang shader formula
+# (the formula named `s-lang` is John E. Davis's S-Lang interpreter,
+# unrelated). Upstream ships pre-built tarballs on GitHub Releases.
+#
+# The fetched ~200MB toolchain is gitignored under bin/.slang/.
+# bin/slangc is a checked-in shim that exec's bin/.slang/bin/slangc.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SLANG_DIR="$REPO_ROOT/bin/.slang"
+SLANG_VERSION="${SLANG_VERSION:-2026.8.1}"
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64)   ASSET="slang-${SLANG_VERSION}-macos-aarch64.zip" ;;
+  Darwin-x86_64)  ASSET="slang-${SLANG_VERSION}-macos-x86_64.zip"  ;;
+  Linux-x86_64)   ASSET="slang-${SLANG_VERSION}-linux-x86_64.tar.gz" ;;
+  Linux-aarch64)  ASSET="slang-${SLANG_VERSION}-linux-aarch64.tar.gz" ;;
+  *)
+    echo "no prebuilt slang asset for $(uname -s)-$(uname -m)" >&2
+    echo "see https://github.com/shader-slang/slang/releases" >&2
+    exit 1
+    ;;
+esac
+
+URL="https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/${ASSET}"
+
+echo "Fetching $URL"
+mkdir -p "$SLANG_DIR"
+TMP="$(mktemp -d)"
+trap "rm -rf '$TMP'" EXIT
+
+cd "$TMP"
+curl -fL -o slang.archive "$URL"
+case "$ASSET" in
+  *.zip)     unzip -q slang.archive ;;
+  *.tar.gz)  tar -xzf slang.archive ;;
+esac
+
+# Strip the toolchain into bin/.slang/, replacing whatever was there.
+rm -rf "$SLANG_DIR"/{bin,lib,include,share,LICENSE,README.md} 2>/dev/null || true
+mv bin lib include share LICENSE README.md "$SLANG_DIR"/
+
+# Smoke-test the shim.
+"$REPO_ROOT/bin/slangc" -v
+echo "Installed Slang ${SLANG_VERSION} into bin/.slang/"

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -1,0 +1,69 @@
+# Real-input validators for the Cloth.SlangCodegen.* kernels.
+#
+# Each kernel is converted by `slangc -target cpp` to a CPU function
+# `main_0(varyingInput, params, globals)`, then compiled together
+# with a hand-written test harness that:
+#   1. populates the kernel's input buffers with known values,
+#   2. invokes the kernel as a single dispatch,
+#   3. asserts the output matches an independent CPU reference.
+#
+# `make test` runs every harness; non-zero exit on any failure.
+#
+# Tests are listed as `<test_name>:<kernel_name>` pairs so multiple
+# tests can share the same kernel emit if needed.
+#
+# Prerequisite: a slangc toolchain at <repo>/bin/.slang/, installed by
+#   misc/install-slang.sh
+# The bin/slangc wrapper is a shim that exec's bin/.slang/bin/slangc.
+
+REPO_ROOT  := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+SLANGC     := $(REPO_ROOT)/bin/slangc
+SLANG_DIR  := $(REPO_ROOT)/bin/.slang
+EMITTED    := $(CURDIR)/build
+LEAN_DIR   := $(REPO_ROOT)/lean
+
+CXX        ?= clang++
+# -Wno-unused-parameter silences clang's complaint about
+# `entryPointParams_0` in slangc -target cpp output (the parameter is
+# part of the Slang ABI and unused by every compute kernel we emit).
+CXXFLAGS   ?= -std=c++17 -O2 -Wall -Wextra -Wno-unused-parameter
+INCLUDES   := -I$(SLANG_DIR)/include -I$(EMITTED)
+
+# Per-test-to-kernel mapping. test_name → kernel_name.
+TESTS      := spring_project:spring_project
+
+TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
+KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))
+
+KERNELS    := $(sort $(foreach t,$(TESTS),$(word 2,$(subst :, ,$(t)))))
+SHADERS    := $(addprefix $(EMITTED)/,$(addsuffix _emit.cpp,$(KERNELS)))
+BINS       := $(addprefix $(EMITTED)/,$(addsuffix _test,$(TEST_NAMES)))
+
+.PHONY: test clean emit-shaders
+
+test: $(BINS)
+	@fails=0; \
+	for b in $(BINS); do \
+	  echo "=== $$b"; $$b || fails=$$(( fails + 1 )); \
+	done; \
+	if [ $$fails -ne 0 ]; then echo "FAILED: $$fails"; exit 1; fi; \
+	echo "all kernels OK"
+
+# Make sure the .slang files exist before we ask slangc for cpp output.
+emit-shaders:
+	@cd $(LEAN_DIR) && lake exe emit_shaders /tmp/emitted_shaders >/dev/null
+
+# slang → cpp source.
+$(EMITTED)/%_emit.cpp: emit-shaders
+	@mkdir -p $(EMITTED)
+	$(SLANGC) -target cpp -stage compute -entry main \
+	  -o $@ /tmp/emitted_shaders/$*.slang
+
+# Per-test build rule. Each test_name maps to a kernel_name via the
+# TESTS list; the test source #include's its kernel's emit.
+.SECONDEXPANSION:
+$(EMITTED)/%_test: %_test.cpp $$(EMITTED)/$$(call KERNEL_FOR,%)_emit.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -o $@ $<
+
+clean:
+	rm -rf $(EMITTED)

--- a/tests/slang_validate/spring_project_test.cpp
+++ b/tests/slang_validate/spring_project_test.cpp
@@ -1,0 +1,113 @@
+// Real-input validator for Cloth.SlangCodegen.SpringProject — the
+// DiffCloth PD spring local-step, the first kernel ported through the
+// Lean → LeanSlang → slangc-cpp → executable chain.
+//
+// Reference: src/code/simulation/Spring.cpp:108–113. For each spring,
+//   projected[i] = (sqrtWeight[i] * restLen[i] / |p_a − p_b|) · (p_a − p_b)
+// where (a, b) = (p1Idx[i], p2Idx[i]).
+//
+// Test fixture (2 real springs over 3 verts):
+//   v0 = (0,0,0), v1 = (3,0,0), v2 = (0,4,0)
+//   spring 0: a=1 b=0, restLen=1.0, sqrtWeight=1.0
+//     diff=(3,0,0), len=3, scale=1/3 → out=(1,0,0)
+//   spring 1: a=2 b=0, restLen=2.0, sqrtWeight=1.0
+//     diff=(0,4,0), len=4, scale=1/2 → out=(0,2,0)
+//
+// One thread group of 64 (matches the kernel's [numthreads(64,1,1)]).
+// Padded slots 2..63 use a=1, b=0 (distinct positions → nonzero len,
+// no divide-by-zero) with restLen=0 and sqrtWeight=0, so scale=0 and
+// the slot output is (0,0,0). Only slots 0..1 are checked.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "spring_project_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_SPRINGS = 2;
+    constexpr uint32_t GROUP_SIZE = 64;   // numthreads(64,1,1) — pad to one group
+
+    // ---- Positions: 3 verts, no padding needed (only referenced by index).
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(3.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 4.0f, 0.0f),
+    };
+
+    std::vector<Vector<float, 3>> projected(GROUP_SIZE, Vector<float, 3>(0.0f));
+
+    // ---- Spring buffers padded to GROUP_SIZE.
+    // Real springs:                    spring 0,   spring 1
+    // Padded slots (2..63):  a=1, b=0 (distinct → len>0), restLen=0, sqrtWeight=0.
+    std::vector<uint32_t> p1Idx(GROUP_SIZE, 1u);
+    std::vector<uint32_t> p2Idx(GROUP_SIZE, 0u);
+    std::vector<float>    restLen(GROUP_SIZE, 0.0f);
+    std::vector<float>    sqrtWeight(GROUP_SIZE, 0.0f);
+
+    p1Idx[0] = 1u; p2Idx[0] = 0u; restLen[0] = 1.0f; sqrtWeight[0] = 1.0f;
+    p1Idx[1] = 2u; p2Idx[1] = 0u; restLen[1] = 2.0f; sqrtWeight[1] = 1.0f;
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data   = positions.data();   gp.positions_0.count   = positions.size();
+    gp.projected_0.data   = projected.data();   gp.projected_0.count   = projected.size();
+    gp.p1Idx_0.data       = p1Idx.data();       gp.p1Idx_0.count       = p1Idx.size();
+    gp.p2Idx_0.data       = p2Idx.data();       gp.p2Idx_0.count       = p2Idx.size();
+    gp.restLen_0.data     = restLen.data();     gp.restLen_0.count     = restLen.size();
+    gp.sqrtWeight_0.data  = sqrtWeight.data();  gp.sqrtWeight_0.count  = sqrtWeight.size();
+
+    // One thread group of 64 covers both real springs plus the padding.
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    // ---- Reference: independent CPU evaluation of the same kernel.
+    const float expected[N_SPRINGS][3] = {
+        {1.0f, 0.0f, 0.0f},
+        {0.0f, 2.0f, 0.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t s = 0; s < N_SPRINGS; ++s) {
+        for (int c = 0; c < 3; ++c) {
+            const float got = projected[s][c];
+            const float ref = expected[s][c];
+            const float d   = std::fabs(got - ref);
+            if (d > max_abs_diff) max_abs_diff = d;
+            if (d > 1e-6f) {
+                if (fails < 5) {
+                    std::fprintf(stderr,
+                        "spring_project mismatch at s=%u, c=%d: got %g, expected %g (diff %g)\n",
+                        s, c, got, ref, d);
+                }
+                ++fails;
+            }
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr,
+            "spring_project: TIMEOUT — %.3fs > budget %.1fs\n",
+            elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf(
+            "spring_project: %u/%u springs OK (max_abs_diff=%g, %.1fms)\n",
+            N_SPRINGS, N_SPRINGS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "spring_project: %d FAIL out of %u (%u springs × 3 components)\n",
+                 fails, N_SPRINGS * 3u, N_SPRINGS);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Bootstraps the Lean 4 + LeanSlang shader-codegen pipeline inside this repo, and ports the first DiffCloth kernel — `Spring::project` (the Projective-Dynamics local step) — into a slangc-compilable compute shader pinned by `native_decide` and bit-diffed against a CPU reference.

This mirrors the structure V-Sekai-fire's [TOOL_godot_curvenet](https://github.com/V-Sekai-fire/TOOL_godot_curvenet) uses for Pixar's Profile Curves rig, applied here to DiffCloth.

## What's in the box

| Path | Purpose |
|---|---|
| `lean/lean-toolchain` | `leanprover/lean4:v4.29.1` |
| `lean/lakefile.lean` | `Cloth` lib + `emit_shaders` exe; pulls `V-Sekai-fire/lean-slang@v0.0.5` |
| `lean/Cloth/SlangCodegen/SpringProject.lean` | The kernel — `LeanSlang.SlangShaderModule` for the PD spring local step, with pinned `expected` text and `native_decide` |
| `lean/EmitShaders.lean` | `lake exe emit_shaders <out>` writes every kernel to `<out>/<name>.slang` |
| `bin/slangc` | Shim that exec's the local slangc |
| `misc/install-slang.sh` | One-shot fetch of the upstream Slang toolchain into `bin/.slang/` (~200MB, gitignored) |
| `tests/slang_validate/Makefile` | Runs `slangc -target cpp` on each emitted kernel and links it against the matching host harness |
| `tests/slang_validate/spring_project_test.cpp` | 2 real springs over 3 verts (padded to GROUP_SIZE=64), bit-diff against an independent CPU reference |

## The first kernel

```cpp
// src/code/simulation/Spring.cpp:108-113
Eigen::VectorXd Spring::project(const VecXd &x_vec) const {
  Vec3d pos_diff = (p1_vec3(x_vec) - p2_vec3(x_vec));
  Vec3d dir      = pos_diff.normalized();
  Vec3d p        = dir * l0;
  return sqrtConstraintWeight * p;
}
```

per spring `i`:

```
projected[i] = (sqrtWeight[i] * restLen[i] / |p_a − p_b|) · (p_a − p_b)
```

## Verification

```sh
# One-time: fetch the slang toolchain (~200MB, gitignored).
misc/install-slang.sh

# Layer 1: Lean native_decide — the emitted Slang text matches the pinned reference.
cd lean && lake build

# Layer 2: slangc -target cpp + host-diff — the kernel produces bit-exact output.
make -C tests/slang_validate test
# → spring_project: 2/2 springs OK (max_abs_diff=0, 0.0ms)
# → all kernels OK
```

Both layers green locally on macOS aarch64.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned Slang emission.
- [x] `make -C tests/slang_validate test` — slangc-cpp output bit-matches the CPU reference for both real springs.
- [x] (Follow-up PR) GitHub Actions workflow that runs both layers on every push.
- [ ] (Follow-up PR) Port the next DiffCloth kernel — candidates: AttachmentSpring::project (single-vertex pinning), Triangle::project (in-plane stretch), TriangleBending::project (dihedral bending), or a global-solve building block (`spmv` / `saxpby` / `dot_reduce` for the PD outer CG loop).