### PR TITLE
Add cg_demo: multi-kernel CG composition test (spmv + saxpby)

### DIFF
--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -41,7 +41,8 @@ KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))
 
 KERNELS    := $(sort $(foreach t,$(TESTS),$(word 2,$(subst :, ,$(t)))))
 SHADERS    := $(addprefix $(EMITTED)/,$(addsuffix _emit.cpp,$(KERNELS)))
-BINS       := $(addprefix $(EMITTED)/,$(addsuffix _test,$(TEST_NAMES)))
+BINS       := $(addprefix $(EMITTED)/,$(addsuffix _test,$(TEST_NAMES))) \
+              $(EMITTED)/cg_demo_test
 
 .PHONY: test clean emit-shaders
 
@@ -67,6 +68,13 @@ $(EMITTED)/%_emit.cpp: emit-shaders
 # TESTS list; the test source #include's its kernel's emit.
 .SECONDEXPANSION:
 $(EMITTED)/%_test: %_test.cpp $$(EMITTED)/$$(call KERNEL_FOR,%)_emit.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -o $@ $<
+
+# Multi-kernel composition test. cg_demo dispatches both spmv and saxpby
+# from a single TU (see header comment in cg_demo_test.cpp for the
+# namespace + SLANG_PRELUDE_EXTERN_C-undef pattern that lets two
+# slangc-emitted kernels coexist).
+$(EMITTED)/cg_demo_test: cg_demo_test.cpp $(EMITTED)/spmv_emit.cpp $(EMITTED)/saxpby_emit.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -o $@ $<
 
 clean:

