### PR TITLE
Add spmv, the sparse CSR matrix-vector CG primitive

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -3,6 +3,7 @@ import Cloth.SlangCodegen.TriangleBending
 import Cloth.SlangCodegen.AttachmentProject
 import Cloth.SlangCodegen.TriangleProject
 import Cloth.SlangCodegen.Saxpby
+import Cloth.SlangCodegen.Spmv
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/Spmv.lean
+++ b/lean/Cloth/SlangCodegen/Spmv.lean
@@ -1,0 +1,114 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.Spmv` — sparse CSR matrix-vector product
+
+Second of the global-solve building blocks. Computes
+
+```
+y[i] = Σ_{nz in row i}  values[nz] · x[colIdx[nz]]
+```
+
+for a CSR-encoded sparse matrix. One thread per row.
+
+In the PD outer loop this is the kernel that evaluates
+`A · x` where `A = M + h² · Σ_c S_c^T · W_c · S_c` (precomputed,
+SPD, sparse). The system matrix is built once on the host at bind
+time; per step, CG hammers on `spmv` plus `saxpby` and `dot_reduce`
+(next PR).
+
+Verbatim mirror of V-Sekai-fire/Curvenet's
+`Curvenet.SlangCodegen.Spmv` — same ABI, same fp32 fma accumulation,
+same `[numthreads(256, 1, 1)]`.
+
+Bindings (set 0):
+
+  0  ConstantBuffer<SpmvParams> { uint rows; }
+  1  StructuredBuffer<int>       rowPtr   length = rows + 1
+  2  StructuredBuffer<int>       colIdx   length = nnz
+  3  StructuredBuffer<float>     values   length = nnz
+  4  StructuredBuffer<float>     x        length = cols
+  5  RWStructuredBuffer<float>   y        length = rows
+
+Per-row spmv on a triangle-Laplacian-style matrix has only ~7
+nonzeros, so the fp32 accumulation error is ~7·ε and well below
+the §4.3 solve's tolerance. Higher-precision sums (df32) live in
+`Cloth.SlangCodegen.DotReduce` (next PR).
+-/
+
+namespace Cloth.SlangCodegen.Spmv
+
+open LeanSlang
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "SpmvParams"
+        , fields := [⟨"rows", .scalar .uint, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params", .const "SpmvParams",       Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"rowPtr", .roBuf (.scalar .int),     Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"colIdx", .roBuf (.scalar .int),     Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"values", .roBuf (.scalar .float),   Semantic.none, some 3, some 0, .qIn⟩
+      , ⟨"x",      .roBuf (.scalar .float),   Semantic.none, some 4, some 0, .qIn⟩
+      , ⟨"y",      .rwBuf (.scalar .float),   Semantic.none, some 5, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 256 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit (.scalar .uint) "i" (.member (.var "tid") "x")
+        , .ifNoElse (.bin ">=" (.var "i") (.member (.var "params") "rows"))
+            [ .ret none ]
+        , .declInit (.scalar .uint) "rs"
+            (.call "uint" [.index (.var "rowPtr") (.var "i")])
+        , .declInit (.scalar .uint) "re"
+            (.call "uint" [.index (.var "rowPtr")
+              (.bin "+" (.var "i") (.litUint 1))])
+        , .declInit (.scalar .float) "s" (.litFloat 0.0)
+        , .forCount "p" (.var "rs") (.var "re")
+            [ .assign (.var "s")
+                (.call "fma"
+                  [ .index (.var "values") (.var "p")
+                  , .index (.var "x")
+                      (.call "uint" [.index (.var "colIdx") (.var "p")])
+                  , .var "s" ]) ]
+        , .assign (.index (.var "y") (.var "i")) (.var "s")
+        ] }] }
+
+def expected : String :=
+"struct SpmvParams {
+  uint rows;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<SpmvParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<int> rowPtr;
+[[vk::binding(2, 0)]]
+StructuredBuffer<int> colIdx;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> values;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> x;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> y;
+
+[shader(\"compute\")] [numthreads(256, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  if ((i >= params.rows)) {
+    return;
+  }
+  uint rs = uint(rowPtr[i]);
+  uint re = uint(rowPtr[(i + 1u)]);
+  float s = 0.000000;
+  for (uint p = rs; p < re; ++p) {
+    s = fma(values[p], x[uint(colIdx[p])], s);
+  }
+  y[i] = s;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.Spmv

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -23,6 +23,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("attachment_project", AttachmentProject.shader)
   , ("triangle_project",   TriangleProject.shader)
   , ("saxpby",             Saxpby.shader)
+  , ("spmv",               Spmv.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -33,7 +33,8 @@ INCLUDES   := -I$(SLANG_DIR)/include -I$(EMITTED)
 TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               attachment_project:attachment_project \
               triangle_project:triangle_project \
-              saxpby:saxpby
+              saxpby:saxpby \
+              spmv:spmv
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/spmv_test.cpp
+++ b/tests/slang_validate/spmv_test.cpp
@@ -1,0 +1,86 @@
+// Real-input validator for Cloth.SlangCodegen.Spmv.
+// y[i] = Σ_{nz in row i} values[nz] * x[colIdx[nz]]
+//
+// Test fixture: 3x3 sparse matrix
+//
+//   A = [ 2  0  1 ]      x = [1, 2, 3]
+//       [ 0  3  0 ]      y = A·x = [2+0+3, 0+6+0, 4+10+18] = [5, 6, 32]
+//       [ 4  5  6 ]
+//
+// CSR:
+//   rowPtr = [0, 2, 3, 6]
+//   colIdx = [0, 2, 1, 0, 1, 2]
+//   values = [2, 1, 3, 4, 5, 6]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "spmv_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t ROWS = 3;
+    constexpr uint32_t NNZ  = 6;
+
+    SpmvParams_0 params{ROWS};
+
+    int32_t rowPtr[ROWS + 1] = {0, 2, 3, 6};
+    int32_t colIdx[NNZ]      = {0, 2, 1, 0, 1, 2};
+    float   values[NNZ]      = {2.0f, 1.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    float   x[ROWS]          = {1.0f, 2.0f, 3.0f};
+    float   y[ROWS]          = {0.0f, 0.0f, 0.0f};
+
+    const float expected[ROWS] = {
+        2.0f * 1.0f + 1.0f * 3.0f,                    // = 5
+        3.0f * 2.0f,                                  // = 6
+        4.0f * 1.0f + 5.0f * 2.0f + 6.0f * 3.0f,      // = 32
+    };
+
+    GlobalParams_0 gp{};
+    gp.params_0      = &params;
+    gp.rowPtr_0.data = rowPtr;   gp.rowPtr_0.count = ROWS + 1;
+    gp.colIdx_0.data = colIdx;   gp.colIdx_0.count = NNZ;
+    gp.values_0.data = values;   gp.values_0.count = NNZ;
+    gp.x_0.data      = x;        gp.x_0.count      = ROWS;
+    gp.y_0.data      = y;        gp.y_0.count      = ROWS;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t i = 0; i < ROWS; ++i) {
+        const float d = std::fabs(y[i] - expected[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "spmv mismatch at i=%u: got %g, expected %g (diff %g)\n",
+                    i, y[i], expected[i], d);
+            }
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "spmv: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("spmv: %u/%u rows OK (nnz=%u, max_abs_diff=%g, %.1fms)\n",
+                    ROWS, ROWS, NNZ, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "spmv: %d FAIL out of %u\n", fails, ROWS);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Second of three CG-loop primitives. Verbatim mirror of `V-Sekai-fire/Curvenet`'s `Curvenet.SlangCodegen.Spmv` — same ABI, same fp32 `fma` accumulation, same `[numthreads(256, 1, 1)]`. One thread per row.

```
y[i] = sum over nz in row i  values[nz] * x[colIdx[nz]]
```

In the PD outer loop this evaluates `A·x` where `A = M + h²·sum_c S_c^T·W_c·S_c` (precomputed, SPD, sparse, built once at bind time). CG hammers on this three times per iteration (`A·p`, plus saxpby/dot_reduce around it).

## Roadmap update

| | Primitive | Status |
|---|---|---|
| 1 | `saxpby` — α·x + β·y | merged in #12 |
| 2 | **`spmv` — sparse CSR matrix-vector** | **this PR** |
| 3 | `dot_reduce` — Σ x[i]·y[i] cross-thread reduction | next |
| 4 | host CG dispatch — wire constraints + 1–3 into the PD step | follow-up |

## Verification

```sh
cd lean && lake build
make -C tests/slang_validate test
```

```
spring_project:     2/2 springs OK
triangle_bending:   2/2 constraints OK
attachment_project: 3/3 pins OK
triangle_project:   2/2 triangles OK
saxpby:             5/5 OK  (alpha=3, beta=4)
spmv:               3/3 rows OK  (nnz=6)
all kernels OK
```

The `spmv` fixture is a deliberately heterogeneous 3×3 sparse matrix that exercises a multi-nonzero row, a single-nonzero row, and a dense row in one pass:

```
A = [ 2 0 1 ]    x = [1, 2, 3]
    [ 0 3 0 ]    y = A·x = [5, 6, 32]
    [ 4 5 6 ]
```

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned Slang emission.
- [x] `make -C tests/slang_validate test` — slangc-cpp output bit-matches the CPU reference for all 3 rows.
- [ ] CI re-runs all three layers on `macos-14`.