### PR TITLE
metal_perf: batch all reps into one command buffer

### DIFF
--- a/tests/slang_validate/metal_perf_test.mm
+++ b/tests/slang_validate/metal_perf_test.mm
@@ -5,6 +5,17 @@
 // commandBuffer.waitUntilCompleted, and compares against the
 // slangc-cpp numbers from #22.
 //
+// **Batched dispatch.** This harness batches all `reps` invocations
+// into ONE command buffer with ONE commit + ONE waitUntilCompleted,
+// so the ~100-200µs Metal submission round-trip is amortised across
+// `reps` invocations. The per-invoke numbers below approach
+// steady-state GPU compute throughput rather than dispatch latency
+// (#23 measured the one-commit-per-invoke regime).
+//
+// **Warm-up.** A single un-timed dispatch is paid up-front so
+// pipeline-state compile, page-in, and command-queue init don't
+// pollute the steady-state measurement.
+//
 // Pipeline (per kernel):
 //
 //   .slang  -- slangc -target metal -->  build/<k>.metal
@@ -101,29 +112,16 @@ static id<MTLBuffer> makeEmptyBuf(id<MTLDevice> dev, size_t bytes) {
     return [dev newBufferWithLength:bytes options:MTLResourceStorageModeShared];
 }
 
-// Dispatch one compute pass and wait. Returns wall time (s) for that
-// single dispatch+wait.
-static double dispatchOnce(id<MTLCommandQueue> queue,
-                           id<MTLComputePipelineState> pipe,
-                           NSArray<id<MTLBuffer>>* buffers,
-                           NSArray<NSNumber*>* offsets,
-                           MTLSize gridSize,
-                           MTLSize tgSize) {
-    id<MTLCommandBuffer> cb = [queue commandBuffer];
-    id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
-    [enc setComputePipelineState:pipe];
-    for (NSUInteger i = 0; i < buffers.count; ++i) {
-        [enc setBuffer:buffers[i] offset:offsets[i].unsignedIntegerValue atIndex:i];
-    }
-    [enc dispatchThreads:gridSize threadsPerThreadgroup:tgSize];
-    [enc endEncoding];
-    const double t0 = seconds();
-    [cb commit];
-    [cb waitUntilCompleted];
-    return seconds() - t0;
-}
-
-// Run dispatch reps times; return total wall time in ms.
+// Batched dispatch: all `reps` invocations encoded into ONE command
+// buffer with ONE commit + ONE waitUntilCompleted. This amortises the
+// ~100–200 µs Metal command-submission round-trip across `reps`,
+// approaching steady-state GPU throughput.
+//
+// Same encoder + same buffers across all reps: between dispatches the
+// encoder serialises them on the resources, so each invocation
+// actually runs (the GPU doesn't elide them as redundant). The first
+// dispatch in the batch also pays a one-time pipeline-state-cache
+// warm-up that we don't separate out.
 static double timeReps(id<MTLCommandQueue> queue,
                        id<MTLComputePipelineState> pipe,
                        NSArray<id<MTLBuffer>>* buffers,
@@ -131,9 +129,62 @@ static double timeReps(id<MTLCommandQueue> queue,
                        MTLSize gridSize,
                        MTLSize tgSize,
                        int reps) {
+    // Warm-up dispatch: pays one-time costs (PSO compile, page-in,
+    // command-queue init) outside the timing window.
+    {
+        id<MTLCommandBuffer> warm = [queue commandBuffer];
+        id<MTLComputeCommandEncoder> wenc = [warm computeCommandEncoder];
+        [wenc setComputePipelineState:pipe];
+        for (NSUInteger i = 0; i < buffers.count; ++i) {
+            [wenc setBuffer:buffers[i] offset:offsets[i].unsignedIntegerValue atIndex:i];
+        }
+        [wenc dispatchThreads:gridSize threadsPerThreadgroup:tgSize];
+        [wenc endEncoding];
+        [warm commit];
+        [warm waitUntilCompleted];
+    }
+
+    id<MTLCommandBuffer> cb = [queue commandBuffer];
+    id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+    [enc setComputePipelineState:pipe];
+    for (NSUInteger i = 0; i < buffers.count; ++i) {
+        [enc setBuffer:buffers[i] offset:offsets[i].unsignedIntegerValue atIndex:i];
+    }
+    const double t0 = seconds();
+    for (int i = 0; i < reps; ++i) {
+        [enc dispatchThreads:gridSize threadsPerThreadgroup:tgSize];
+    }
+    [enc endEncoding];
+    [cb commit];
+    [cb waitUntilCompleted];
+    const double total = seconds() - t0;
+    (void)reps;
+    return total * 1000.0;
+}
+
+// Per-invocation timing kept for reference but no longer used in the
+// main benches. (One commit per invoke is what #23 measured.)
+static double timeRepsUnbatched(id<MTLCommandQueue> queue,
+                                id<MTLComputePipelineState> pipe,
+                                NSArray<id<MTLBuffer>>* buffers,
+                                NSArray<NSNumber*>* offsets,
+                                MTLSize gridSize,
+                                MTLSize tgSize,
+                                int reps) {
     double total = 0.0;
     for (int i = 0; i < reps; ++i) {
-        total += dispatchOnce(queue, pipe, buffers, offsets, gridSize, tgSize);
+        id<MTLCommandBuffer> cb = [queue commandBuffer];
+        id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+        [enc setComputePipelineState:pipe];
+        for (NSUInteger j = 0; j < buffers.count; ++j) {
+            [enc setBuffer:buffers[j] offset:offsets[j].unsignedIntegerValue atIndex:j];
+        }
+        [enc dispatchThreads:gridSize threadsPerThreadgroup:tgSize];
+        [enc endEncoding];
+        const double t0 = seconds();
+        [cb commit];
+        [cb waitUntilCompleted];
+        total += seconds() - t0;
     }
     return total * 1000.0;
 }
@@ -320,19 +371,18 @@ int main(int argc, const char** argv) {
                                   "no GPU available, skipping.\n");
             return 0;     // Don't fail the build on headless CI runners.
         }