--- a/tests/slang_validate/cg_demo_test.cpp
+++ b/tests/slang_validate/cg_demo_test.cpp
@@ -1,0 +1,213 @@
+// Composition test for spmv + saxpby — runs a textbook Conjugate Gradient
+// solve to convergence on a 3x3 SPD system, dispatching only those two
+// slangc-emitted kernels per iteration (dot products are computed on the
+// host because slangc-cpp target can't link the dot_reduce kernel — see
+// Cloth.SlangCodegen.DotReduce docstring).
+//
+// System:
+//
+//   A = [ 4 1 0 ]      b = [5, 7, 6]
+//       [ 1 3 0 ]      analytic x = A⁻¹·b = [8/11, 23/11, 3]
+//       [ 0 0 2 ]                          ≈ [0.7272727, 2.0909091, 3.0]
+//
+//   CSR:
+//     rowPtr = [0, 2, 4, 5]
+//     colIdx = [0, 1, 0, 1, 2]
+//     values = [4, 1, 1, 3, 2]
+//
+// CG (textbook, Shewchuk § B.2):
+//
+//   r₀ = b − A·x₀    (= b when x₀ = 0)
+//   p₀ = r₀
+//   δ_new = dot(r₀, r₀)
+//   loop:
+//     q     = A·p              ← spmv kernel
+//     α     = δ_new / dot(p,q)
+//     x    := 1·x + α·p        ← saxpby kernel (in-place on x)
+//     r    := 1·r + (−α)·q     ← saxpby kernel (in-place on r)
+//     δ_old = δ_new
+//     δ_new = dot(r, r)
+//     if δ_new < tol²·δ₀ break
+//     β     = δ_new / δ_old
+//     p    := 1·r + β·p        ← saxpby kernel (in-place on p)
+//
+// CG on a 3×3 SPD matrix converges in ≤ 3 iterations in exact
+// arithmetic; with fp32 storage we accept 1e-5 absolute tolerance and
+// allow up to 20 iterations for safety.
+//
+// **How two kernels co-exist in one TU.** slangc-cpp emits each kernel
+// as a translation unit with `main_0` and `GlobalParams_0` at file
+// scope. `main_0` is wrapped in SLANG_PRELUDE_EXPORT (= `extern "C"`),
+// so naive namespace wrapping leaks the symbol to global scope.
+//
+// We work around this by `#undef`-ing the macro inside each namespace
+// before `#include`-ing the emit.cpp, so the kernel functions become
+// regular C++ functions that respect the surrounding namespace. The
+// `<cstdint>` / Slang prelude headers are pulled in once at file scope
+// before the namespaces (their include guards make the per-namespace
+// `#include`s of the prelude no-ops).
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "slang-cpp-prelude.h"
+
+namespace cg_spmv {
+    #pragma push_macro("SLANG_PRELUDE_EXTERN_C")
+    #pragma push_macro("SLANG_PRELUDE_EXTERN_C_START")
+    #pragma push_macro("SLANG_PRELUDE_EXTERN_C_END")
+    #undef  SLANG_PRELUDE_EXTERN_C
+    #undef  SLANG_PRELUDE_EXTERN_C_START
+    #undef  SLANG_PRELUDE_EXTERN_C_END
+    #define SLANG_PRELUDE_EXTERN_C
+    #define SLANG_PRELUDE_EXTERN_C_START
+    #define SLANG_PRELUDE_EXTERN_C_END
+    #include "spmv_emit.cpp"
+    #pragma pop_macro("SLANG_PRELUDE_EXTERN_C")
+    #pragma pop_macro("SLANG_PRELUDE_EXTERN_C_START")
+    #pragma pop_macro("SLANG_PRELUDE_EXTERN_C_END")
+}
+
+namespace cg_saxpby {
+    #pragma push_macro("SLANG_PRELUDE_EXTERN_C")
+    #pragma push_macro("SLANG_PRELUDE_EXTERN_C_START")
+    #pragma push_macro("SLANG_PRELUDE_EXTERN_C_END")
+    #undef  SLANG_PRELUDE_EXTERN_C
+    #undef  SLANG_PRELUDE_EXTERN_C_START
+    #undef  SLANG_PRELUDE_EXTERN_C_END
+    #define SLANG_PRELUDE_EXTERN_C
+    #define SLANG_PRELUDE_EXTERN_C_START
+    #define SLANG_PRELUDE_EXTERN_C_END
+    #include "saxpby_emit.cpp"
+    #pragma pop_macro("SLANG_PRELUDE_EXTERN_C")
+    #pragma pop_macro("SLANG_PRELUDE_EXTERN_C_START")
+    #pragma pop_macro("SLANG_PRELUDE_EXTERN_C_END")
+}
+
+static constexpr double kBudgetSeconds = 5.0;
+
+static double hostDot(const float* a, const float* b, uint32_t n) {
+    // Plain fp64 accumulation. For n = 3 there's no precision concern;
+    // for larger problems the matching GPU dispatch would use the
+    // dot_reduce kernel (df32) instead.
+    double s = 0.0;
+    for (uint32_t i = 0; i < n; ++i) s += double(a[i]) * double(b[i]);
+    return s;
+}
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N    = 3;
+    constexpr uint32_t NNZ  = 5;
+    constexpr int MAX_ITER  = 20;
+    constexpr double TOL    = 1e-6;
+
+    // SPD system.
+    int32_t rowPtr[N + 1] = {0, 2, 4, 5};
+    int32_t colIdx[NNZ]   = {0, 1, 0, 1, 2};
+    float   values[NNZ]   = {4.0f, 1.0f, 1.0f, 3.0f, 2.0f};
+    float   b[N]          = {5.0f, 7.0f, 6.0f};
+
+    // CG workspace.
+    float x[N] = {0.0f, 0.0f, 0.0f};   // initial guess: zero → r₀ = b
+    float r[N] = {b[0], b[1], b[2]};
+    float p[N] = {b[0], b[1], b[2]};
+    float q[N] = {0.0f, 0.0f, 0.0f};   // A·p workspace
+
+    double delta_new = hostDot(r, r, N);
+    const double delta_0 = delta_new;
+
+    // Persistent parameter buffers (one per kernel).
+    cg_spmv::SpmvParams_0     sp{N};
+    cg_spmv::GlobalParams_0   gp_spmv{};
+    gp_spmv.params_0      = &sp;
+    gp_spmv.rowPtr_0.data = rowPtr; gp_spmv.rowPtr_0.count = N + 1;
+    gp_spmv.colIdx_0.data = colIdx; gp_spmv.colIdx_0.count = NNZ;
+    gp_spmv.values_0.data = values; gp_spmv.values_0.count = NNZ;
+    gp_spmv.x_0.data      = p;      gp_spmv.x_0.count      = N;
+    gp_spmv.y_0.data      = q;      gp_spmv.y_0.count      = N;
+
+    cg_saxpby::SaxpbyParams_0 spy{N, 0.0f, 0.0f};
+    cg_saxpby::GlobalParams_0 gp_sax{};
+    gp_sax.params_0 = &spy;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+
+    int iter = 0;
+    for (; iter < MAX_ITER; ++iter) {
+        // q = A · p
+        gp_spmv.x_0.data = p; gp_spmv.x_0.count = N;
+        gp_spmv.y_0.data = q; gp_spmv.y_0.count = N;
+        cg_spmv::main_0(&vi, nullptr, &gp_spmv);
+
+        const double pq    = hostDot(p, q, N);
+        const double alpha = delta_new / pq;
+
+        // x := 1·x + α·p     (saxpby with src x aliased to dst)
+        spy.alpha_0 = 1.0f; spy.beta_0 = float(alpha);
+        gp_sax.x_0.data = x; gp_sax.x_0.count = N;
+        gp_sax.y_0.data = p; gp_sax.y_0.count = N;
+        gp_sax.dst_0.data = x; gp_sax.dst_0.count = N;
+        cg_saxpby::main_0(&vi, nullptr, &gp_sax);
+
+        // r := 1·r + (−α)·q
+        spy.alpha_0 = 1.0f; spy.beta_0 = float(-alpha);
+        gp_sax.x_0.data = r; gp_sax.x_0.count = N;
+        gp_sax.y_0.data = q; gp_sax.y_0.count = N;
+        gp_sax.dst_0.data = r; gp_sax.dst_0.count = N;
+        cg_saxpby::main_0(&vi, nullptr, &gp_sax);
+
+        const double delta_old = delta_new;
+        delta_new = hostDot(r, r, N);
+        if (delta_new < TOL * TOL * delta_0) { ++iter; break; }
+
+        const double beta = delta_new / delta_old;
+
+        // p := 1·r + β·p
+        spy.alpha_0 = 1.0f; spy.beta_0 = float(beta);
+        gp_sax.x_0.data = r; gp_sax.x_0.count = N;
+        gp_sax.y_0.data = p; gp_sax.y_0.count = N;
+        gp_sax.dst_0.data = p; gp_sax.dst_0.count = N;
+        cg_saxpby::main_0(&vi, nullptr, &gp_sax);
+    }
+
+    // Compare against analytic A⁻¹·b = [8/11, 23/11, 3].
+    const float expected[N] = {8.0f/11.0f, 23.0f/11.0f, 3.0f};
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t i = 0; i < N; ++i) {
+        const float d = std::fabs(x[i] - expected[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "cg_demo mismatch at i=%u: got %g, expected %g (diff %g)\n",
+                    i, x[i], expected[i], d);
+            }
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "cg_demo: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("cg_demo: %u/%u OK (iters=%d, max_abs_diff=%g, residual=%g, %.1fms)\n",
+                    N, N, iter, max_abs_diff, std::sqrt(delta_new / delta_0),
+                    elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr,
+        "cg_demo: FAIL (iters=%d, max_abs_diff=%g, x=[%g %g %g])\n",
+        iter, max_abs_diff, x[0], x[1], x[2]);
+    return 1;
+}


