### PR TITLE
metal_perf: wire parallel dot_reduce into the Metal dispatcher

### DIFF
--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial assemble_b
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++

--- a/tests/slang_validate/metal_perf_test.mm
+++ b/tests/slang_validate/metal_perf_test.mm
@@ -282,6 +282,37 @@ static double benchDotReduceSerial(id<MTLDevice> dev, id<MTLCommandQueue> queue,
                     reps);
 }
 
+// Parallel dot_reduce: one threadgroup of 256 threads doing a
+// grid-strided df32 fold + groupshared tree reduce. Compiles fine
+// through slangc-metal (Metal natively supports threadgroup memory +
+// threadgroup_barrier); only slangc-cpp can't run it, which is why
+// the serial variant exists.
+static double benchDotReduceParallel(id<MTLDevice> dev, id<MTLCommandQueue> queue,
+                                     id<MTLLibrary> lib, uint32_t N, int reps) {
+    id<MTLComputePipelineState> pipe = makePipe(dev, lib, "main_0");
+    if (!pipe) return -1;
+
+    DotParams p{N};
+    std::vector<float> a(N), b(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        a[i] = float((i % 17) - 8);
+        b[i] = float((i % 23) - 11);
+    }
+    std::vector<float> dst(2, 0.0f);
+
+    id<MTLBuffer> bp  = makeBuf(dev, p);
+    id<MTLBuffer> ba  = makeBuf(dev, a);
+    id<MTLBuffer> bb  = makeBuf(dev, b);
+    id<MTLBuffer> bd  = makeBuf(dev, dst);
+
+    return timeReps(queue, pipe,
+                    @[bp, ba, bb, bd],
+                    @[@0, @0, @0, @0],
+                    MTLSizeMake(256, 1, 1),    // one threadgroup of 256
+                    MTLSizeMake(256, 1, 1),
+                    reps);
+}
+
 static double benchAssembleB(id<MTLDevice> dev, id<MTLCommandQueue> queue,
                              id<MTLLibrary> lib, uint32_t V,
                              uint32_t incPerV, int reps, uint32_t& slots_out) {
@@ -435,8 +466,19 @@ int main(int argc, const char** argv) {
             if (lib) {
                 const double ms  = benchDotReduceSerial(dev, queue, lib, N, REPS_DOT);
                 const double per = ms / REPS_DOT;
-                std::printf("%-22s %-12u %-12d %-14.4f %.1f M elems/s  [single-thread, 1 SIMT lane]\n",
+                std::printf("%-22s %-12u %-12d %-14.4f %.1f M elems/s  [serial, 1 SIMT lane]\n",
                             "dot_reduce_serial", N, REPS_DOT, per,
+                            (double(N) / per) / 1e3);
+            }
+        }
+
+        {
+            id<MTLLibrary> lib = loadLib(dev, (libRoot + "dot_reduce.metallib").c_str());
+            if (lib) {
+                const double ms  = benchDotReduceParallel(dev, queue, lib, N, REPS_FAST);
+                const double per = ms / REPS_FAST;
+                std::printf("%-22s %-12u %-12d %-14.4f %.1f M elems/s  [parallel, 256 threads, df32]\n",
+                            "dot_reduce", N, REPS_FAST, per,
                             (double(N) / per) / 1e3);
             }
         }


### PR DESCRIPTION
## Summary

The parallel `dot_reduce` kernel (groupshared + `GroupMemoryBarrierWithGroupSync`) was previously only verified via Layer 1 SPIR-V round-trip — slangc-cpp rejects barriers (E36107), so we kept the `[numthreads(1,1,1)]` serial sibling as the slang_validate-compatible stand-in.

**slangc-metal accepts barriers natively.** Metal has `threadgroup` memory + `threadgroup_barrier` built in. Adding `dot_reduce` to the `METAL_KERNELS` list picks up the existing `.slang → .metal → .air → .metallib` pipeline; the harness adds a `benchDotReduceParallel` that dispatches one threadgroup of 256 threads doing the grid-strided df32 fold + tree reduce.

## Result at N=30 000 on M2 Pro

```
dot_reduce_serial    2.14 ms/invoke     14 M elems/s    [serial, 1 SIMT lane]
dot_reduce           0.020 ms/invoke   1540 M elems/s    [parallel, 256 threads]
```

**110× speedup.** The parallel kernel is now in the same regime as the other parallel kernels:

```
spring_project       0.013 ms        2325 M springs/s
saxpby               0.007 ms        4056 M elems/s
spmv (nnz=90k)       0.015 ms        6038 M nnz/s
dot_reduce           0.020 ms        1540 M elems/s    ← this PR
assemble_b           0.004 ms        7970 M inc/s
```

## Projected per-PD-step cost at N=30 000

```
one CG iter:  spmv + 3 saxpby + 2 dot  = 0.015 + 0.021 + 0.040  = 0.076 ms
30-iter CG                                                       = 2.3 ms
+ 4 constraint projects + assemble_b + velocity saxpby           = ~0.1 ms
                                                                   ───────
one full PD step                                                  = ~2.4 ms
```

vs DiffCloth's `Simulation::step()` at dress scale (10 902 DoF, ~3× smaller than this benchmark): **~280 ms median** on the same M2 Pro, including collision detection + multi-outer-iter PD + friction.

**The solver math (linalg + assembly) is ~100× faster through this Metal pipeline.** The remaining gap to a real cloth simulator is collision detection + multi-outer-iter PD coordination + friction — none of which the per-kernel benchmarks measure.

## Why we keep both `dot_reduce` and `dot_reduce_serial`

| Kernel | slang_validate (cpp) | Metal | Use |
|---|---|---|---|
| `dot_reduce` | ❌ (barrier blocker) | ✅ parallel | GPU production |
| `dot_reduce_serial` | ✅ (no barrier) | ✅ but slow | slangc-cpp host-diff |

Both produce the same df32 `(hi, lo)` result on the same input. Same EFTs (two_sum, quick_two_sum, two_prod, df_add); different parallel structure.

## Verification

```
$ make -C tests/slang_validate test
…
metal_perf (real GPU dispatch — batched, all reps per command buffer)
=================================================================
device: Apple M2 Pro
…
spring_project         30000        200          0.0129         2325.1 M springs/s
saxpby                 30000        200          0.0074         4056.2 M elems/s
spmv                   30000        200          0.0149         6038.4 M nnz/s  (nnz=89998)
dot_reduce_serial      30000        50           2.1423         14.0 M elems/s  [serial, 1 SIMT lane]
dot_reduce             30000        200          0.0195         1540.4 M elems/s  [parallel, 256 threads, df32]
assemble_b             10000        200          0.0038         7969.9 M inc/s  (V=10000, inc=30000, slots=10000)
```

## Roadmap

| | Step | Status |
|---|---|---|
| Tier-1 native_decide | merged each kernel PR |
| Tier-2 slangc-cpp throughput | merged #22 |
| Tier-3a real GPU dispatch (one-shot) | merged #23 |
| Tier-3b batched dispatch | merged #24 |
| **Parallel dot_reduce on Metal** | **this PR** |
| Tier-3c MTLCounterSampleBuffer for compute-only timing | next |
| Wrap kernels into a full-PD-step Metal harness at N=30k | next |
| Add collision detection + friction (port DiffCloth's missing parts) | future |