### PR TITLE
Port TriangleBending::project as the second DiffCloth kernel

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -1,4 +1,5 @@
 import Cloth.SlangCodegen.SpringProject
+import Cloth.SlangCodegen.TriangleBending
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/TriangleBending.lean
+++ b/lean/Cloth/SlangCodegen/TriangleBending.lean
@@ -1,0 +1,198 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.TriangleBending` — DiffCloth PD bending local-step
+
+Second kernel ported. Implements the Projective-Dynamics local step for
+a dihedral-bending constraint, as defined in
+`src/code/simulation/TriangleBending.cpp:project`:
+
+```cpp
+VecXd TriangleBending::project(const VecXd &x_vec) const {
+  Vec3d e; e.setZero();
+  if (n > 1e-6) {
+    for (int i = 0; i < 4; i++)
+      e += weightVert[i] * x_vec.segment(3 * idx_arr[i], 3);
+    e = e.normalized() * n;
+  }
+  return constrainWeightSqrt * e;
+}
+```
+
+Per constraint `c` (4-vertex stencil over the two triangles sharing an
+edge, with bind-time cotangent-Laplacian weights):
+
+```
+e_c = Σ_{j=0..3} weight[4c + j] · positions[idx[4c + j]]
+projected[c] = sqrtWeight[c] · ( e_c / |e_c| · nTarget[c] )     if nTarget[c] > 1e-6
+             = (0, 0, 0)                                         otherwise
+```
+
+`nTarget` is captured at bind time and represents the rest-pose bending
+magnitude; the local step pulls the current weighted sum toward that
+magnitude while preserving its direction. The `nTarget == 0` branch
+covers degenerate / collinear stencils.
+
+One thread per constraint. The host pads the dispatch to a multiple of
+the group size (64) and seeds unused slots with `nTarget = 0` so they
+short-circuit to `(0,0,0)` without touching the (idx, weight) buffers.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions   length = N_verts
+  1  RWStructuredBuffer<float3> projected   length = N_constraints (rounded up)
+  2  StructuredBuffer<uint>     idx         length = 4 · N_constraints
+  3  StructuredBuffer<float>    weight      length = 4 · N_constraints
+  4  StructuredBuffer<float>    nTarget     length = N_constraints
+  5  StructuredBuffer<float>    sqrtWeight  length = N_constraints
+
+The pinned reference text below is asserted by `native_decide`. The
+matching slangc-cpp host-diff harness lives in
+`tests/slang_validate/triangle_bending_test.cpp`.
+-/
+
+namespace Cloth.SlangCodegen.TriangleBending
+
+open LeanSlang
+
+/-- PD per-constraint bending projection kernel. -/
+def shader : SlangShaderModule :=
+  let f3 : SlangType := .vec .float 3
+  let u  : SlangType := .scalar .uint
+  let f  : SlangType := .scalar .float
+  let bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+    { name := name, type := t, semantic := Semantic.none
+    , binding := some n, space := some 0 }
+  let body : List SlangStmt :=
+    [ .declInit u  "c"    (.member (.var "tid") "x")
+    , .declInit f  "n_c"  (.index (.var "nTarget") (.var "c"))
+    , .declInit f  "ex"   (.litFloat 0.0)
+    , .declInit f  "ey"   (.litFloat 0.0)
+    , .declInit f  "ez"   (.litFloat 0.0)
+    , .ifNoElse (.bin ">" (.var "n_c") (.litFloat 0.000001))
+        [ .declInit u  "base" (.bin "*" (.var "c") (.litUint 4))
+        , .declInit u  "i0"   (.index (.var "idx") (.var "base"))
+        , .declInit u  "i1"   (.index (.var "idx")
+                                (.bin "+" (.var "base") (.litUint 1)))
+        , .declInit u  "i2"   (.index (.var "idx")
+                                (.bin "+" (.var "base") (.litUint 2)))
+        , .declInit u  "i3"   (.index (.var "idx")
+                                (.bin "+" (.var "base") (.litUint 3)))
+        , .declInit f  "w0"   (.index (.var "weight") (.var "base"))
+        , .declInit f  "w1"   (.index (.var "weight")
+                                (.bin "+" (.var "base") (.litUint 1)))
+        , .declInit f  "w2"   (.index (.var "weight")
+                                (.bin "+" (.var "base") (.litUint 2)))
+        , .declInit f  "w3"   (.index (.var "weight")
+                                (.bin "+" (.var "base") (.litUint 3)))
+        , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
+        , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
+        , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
+        , .declInit f3 "p3"   (.index (.var "positions") (.var "i3"))
+        , .declInit f  "sx"
+            (.bin "+"
+              (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "x"))
+                        (.bin "*" (.var "w1") (.member (.var "p1") "x")))
+              (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "x"))
+                        (.bin "*" (.var "w3") (.member (.var "p3") "x"))))
+        , .declInit f  "sy"
+            (.bin "+"
+              (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "y"))
+                        (.bin "*" (.var "w1") (.member (.var "p1") "y")))
+              (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "y"))
+                        (.bin "*" (.var "w3") (.member (.var "p3") "y"))))
+        , .declInit f  "sz"
+            (.bin "+"
+              (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "z"))
+                        (.bin "*" (.var "w1") (.member (.var "p1") "z")))
+              (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "z"))
+                        (.bin "*" (.var "w3") (.member (.var "p3") "z"))))
+        , .declInit f  "len"
+            (.call "sqrt"
+              [ .bin "+"
+                  (.bin "+" (.bin "*" (.var "sx") (.var "sx"))
+                            (.bin "*" (.var "sy") (.var "sy")))
+                  (.bin "*" (.var "sz") (.var "sz")) ])
+        , .declInit f  "scale" (.bin "/" (.var "n_c") (.var "len"))
+        , .assign (.var "ex") (.bin "*" (.var "scale") (.var "sx"))
+        , .assign (.var "ey") (.bin "*" (.var "scale") (.var "sy"))
+        , .assign (.var "ez") (.bin "*" (.var "scale") (.var "sz"))
+        ]
+    , .declInit f  "sw"  (.index (.var "sqrtWeight") (.var "c"))
+    , .assign (.index (.var "projected") (.var "c"))
+        (.call "float3"
+          [ .bin "*" (.var "sw") (.var "ex")
+          , .bin "*" (.var "sw") (.var "ey")
+          , .bin "*" (.var "sw") (.var "ez") ])
+    ]
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "projected"  (.rwBuf f3)
+      , bnd 2 "idx"        (.roBuf u)
+      , bnd 3 "weight"     (.roBuf f)
+      , bnd 4 "nTarget"    (.roBuf f)
+      , bnd 5 "sqrtWeight" (.roBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+/-- Pinned reference emission. -/
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+RWStructuredBuffer<float3> projected;
+[[vk::binding(2, 0)]]
+StructuredBuffer<uint> idx;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> weight;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> nTarget;
+[[vk::binding(5, 0)]]
+StructuredBuffer<float> sqrtWeight;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  float n_c = nTarget[c];
+  float ex = 0.000000;
+  float ey = 0.000000;
+  float ez = 0.000000;
+  if ((n_c > 0.000001)) {
+    uint base = (c * 4u);
+    uint i0 = idx[base];
+    uint i1 = idx[(base + 1u)];
+    uint i2 = idx[(base + 2u)];
+    uint i3 = idx[(base + 3u)];
+    float w0 = weight[base];
+    float w1 = weight[(base + 1u)];
+    float w2 = weight[(base + 2u)];
+    float w3 = weight[(base + 3u)];
+    float3 p0 = positions[i0];
+    float3 p1 = positions[i1];
+    float3 p2 = positions[i2];
+    float3 p3 = positions[i3];
+    float sx = (((w0 * p0.x) + (w1 * p1.x)) + ((w2 * p2.x) + (w3 * p3.x)));
+    float sy = (((w0 * p0.y) + (w1 * p1.y)) + ((w2 * p2.y) + (w3 * p3.y)));
+    float sz = (((w0 * p0.z) + (w1 * p1.z)) + ((w2 * p2.z) + (w3 * p3.z)));
+    float len = sqrt((((sx * sx) + (sy * sy)) + (sz * sz)));
+    float scale = (n_c / len);
+    ex = (scale * sx);
+    ey = (scale * sy);
+    ez = (scale * sz);
+  }
+  float sw = sqrtWeight[c];
+  projected[c] = float3((sw * ex), (sw * ey), (sw * ez));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.TriangleBending

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -18,7 +18,8 @@ open Cloth.SlangCodegen
 open LeanSlang
 
 private def kernels : List (String × SlangShaderModule) :=
-  [ ("spring_project", SpringProject.shader)
+  [ ("spring_project",   SpringProject.shader)
+  , ("triangle_bending", TriangleBending.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -30,7 +30,7 @@ CXXFLAGS   ?= -std=c++17 -O2 -Wall -Wextra -Wno-unused-parameter
 INCLUDES   := -I$(SLANG_DIR)/include -I$(EMITTED)
 
 # Per-test-to-kernel mapping. test_name → kernel_name.
-TESTS      := spring_project:spring_project
+TESTS      := spring_project:spring_project triangle_bending:triangle_bending
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/triangle_bending_test.cpp
+++ b/tests/slang_validate/triangle_bending_test.cpp
@@ -1,0 +1,137 @@
+// Real-input validator for Cloth.SlangCodegen.TriangleBending — the
+// DiffCloth PD dihedral-bending local step.
+//
+// Reference: src/code/simulation/TriangleBending.cpp:project. For each
+// constraint, with 4-vertex stencil (idx[4c..4c+3]) and cotangent
+// weights (weight[4c..4c+3]):
+//
+//   if (nTarget[c] > 1e-6) {
+//     e_c   = sum_j weight[4c+j] * positions[idx[4c+j]]
+//     e_c   = (e_c / |e_c|) * nTarget[c]
+//   } else {
+//     e_c   = (0, 0, 0)
+//   }
+//   projected[c] = sqrtWeight[c] * e_c
+//
+// Test fixture (2 constraints sharing 4 vertices in a tetrahedral pose):
+//   v0 = (0, 0, 0),  v1 = (1, 0, 0),  v2 = (0, 1, 0),  v3 = (0, 0, 1)
+//
+//   constraint 0 (active): weights = (-1, 1, 1, -1), nTarget = sqrt(3),
+//                          sqrtWeight = 1
+//       sum = (-1*v0 + 1*v1 + 1*v2 + -1*v3) = (1, 1, -1), |sum| = sqrt(3)
+//       e   = sum / sqrt(3) * sqrt(3)     = (1, 1, -1)
+//       out = 1 * (1, 1, -1)              = (1, 1, -1)
+//
+//   constraint 1 (degenerate): nTarget = 0 → short-circuit
+//       out = (0, 0, 0) regardless of weights / positions
+//
+// Padding (slots 2..63): nTarget = 0 makes the kernel skip the
+// idx/weight loads entirely, so those buffers only need the 8 entries
+// covering the 2 real constraints.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "triangle_bending_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_CONSTRAINTS_REAL = 2;
+    constexpr uint32_t N_CONSTRAINTS_TOTAL = 64;  // = GROUP_SIZE
+    constexpr uint32_t N_REAL_INDICES = 4u * N_CONSTRAINTS_REAL;
+
+    // 4 vertices forming a corner of a unit cube.
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(1.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 1.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 1.0f),
+    };
+
+    std::vector<Vector<float, 3>> projected(N_CONSTRAINTS_TOTAL,
+                                            Vector<float, 3>(0.0f));
+
+    // Stencil indices for the 2 real constraints — both reference the
+    // same 4 verts in the same order.
+    std::vector<uint32_t> idx(N_REAL_INDICES);
+    for (uint32_t c = 0; c < N_CONSTRAINTS_REAL; ++c) {
+        idx[4*c + 0] = 0u;
+        idx[4*c + 1] = 1u;
+        idx[4*c + 2] = 2u;
+        idx[4*c + 3] = 3u;
+    }
+
+    // Weights: constraint 0 uses an asymmetric (−1,1,1,−1) stencil to
+    // give a non-axis-aligned, easy-to-eyeball expected output.
+    std::vector<float> weight(N_REAL_INDICES);
+    weight[0] = -1.0f; weight[1] = 1.0f; weight[2] = 1.0f; weight[3] = -1.0f;
+    weight[4] =  0.0f; weight[5] = 0.0f; weight[6] = 0.0f; weight[7] =  0.0f;
+
+    // nTarget = 0 short-circuits to (0,0,0); all padded slots stay 0.
+    std::vector<float> nTarget(N_CONSTRAINTS_TOTAL, 0.0f);
+    nTarget[0] = std::sqrt(3.0f);   // active
+    // nTarget[1] = 0 (degenerate)
+
+    std::vector<float> sqrtWeight(N_CONSTRAINTS_TOTAL, 1.0f);
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data   = positions.data();    gp.positions_0.count   = positions.size();
+    gp.projected_0.data   = projected.data();    gp.projected_0.count   = projected.size();
+    gp.idx_0.data         = idx.data();          gp.idx_0.count         = idx.size();
+    gp.weight_0.data      = weight.data();       gp.weight_0.count      = weight.size();
+    gp.nTarget_0.data     = nTarget.data();      gp.nTarget_0.count     = nTarget.size();
+    gp.sqrtWeight_0.data  = sqrtWeight.data();   gp.sqrtWeight_0.count  = sqrtWeight.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected[N_CONSTRAINTS_REAL][3] = {
+        {1.0f, 1.0f, -1.0f},   // active branch
+        {0.0f, 0.0f,  0.0f},   // short-circuit branch
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t c = 0; c < N_CONSTRAINTS_REAL; ++c) {
+        for (int k = 0; k < 3; ++k) {
+            const float got = projected[c][k];
+            const float ref = expected[c][k];
+            const float d   = std::fabs(got - ref);
+            if (d > max_abs_diff) max_abs_diff = d;
+            if (d > 1e-6f) {
+                if (fails < 5) {
+                    std::fprintf(stderr,
+                        "triangle_bending mismatch at c=%u, k=%d: got %g, expected %g (diff %g)\n",
+                        c, k, got, ref, d);
+                }
+                ++fails;
+            }
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr,
+            "triangle_bending: TIMEOUT — %.3fs > budget %.1fs\n",
+            elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf(
+            "triangle_bending: %u/%u constraints OK (max_abs_diff=%g, %.1fms)\n",
+            N_CONSTRAINTS_REAL, N_CONSTRAINTS_REAL, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "triangle_bending: %d FAIL out of %u (%u constraints × 3 components)\n",
+                 fails, N_CONSTRAINTS_REAL * 3u, N_CONSTRAINTS_REAL);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Second kernel through the Lean → LeanSlang → slangc-cpp pipeline established by #8. Lifts `TriangleBending::project` (the PD dihedral-bending local step) from `src/code/simulation/TriangleBending.cpp` into a Slang compute shader, registered in the `Cloth.SlangCodegen` umbrella alongside `spring_project`.

## What this kernel does

Per bending constraint `c`, with bind-time cotangent-Laplacian weights over a 4-vertex stencil:

```
if (nTarget[c] > 1e-6) {
  e_c = sum_j weight[4c+j] * positions[idx[4c+j]]
  e_c = e_c / |e_c| * nTarget[c]
} else {
  e_c = (0, 0, 0)
}
projected[c] = sqrtWeight[c] * e_c
```

`nTarget == 0` is the degenerate / collinear-stencil branch — short-circuits without touching `idx` / `weight`. The same `[numthreads(64,1,1)]` host-pads-the-dispatch pattern as `spring_project`.

This is the first kernel in this project to exercise:
- **conditional logic** (`if (n_c > 0.000001)` body with multi-statement scope), and
- a **multi-vertex stencil** (4-vertex sum with 4 weight-loads + 4 position-loads).

## Verification

```sh
cd lean && lake build
make -C tests/slang_validate test
```

```
spring_project:   2/2 springs OK     (max_abs_diff=0)
triangle_bending: 2/2 constraints OK (max_abs_diff=0)
all kernels OK
```

The `triangle_bending` fixture covers both branches:
- **active branch:** 4-vertex tetrahedral corner stencil with weights `(-1, 1, 1, -1)` and `nTarget = √3` → expected `(1, 1, -1)`.
- **short-circuit branch:** `nTarget = 0` → expected `(0, 0, 0)`.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned Slang emission.
- [x] `make -C tests/slang_validate test` — slangc-cpp output bit-matches the CPU reference for both branches.
- [ ] CI re-runs both layers on `macos-14`.