### PR DESCRIPTION
## Summary

First test that composes two slangc-emitted kernels in a single host harness, running a textbook Conjugate Gradient solve to convergence on a 3×3 SPD system. Proves the `spmv` + `saxpby` pair compose into a working linear solver — the validation step that has to land **before** the PD outer loop assembles the four constraint kernels on top of it.

## The system

```
A = [ 4 1 0 ]      b = [5, 7, 6]
    [ 1 3 0 ]      analytic A⁻¹·b = [8/11, 23/11, 3]
    [ 0 0 2 ]                     ≈ [0.7272727, 2.0909091, 3.0]

CSR:
  rowPtr = [0, 2, 4, 5]
  colIdx = [0, 1, 0, 1, 2]
  values = [4, 1, 1, 3, 2]
```

## The CG loop (Shewchuk § B.2)

Per iteration, **only `spmv` and `saxpby` are dispatched**. Inner products are computed host-side because slangc-cpp can't link the `dot_reduce` kernel (`groupshared` + barriers — see the `Cloth.SlangCodegen.DotReduce` docstring). Once a GPU-side dispatcher is wired up, the host dot calls are replaced by `dot_reduce` invocations.

```
q     = A·p                  ← spmv
α     = δ_new / dot(p, q)    ← host dot
x    := 1·x + α·p            ← saxpby in-place on x
r    := 1·r + (−α)·q         ← saxpby in-place on r
δ_old = δ_new
δ_new = dot(r, r)            ← host dot
if δ_new < tol²·δ_0: break
β     = δ_new / δ_old
p    := 1·r + β·p            ← saxpby in-place on p
```