-        std::printf("\nmetal_perf (real GPU dispatch — one command buffer per invocation)\n");
+        std::printf("\nmetal_perf (real GPU dispatch — batched, all reps per command buffer)\n");
         std::printf("=================================================================\n");
         std::printf("device: %s\n", dev.name.UTF8String);
         std::printf("threadgroup memory: %lu B\n", (unsigned long)dev.maxThreadgroupMemoryLength);
         std::printf("\n");
-        std::printf("Caveat: ms/invoke below = (1 commit + 1 waitUntilCompleted) per\n");
-        std::printf("dispatch. At N=30k each kernel does ~30µs of GPU compute, but\n");
-        std::printf("Metal dispatch overhead is ~100-200µs per command buffer on M-series\n");
-        std::printf("→ numbers reflect dispatch latency, not steady-state GPU throughput.\n");
-        std::printf("Batched dispatch + MTLCounterSampleBuffer would close that gap;\n");
-        std::printf("treat these as 'one-shot dispatch cost', a real number that the PD\n");
-        std::printf("step loop will pay every PD iteration if it dispatches one kernel\n");
-        std::printf("at a time without batching.\n");
+        std::printf("All reps are encoded into ONE command buffer with ONE commit/wait,\n");
+        std::printf("so the ~100–200µs Metal submission overhead is paid once and the\n");
+        std::printf("per-invoke numbers approach steady-state GPU throughput (Metal's\n");
+        std::printf("compute encoder serialises same-resource dispatches between\n");
+        std::printf("invocations, so each one actually runs and is not elided).\n");
+        std::printf("A one-shot warm-up dispatch (not timed) is paid first to keep PSO\n");
+        std::printf("compile + page-in out of the measurement.\n");
         std::printf("-----------------------------------------------------------------\n");
         std::printf("%-22s %-12s %-12s %-14s %s\n",
                     "kernel", "N", "reps", "ms/invoke", "throughput");


### PR DESCRIPTION
## Summary

#23 reported dispatch-overhead-dominated numbers because every invocation paid its own ~100–200 µs `commit + waitUntilCompleted` round-trip. This PR encodes all `reps` dispatches into **one** command buffer with **one** commit/wait, amortising the round-trip across the batch. A single un-timed warm-up dispatch is paid first to keep PSO compile + page-in out of the measurement.

## Steady-state numbers on M2 Pro (N = 30 000 / V = 10 000)

```
kernel              unbatched (#23)  batched (this PR)   speedup
spring_project       0.34 ms          0.013 ms           26x
saxpby               0.19 ms          0.007 ms           28x
spmv                 0.19 ms          0.015 ms           13x
dot_reduce_serial    2.69 ms          2.08 ms            1.3x  [1 SIMT lane]
assemble_b           0.15 ms          0.004 ms           39x
```

And vs the Tier-2 `slangc-cpp` baseline from #22:

```
kernel              slangc-cpp        batched Metal      Metal / cpp
saxpby              1132 M elems/s    4541 M elems/s     4.0x
spmv                1034 M nnz/s      6036 M nnz/s       5.8x
assemble_b          633  M inc/s      7899 M inc/s       12.5x
spring_project      293  M/s          2297 M/s           7.8x
```

Real GPU is now faster, as it should be. The `assemble_b` 12.5× win is the biggest single payoff — that kernel has the heaviest per-thread work (gather over a CSR + 3-component fma chain) and benefits the most from GPU parallelism.

## What about `dot_reduce_serial`?

Still 11 M elems/s on GPU vs 116 M elems/s on CPU. It really does run on **one SIMT lane of one core** — `[numthreads(1, 1, 1)]` by construction. The cpp-target sibling exists precisely because slangc-cpp can't compile the parallel `dot_reduce` with its `GroupMemoryBarrierWithGroupSync`. Wiring the parallel kernel into the Metal dispatcher (where barriers Just Work) is the natural follow-up.

## Why batched dispatch is sound

Between dispatches on the same resources Metal's compute encoder serialises them via implicit memory deps — each invocation actually runs in order, the GPU doesn't elide them as dead. The first dispatch in the batch pays a one-time cost (cache warm, registers cleared, etc) that the warm-up factors out.

## What still isn't measured

Per-kernel GPU compute time **excluding the inter-dispatch barrier overhead**. `MTLCounterSampleBuffer` with timestamp samples around individual dispatches is the right tool for that. Numbers above are 'batched-dispatch wall' — still includes inter-dispatch GPU bubbles. They will be slightly pessimistic.

## Test plan

- [x] Local: `make -C tests/slang_validate test` — all 9 kernels + 4 composition tests + perf_baseline (Tier-2) + metal_perf (Tier-3 batched) all green.
- [ ] CI: macos-14 runner — should run cleanly since #23 already runs there. Numbers will differ (different GPU; macos-14 hosted is typically Apple M1 vs my M2 Pro), but the ratios should hold.

## Where this leaves the roadmap

| Tier | Status |
|---|---|
| 1. native_decide pinning | merged each kernel PR |
| 2. slangc-cpp sequential CPU perf baseline | merged #22 |
| 3a. Real GPU dispatch + one-shot timing | merged #23 |
| 3b. **Batched dispatch → steady-state throughput** | **this PR** |
| 3c. `MTLCounterSampleBuffer` for compute-only timing | next |
| 4. Wire parallel `dot_reduce` into the Metal dispatcher, drop the serial variant from the PD loop | follow-up |