### PR TITLE
Add assemble_b: PD right-hand-side gather kernel

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -6,6 +6,7 @@ import Cloth.SlangCodegen.Saxpby
 import Cloth.SlangCodegen.Spmv
 import Cloth.SlangCodegen.DotReduce
 import Cloth.SlangCodegen.DotReduceSerial
+import Cloth.SlangCodegen.AssembleB
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/AssembleB.lean
+++ b/lean/Cloth/SlangCodegen/AssembleB.lean
@@ -1,0 +1,168 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.AssembleB` — PD right-hand-side assembly
+
+The bridge kernel between the per-constraint local-step projections
+(spring / bending / attachment / triangle) and the CG inner loop.
+Computes the Projective-Dynamics right-hand side
+
+```
+b[3v + d]  =  mass[v] * s[3v + d]  +  Σ_{(slot, w) in incident[v]}  w * projections[3*slot + d]
+```
+
+for each vertex `v` and dimension `d ∈ {0, 1, 2}`. One thread per
+vertex; no atomics. The sum is a CSR-style gather over each vertex's
+incident-constraint list.
+
+The constraint-output buffer `projections` is treated as a flat array
+of `slot_count` 3-vectors, one per constraint output (spring → 1 slot,
+bending → 1 slot, attachment → 1 slot, triangle in-plane → 2 slots
+for col0/col1). The bind-time-built CSR `(ctxStart, ctxSlot, ctxWeight)`
+encodes the linear map `S^T` from constraint outputs back to per-vertex
+contributions:
+
+  ctxStart   : rowPtr, length = numVerts + 1
+  ctxSlot    : which projection slot this incidence reads from
+  ctxWeight  : ±sqrtConstraintWeight (the entry in S^T at this row/col)
+
+For a spring connecting verts (a, b) with sqrt-weight `w`, the bind
+emits two incidences:
+  vertex a: slot = spring_slot, weight = +w
+  vertex b: slot = spring_slot, weight = −w
+And similar for bending (4 entries with cotangent weights), attachment
+(1 entry, +w), and triangle in-plane (more complex — selects col0/col1
+slots via the rest_inv_uv coefficients).
+
+The mass term `M·s` is baked in directly: lumped (diagonal) PD mass is
+just a per-vertex scalar, so `mass[v] * s[3v + d]` is the M-contribution.
+Callers wanting the `(M/h² + …)` form scale `mass` before binding.
+
+Bindings (set 0):
+
+  0  ConstantBuffer<AssembleBParams> { uint numVerts; }
+  1  StructuredBuffer<float>     s             length = 3 · numVerts
+  2  StructuredBuffer<float>     mass          length = numVerts
+  3  StructuredBuffer<float>     projections   length = 3 · slot_count
+  4  StructuredBuffer<uint>      ctxStart      length = numVerts + 1
+  5  StructuredBuffer<uint>      ctxSlot       length = total_incidences
+  6  StructuredBuffer<float>     ctxWeight     length = total_incidences
+  7  RWStructuredBuffer<float>   b             length = 3 · numVerts
+-/
+
+namespace Cloth.SlangCodegen.AssembleB
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "AssembleBParams"
+        , fields := [⟨"numVerts", uintTy, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params",      .const "AssembleBParams",  Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"s",           .roBuf floatTy,            Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"mass",        .roBuf floatTy,            Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"projections", .roBuf floatTy,            Semantic.none, some 3, some 0, .qIn⟩
+      , ⟨"ctxStart",    .roBuf uintTy,             Semantic.none, some 4, some 0, .qIn⟩
+      , ⟨"ctxSlot",     .roBuf uintTy,             Semantic.none, some 5, some 0, .qIn⟩
+      , ⟨"ctxWeight",   .roBuf floatTy,            Semantic.none, some 6, some 0, .qIn⟩
+      , ⟨"b",           .rwBuf floatTy,            Semantic.none, some 7, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit uintTy "v" (.member (.var "tid") "x")
+        , .ifNoElse (.bin ">=" (.var "v") (.member (.var "params") "numVerts"))
+            [ .ret none ]
+        , .declInit uintTy  "v3" (.bin "*" (.litUint 3) (.var "v"))
+        , .declInit uintTy  "cs" (.index (.var "ctxStart") (.var "v"))
+        , .declInit uintTy  "ce" (.index (.var "ctxStart")
+                                   (.bin "+" (.var "v") (.litUint 1)))
+        , .declInit floatTy "m"  (.index (.var "mass") (.var "v"))
+        , .declInit floatTy "bx" (.bin "*" (.var "m") (.index (.var "s") (.var "v3")))
+        , .declInit floatTy "by" (.bin "*" (.var "m")
+                                   (.index (.var "s")
+                                     (.bin "+" (.var "v3") (.litUint 1))))
+        , .declInit floatTy "bz" (.bin "*" (.var "m")
+                                   (.index (.var "s")
+                                     (.bin "+" (.var "v3") (.litUint 2))))
+        , .forCount "k" (.var "cs") (.var "ce")
+            [ .declInit floatTy "w"    (.index (.var "ctxWeight") (.var "k"))
+            , .declInit uintTy  "slot" (.index (.var "ctxSlot") (.var "k"))
+            , .declInit uintTy  "s3"   (.bin "*" (.litUint 3) (.var "slot"))
+            , .assign (.var "bx")
+                (.bin "+" (.var "bx")
+                  (.bin "*" (.var "w")
+                    (.index (.var "projections") (.var "s3"))))
+            , .assign (.var "by")
+                (.bin "+" (.var "by")
+                  (.bin "*" (.var "w")
+                    (.index (.var "projections")
+                      (.bin "+" (.var "s3") (.litUint 1)))))
+            , .assign (.var "bz")
+                (.bin "+" (.var "bz")
+                  (.bin "*" (.var "w")
+                    (.index (.var "projections")
+                      (.bin "+" (.var "s3") (.litUint 2)))))
+            ]
+        , .assign (.index (.var "b") (.var "v3")) (.var "bx")
+        , .assign (.index (.var "b") (.bin "+" (.var "v3") (.litUint 1))) (.var "by")
+        , .assign (.index (.var "b") (.bin "+" (.var "v3") (.litUint 2))) (.var "bz")
+        ] }] }
+
+def expected : String :=
+"struct AssembleBParams {
+  uint numVerts;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<AssembleBParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> s;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> mass;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> projections;
+[[vk::binding(4, 0)]]
+StructuredBuffer<uint> ctxStart;
+[[vk::binding(5, 0)]]
+StructuredBuffer<uint> ctxSlot;
+[[vk::binding(6, 0)]]
+StructuredBuffer<float> ctxWeight;
+[[vk::binding(7, 0)]]
+RWStructuredBuffer<float> b;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint v = tid.x;
+  if ((v >= params.numVerts)) {
+    return;
+  }
+  uint v3 = (3u * v);
+  uint cs = ctxStart[v];
+  uint ce = ctxStart[(v + 1u)];
+  float m = mass[v];
+  float bx = (m * s[v3]);
+  float by = (m * s[(v3 + 1u)]);
+  float bz = (m * s[(v3 + 2u)]);
+  for (uint k = cs; k < ce; ++k) {
+    float w = ctxWeight[k];
+    uint slot = ctxSlot[k];
+    uint s3 = (3u * slot);
+    bx = (bx + (w * projections[s3]));
+    by = (by + (w * projections[(s3 + 1u)]));
+    bz = (bz + (w * projections[(s3 + 2u)]));
+  }
+  b[v3] = bx;
+  b[(v3 + 1u)] = by;
+  b[(v3 + 2u)] = bz;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.AssembleB

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -26,6 +26,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("spmv",               Spmv.shader)
   , ("dot_reduce",         DotReduce.shader)
   , ("dot_reduce_serial",  DotReduceSerial.shader)
+  , ("assemble_b",         AssembleB.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -35,7 +35,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               triangle_project:triangle_project \
               saxpby:saxpby \
               spmv:spmv \
-              dot_reduce_serial:dot_reduce_serial
+              dot_reduce_serial:dot_reduce_serial \
+              assemble_b:assemble_b
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/assemble_b_test.cpp
+++ b/tests/slang_validate/assemble_b_test.cpp
@@ -1,0 +1,111 @@
+// Real-input validator for Cloth.SlangCodegen.AssembleB — the PD
+// right-hand-side gather kernel.
+//
+//   b[3v+d] = mass[v] * s[3v+d]
+//           + Σ_{(slot, w) in incident[v]}  w * projections[3*slot + d]
+//
+// Test fixture: 2-vertex system with 1 spring + 1 attachment.
+//
+//   verts:   v0, v1
+//   slot 0:  spring projection p_s = (1, 0, 0)
+//             touches v0 with w = +1 (the +sqrtW endpoint)
+//             touches v1 with w = −1 (the −sqrtW endpoint)
+//   slot 1:  attachment projection p_a = (10, 0, 0)
+//             touches v0 with w = +2 (the pinned vertex, sqrtW = 2)
+//
+//   predicted positions s = [0.5, 0, 0,  1.0, 0, 0]
+//   diagonal mass       m = [1.0, 1.0]
+//
+// Expected:
+//   b[v=0] = 1·(0.5, 0, 0) + (+1)·(1,0,0) + (+2)·(10,0,0) = (21.5, 0, 0)
+//   b[v=1] = 1·(1.0, 0, 0) + (−1)·(1,0,0)                  = ( 0.0, 0, 0)
+//
+// CSR encoding:
+//   ctxStart  = [0, 2, 3]
+//   ctxSlot   = [0, 1, 0]
+//   ctxWeight = [+1, +2, −1]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "assemble_b_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t V          = 2;
+    constexpr uint32_t SLOT_COUNT = 2;
+    constexpr uint32_t INCIDENCES = 3;
+
+    AssembleBParams_0 params{V};
+
+    float s[3 * V] = {
+        0.5f, 0.0f, 0.0f,    // v0
+        1.0f, 0.0f, 0.0f,    // v1
+    };
+    float mass[V] = {1.0f, 1.0f};
+    float projections[3 * SLOT_COUNT] = {
+         1.0f, 0.0f, 0.0f,   // slot 0 — spring projection
+        10.0f, 0.0f, 0.0f,   // slot 1 — attachment projection
+    };
+    uint32_t ctxStart[V + 1]   = {0u, 2u, 3u};
+    uint32_t ctxSlot[INCIDENCES]   = {0u, 1u, 0u};
+    float    ctxWeight[INCIDENCES] = {+1.0f, +2.0f, -1.0f};
+
+    float b[3 * V] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    GlobalParams_0 gp{};
+    gp.params_0          = &params;
+    gp.s_0.data          = s;            gp.s_0.count          = 3 * V;
+    gp.mass_0.data       = mass;         gp.mass_0.count       = V;
+    gp.projections_0.data = projections; gp.projections_0.count = 3 * SLOT_COUNT;
+    gp.ctxStart_0.data   = ctxStart;     gp.ctxStart_0.count   = V + 1;
+    gp.ctxSlot_0.data    = ctxSlot;      gp.ctxSlot_0.count    = INCIDENCES;
+    gp.ctxWeight_0.data  = ctxWeight;    gp.ctxWeight_0.count  = INCIDENCES;
+    gp.b_0.data          = b;            gp.b_0.count          = 3 * V;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected[3 * V] = {
+        21.5f, 0.0f, 0.0f,    // v0: 0.5 + 1 + 20
+         0.0f, 0.0f, 0.0f,    // v1: 1 - 1
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t i = 0; i < 3 * V; ++i) {
+        const float d = std::fabs(b[i] - expected[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "assemble_b mismatch at i=%u: got %g, expected %g (diff %g)\n",
+                    i, b[i], expected[i], d);
+            }
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "assemble_b: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf(
+            "assemble_b: %u/%u OK (V=%u, slots=%u, incidences=%u, max_abs_diff=%g, %.1fms)\n",
+            V, V, V, SLOT_COUNT, INCIDENCES, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "assemble_b: %d FAIL out of %u\n", fails, 3 * V);
+    return 1;
+}


### PR DESCRIPTION
## Summary

The missing bridge between the four constraint-projection kernels and the CG inner loop. Computes the Projective-Dynamics right-hand side

```
b[3v + d]  =  mass[v] * s[3v + d]
            + Σ_{(slot, w) in incident[v]}  w * projections[3*slot + d]