## The multi-kernel-in-one-TU pattern

slangc-cpp emits each kernel as a file-scope `main_0` / `GlobalParams_0` wrapped in `SLANG_PRELUDE_EXPORT` (= `extern \"C\"`), which leaks the symbol past any namespace. The harness `#undef`-s `SLANG_PRELUDE_EXTERN_C` inside each per-kernel wrapping namespace before `#include`-ing the emit.cpp:

```cpp
#include \"slang-cpp-prelude.h\"   // file scope: brings in Vector<…>, uint3, etc.

namespace cg_spmv {
    #pragma push_macro(\"SLANG_PRELUDE_EXTERN_C\")
    #undef  SLANG_PRELUDE_EXTERN_C
    #define SLANG_PRELUDE_EXTERN_C
    #include \"spmv_emit.cpp\"
    #pragma pop_macro(\"SLANG_PRELUDE_EXTERN_C\")
}
namespace cg_saxpby { …same pattern… #include \"saxpby_emit.cpp\" … }
```

Reusable pattern for the eventual PD-step assembler PR, which will need all four constraint kernels + spmv + saxpby in one harness.

## Result

```
spring_project:     2/2 springs OK
triangle_bending:   2/2 constraints OK
attachment_project: 3/3 pins OK
triangle_project:   2/2 triangles OK
saxpby:             5/5 OK  (alpha=3, beta=4)
spmv:               3/3 rows OK  (nnz=6)
cg_demo:            3/3 OK (iters=3, max_abs_diff=2.4e-7, residual=6.4e-9)
all kernels OK
```

CG converges in exactly 3 iterations on a 3×3 SPD matrix (textbook expectation), matching the analytic solution to fp32 limits.

## Test plan

- [x] `cd lean && lake build` — no Lean changes; native_decide pins all unchanged.
- [x] `make -C tests/slang_validate test` — 6 kernel harnesses still bit-match; cg_demo converges.
- [ ] CI re-runs all three layers on `macos-14`.

## Where this leaves the roadmap

| | Step | Status |
|---|---|---|
| 1 | 4 constraint local-step kernels | merged #8–#11 |
| 2 | 3 CG primitives (saxpby, spmv, dot_reduce) | merged #12–#14 |
| 3 | **CG composition test on a small SPD system** | **this PR** |
| 4 | PD-step assembler: dispatch all 4 constraint kernels per step + assemble `b = M·s + h²·S^T·W·p` + run CG, bit-diff against the existing DiffCloth C++ simulator on a tiny mesh | next |