### PR TITLE
Port AttachmentSpring::project as the third DiffCloth kernel

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -1,5 +1,6 @@
 import Cloth.SlangCodegen.SpringProject
 import Cloth.SlangCodegen.TriangleBending
+import Cloth.SlangCodegen.AttachmentProject
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/AttachmentProject.lean
+++ b/lean/Cloth/SlangCodegen/AttachmentProject.lean
@@ -1,0 +1,94 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.AttachmentProject` — DiffCloth PD attachment local-step
+
+Third kernel ported. Implements the Projective-Dynamics local step for
+a single-vertex attachment (pin) constraint, as defined in
+`src/code/simulation/AttachmentSpring.cpp:project`:
+
+```cpp
+Eigen::VectorXd AttachmentSpring::project(const VecXd &x_vec) const {
+  Vec3d ret = fixedPointPos();
+  return sqrtConstraintWeight * ret;
+}
+```
+
+Per attachment `c`:
+
+```
+projected[c] = sqrtWeight[c] · fixedPos[c]
+```
+
+The current particle position is intentionally unused — the PD update
+drives the pinned vertex toward the world-space anchor, and the local
+step's job is just to emit that anchor (scaled).
+
+One thread per attachment. Host pads with `sqrtWeight = 0` so unused
+slots produce `(0, 0, 0)`.
+
+Bindings (set 0):
+
+  0  RWStructuredBuffer<float3> projected   length = N_attach (rounded up)
+  1  StructuredBuffer<float3>   fixedPos    length = N_attach
+  2  StructuredBuffer<float>    sqrtWeight  length = N_attach
+-/
+
+namespace Cloth.SlangCodegen.AttachmentProject
+
+open LeanSlang
+
+/-- PD per-attachment projection kernel. -/
+def shader : SlangShaderModule :=
+  let f3 : SlangType := .vec .float 3
+  let u  : SlangType := .scalar .uint
+  let f  : SlangType := .scalar .float
+  let bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+    { name := name, type := t, semantic := Semantic.none
+    , binding := some n, space := some 0 }
+  let body : List SlangStmt :=
+    [ .declInit u  "c"   (.member (.var "tid") "x")
+    , .declInit f3 "fp"  (.index (.var "fixedPos") (.var "c"))
+    , .declInit f  "sw"  (.index (.var "sqrtWeight") (.var "c"))
+    , .assign (.index (.var "projected") (.var "c"))
+        (.call "float3"
+          [ .bin "*" (.var "sw") (.member (.var "fp") "x")
+          , .bin "*" (.var "sw") (.member (.var "fp") "y")
+          , .bin "*" (.var "sw") (.member (.var "fp") "z") ])
+    ]
+  { globals :=
+      [ bnd 0 "projected"  (.rwBuf f3)
+      , bnd 1 "fixedPos"   (.roBuf f3)
+      , bnd 2 "sqrtWeight" (.roBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+/-- Pinned reference emission. -/
+def expected : String :=
+"[[vk::binding(0, 0)]]
+RWStructuredBuffer<float3> projected;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float3> fixedPos;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> sqrtWeight;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  float3 fp = fixedPos[c];
+  float sw = sqrtWeight[c];
+  projected[c] = float3((sw * fp.x), (sw * fp.y), (sw * fp.z));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.AttachmentProject

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -18,8 +18,9 @@ open Cloth.SlangCodegen
 open LeanSlang
 
 private def kernels : List (String × SlangShaderModule) :=
-  [ ("spring_project",   SpringProject.shader)
-  , ("triangle_bending", TriangleBending.shader)
+  [ ("spring_project",     SpringProject.shader)
+  , ("triangle_bending",   TriangleBending.shader)
+  , ("attachment_project", AttachmentProject.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -30,7 +30,8 @@ CXXFLAGS   ?= -std=c++17 -O2 -Wall -Wextra -Wno-unused-parameter
 INCLUDES   := -I$(SLANG_DIR)/include -I$(EMITTED)
 
 # Per-test-to-kernel mapping. test_name → kernel_name.
-TESTS      := spring_project:spring_project triangle_bending:triangle_bending
+TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
+              attachment_project:attachment_project
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/attachment_project_test.cpp
+++ b/tests/slang_validate/attachment_project_test.cpp
@@ -1,0 +1,94 @@
+// Real-input validator for Cloth.SlangCodegen.AttachmentProject — the
+// DiffCloth PD per-pin local step. The current particle position is
+// ignored; the kernel just emits sqrtWeight * fixedPos per attachment.
+//
+// Reference: src/code/simulation/AttachmentSpring.cpp:project.
+//
+// Test fixture (3 real attachments + 61 padded slots):
+//   pin 0:  fixedPos = (5, 0, 0),  sqrtWeight = 2.0
+//             → out = (10, 0, 0)
+//   pin 1:  fixedPos = (0, 3, 0),  sqrtWeight = 1.0
+//             → out = (0, 3, 0)
+//   pin 2:  fixedPos = (1, 2, 3),  sqrtWeight = 4.0
+//             → out = (4, 8, 12)
+//   pins 3..63: sqrtWeight = 0 → out = (0, 0, 0) (not checked).
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "attachment_project_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_REAL = 3;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> projected(GROUP_SIZE, Vector<float, 3>(0.0f));
+
+    std::vector<Vector<float, 3>> fixedPos(GROUP_SIZE, Vector<float, 3>(0.0f));
+    fixedPos[0] = Vector<float, 3>(5.0f, 0.0f, 0.0f);
+    fixedPos[1] = Vector<float, 3>(0.0f, 3.0f, 0.0f);
+    fixedPos[2] = Vector<float, 3>(1.0f, 2.0f, 3.0f);
+
+    std::vector<float> sqrtWeight(GROUP_SIZE, 0.0f);
+    sqrtWeight[0] = 2.0f;
+    sqrtWeight[1] = 1.0f;
+    sqrtWeight[2] = 4.0f;
+
+    GlobalParams_0 gp{};
+    gp.projected_0.data   = projected.data();   gp.projected_0.count   = projected.size();
+    gp.fixedPos_0.data    = fixedPos.data();    gp.fixedPos_0.count    = fixedPos.size();
+    gp.sqrtWeight_0.data  = sqrtWeight.data();  gp.sqrtWeight_0.count  = sqrtWeight.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected[N_REAL][3] = {
+        {10.0f,  0.0f,  0.0f},
+        { 0.0f,  3.0f,  0.0f},
+        { 4.0f,  8.0f, 12.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t c = 0; c < N_REAL; ++c) {
+        for (int k = 0; k < 3; ++k) {
+            const float got = projected[c][k];
+            const float ref = expected[c][k];
+            const float d   = std::fabs(got - ref);
+            if (d > max_abs_diff) max_abs_diff = d;
+            if (d > 1e-6f) {
+                if (fails < 5) {
+                    std::fprintf(stderr,
+                        "attachment_project mismatch at c=%u, k=%d: got %g, expected %g (diff %g)\n",
+                        c, k, got, ref, d);
+                }
+                ++fails;
+            }
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "attachment_project: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("attachment_project: %u/%u pins OK (max_abs_diff=%g, %.1fms)\n",
+                    N_REAL, N_REAL, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "attachment_project: %d FAIL out of %u\n",
+                 fails, N_REAL * 3u);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Third constraint-projection kernel through the pipeline. Lifts `AttachmentSpring::project` (the PD single-vertex pin local step) into Slang. With this PR, three of DiffCloth's four constraint types are present as native_decide-pinned, slang_validate-checked compute kernels:

| Kernel | Lean module | What it projects |
|---|---|---|
| `spring_project` | `Cloth.SlangCodegen.SpringProject` | edge stretch |
| `triangle_bending` | `Cloth.SlangCodegen.TriangleBending` | dihedral bending |
| **`attachment_project`** | **`Cloth.SlangCodegen.AttachmentProject`** | **single-vertex pin** |
| (next) | (next) | in-plane triangle stretch (`Triangle::project`, SVD-based) |

## What this kernel does

Per attachment `c`:

```
projected[c] = sqrtWeight[c] * fixedPos[c]
```

The current particle position is intentionally unused — the PD update drives the pinned vertex toward the world-space anchor, and the local step's only job is to emit that anchor scaled by √stiffness.

This is the smallest of the constraint kernels (three buffers, no conditionals, no normalize). Useful as a fast unit demonstrating the Lean → Slang → slangc-cpp pipeline can absorb a near-trivial kernel cleanly.

## Verification

```sh
cd lean && lake build
make -C tests/slang_validate test
```

```
spring_project:     2/2 springs OK     (max_abs_diff=0)
triangle_bending:   2/2 constraints OK (max_abs_diff=0)
attachment_project: 3/3 pins OK        (max_abs_diff=0)
all kernels OK
```

The `attachment_project` fixture covers 3 pins with distinct anchors and weights (`(5,0,0)·2`, `(0,3,0)·1`, `(1,2,3)·4`) plus 61 padded slots that short-circuit to `(0,0,0)`.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned Slang emission.
- [x] `make -C tests/slang_validate test` — slangc-cpp output bit-matches the CPU reference for all 3 pins.
- [ ] CI re-runs all three layers on `macos-14`.