```

for each vertex `v` and dimension `d`. One thread per vertex; no atomics.

## The kernel is constraint-agnostic

The bind-time CSR `(ctxStart, ctxSlot, ctxWeight)` encodes the linear map `S^T` from constraint outputs back to per-vertex contributions. Each constraint type reduces to incidence entries in the same CSR:

| Constraint | Incidences per constraint | Weight on each |
|---|---|---|
| `spring_project` | 2 (the two endpoints) | ±sqrt(stiffness) |
| `attachment_project` | 1 (the pinned vertex) | +sqrt(stiffness) |
| `triangle_bending` | 4 (the bending stencil) | sqrt(stiffness) × cotangent weight |
| `triangle_project` | more (col0 + col1 per vertex) | rest_inv_uv-derived |

The kernel itself doesn't know or care about constraint types — it just gathers per-vertex contributions over its bind-time CSR.

## Test fixture (2 verts + 1 spring + 1 attachment)

```
s         = [0.5, 0, 0,  1.0, 0, 0]
mass      = [1, 1]
projections:
  slot 0 (spring)     = (1, 0, 0)
  slot 1 (attachment) = (10, 0, 0)

Incidence CSR:
  ctxStart  = [0, 2, 3]
  ctxSlot   = [0,    1,    0]
  ctxWeight = [+1,  +2,   −1]
  i.e. v0 ← +1·slot 0 + 2·slot 1
       v1 ← −1·slot 0

Expected:
  b[v=0] = 1·(0.5, 0, 0) + 1·(1,0,0) + 2·(10,0,0) = (21.5, 0, 0)
  b[v=1] = 1·(1.0, 0, 0) − 1·(1,0,0)               = ( 0.0, 0, 0)
```

Exercises both positive and negative incidence weights, the mass term, and the gather-over-CSR pattern.

## Verification

```
spring_project:     2/2 springs OK
triangle_bending:   2/2 constraints OK
attachment_project: 3/3 pins OK
triangle_project:   2/2 triangles OK
saxpby:             5/5 OK
spmv:               3/3 rows OK
dot_reduce_serial:  2/2 OK
assemble_b:         2/2 OK
cg_demo:            3/3 OK
all kernels OK
```

`assemble_b: 2/2 OK (V=2, slots=2, incidences=3, max_abs_diff=0)` — bit-exact match.

## Where this leaves the roadmap

Every kernel needed for a PD step now exists and is validated:

| Phase | Kernel(s) |
|---|---|
| local projections | `spring_project`, `triangle_bending`, `attachment_project`, `triangle_project` |
| assemble RHS | **`assemble_b`** ← this PR |
| global CG solve | `spmv`, `saxpby`, `dot_reduce_serial` (composed in `cg_demo`) |

Next: compose them into a full PD timestep on a 1-spring-1-pin (or slightly larger) system and bit-diff against the existing DiffCloth C++ simulator.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned Slang emission.
- [x] `make -C tests/slang_validate test` — all 8 kernel harnesses + cg_demo green.
- [ ] CI re-runs all three layers on `macos-14`.