### PR TITLE
Stand up MetalCGSolver: C++-callable wrapper around Slang/Metal CG

### DIFF
--- a/src/code/slang_solver/Makefile
+++ b/src/code/slang_solver/Makefile
@@ -1,0 +1,37 @@
+# Standalone build for the MetalCGSolver wrapper + its correctness test.
+# This Makefile is deliberately separate from DiffCloth's CMake build
+# (in build_diffcloth/) and from tests/slang_validate/Makefile — it
+# proves the C++ ↔ Obj-C++ ↔ Metal wrapper works in isolation before
+# we wire it into Simulation.cpp.
+#
+# Prerequisite:
+#   make -C ../../../tests/slang_validate test
+# (so that spmv.metallib, saxpby.metallib, dot_reduce.metallib exist).
+
+REPO_ROOT  := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../../..)
+METALLIB_DIR := $(REPO_ROOT)/tests/slang_validate/build
+BUILD      := $(CURDIR)/build
+
+CXX        ?= clang++
+CXXFLAGS   ?= -std=c++17 -O2 -Wall -Wextra
+INCLUDES   := -I.
+
+.PHONY: test clean
+
+test: $(BUILD)/test_metal_cg_solver
+	@echo "=== Smoke test of the wrapper (no Eigen, no DiffCloth)."
+	$(BUILD)/test_metal_cg_solver $(METALLIB_DIR)
+
+$(BUILD)/test_metal_cg_solver: test_metal_cg_solver.cpp \
+                                $(BUILD)/MetalCGSolver.o
+	@mkdir -p $(BUILD)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) \
+	  -framework Metal -framework Foundation \
+	  -o $@ $^
+
+$(BUILD)/MetalCGSolver.o: MetalCGSolver.mm MetalCGSolver.h
+	@mkdir -p $(BUILD)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -fobjc-arc -c -o $@ MetalCGSolver.mm
+
+clean:
+	rm -rf $(BUILD)

--- a/src/code/slang_solver/MetalCGSolver.h
+++ b/src/code/slang_solver/MetalCGSolver.h
@@ -1,0 +1,64 @@
+// MetalCGSolver — pure-C++ interface to the Slang/Metal CG solver
+// pipeline (spmv + saxpby + dot_reduce). Wraps the Metal dispatcher
+// so DiffCloth's simulation code can call into our Tier-3 perf path
+// without pulling Foundation/Metal headers into Eigen-using TUs.
+//
+// Lifecycle:
+//   - Construct once per system matrix (does CSR upload + PSO compile).
+//   - `solve(b)` per PD outer iteration; returns x such that A·x = b.
+//   - Destruct to free Metal resources.
+//
+// Precision caveat: kernels are fp32. The CG inner loop accumulates
+// in df32 via dot_reduce_serial / dot_reduce, but spmv and saxpby
+// are pure fp32. DiffCloth uses fp64 (Eigen VecXd = double). This
+// wrapper accepts and returns double for API compatibility, but the
+// solve happens in fp32 internally with df32 inner products. Drift
+// vs Eigen's LLT solve is expected at ~1e-5..1e-7 relative.
+
+#ifndef CLOTH_METAL_CG_SOLVER_H
+#define CLOTH_METAL_CG_SOLVER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace cloth {
+
+// Sparse CSR matrix in 32-bit indices + 32-bit values. The wrapper
+// takes whatever (rowPtr, colIdx, values) you give it; the caller
+// is responsible for ensuring A is SPD (which DiffCloth's system
+// matrix is).
+struct CSRSpMatF {
+    std::vector<int32_t> rowPtr;   // length = rows + 1
+    std::vector<int32_t> colIdx;   // length = nnz
+    std::vector<float>   values;   // length = nnz
+    uint32_t rows = 0;
+};
+
+class MetalCGSolver {
+public:
+    // Construct from a CSR matrix. Uploads to Metal buffers; builds
+    // compute pipelines for spmv / saxpby / dot_reduce. The
+    // metallibPath must point at the directory containing
+    // spmv.metallib, saxpby.metallib, dot_reduce.metallib (so the
+    // wrapper can `MTLDevice newLibraryWithURL:` them at runtime).
+    MetalCGSolver(const CSRSpMatF& A, const char* metallibPath);
+    ~MetalCGSolver();
+
+    // Solve A·x = b. b.size() == A.rows. Output x.size() == A.rows.
+    // CG inner loop runs until ||r|| <= tol·||r₀|| or max_iter reached.
+    // Returns the number of iterations taken (≤ max_iter). If the
+    // solver failed to construct, returns -1 and leaves x untouched.
+    int solve(const std::vector<double>& b, std::vector<double>& x,
+              double tol = 1e-6, int max_iter = 200);
+
+    bool ok() const;
+
+private:
+    struct Impl;
+    Impl* impl_;
+};
+
+}  // namespace cloth
+
+#endif  // CLOTH_METAL_CG_SOLVER_H

--- a/src/code/slang_solver/MetalCGSolver.mm
+++ b/src/code/slang_solver/MetalCGSolver.mm
@@ -1,0 +1,296 @@
+// MetalCGSolver implementation. Loads three .metallib files
+// (spmv, saxpby, dot_reduce — the parallel df32 reduce), creates
+// MTLComputePipelineState for each, and runs a CG loop on the GPU.
+//
+// CG layout (Shewchuk § B.2), all on-device buffers:
+//   r₀ = b − A·x₀          spmv into a temp, then saxpby
+//   p  = r₀
+//   δ_new = dot(r, r)       dot_reduce reads to a tiny shared buffer
+//   loop:
+//     q     = A·p           spmv
+//     pq    = dot(p, q)     dot_reduce
+//     α     = δ_new / pq    on the host (sync after dot_reduce)
+//     x    += α·p           saxpby
+//     r    -= α·q           saxpby
+//     δ_old = δ_new
+//     δ_new = dot(r, r)     dot_reduce
+//     if δ_new < tol²·δ₀ break
+//     β     = δ_new / δ_old
+//     p     = r + β·p       saxpby
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+#include "MetalCGSolver.h"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+namespace cloth {
+
+struct MetalCGSolver::Impl {
+    id<MTLDevice>               device   = nil;
+    id<MTLCommandQueue>         queue    = nil;
+    id<MTLComputePipelineState> psoSpmv  = nil;
+    id<MTLComputePipelineState> psoSax   = nil;
+    id<MTLComputePipelineState> psoDot   = nil;
+
+    // CSR matrix (uploaded once).
+    id<MTLBuffer> bufRowPtr = nil;
+    id<MTLBuffer> bufColIdx = nil;
+    id<MTLBuffer> bufVals   = nil;
+    uint32_t      rows      = 0;
+
+    // CG workspace (allocated once, length = rows).
+    id<MTLBuffer> bufX      = nil;     // solution
+    id<MTLBuffer> bufR      = nil;     // residual
+    id<MTLBuffer> bufP      = nil;     // search direction
+    id<MTLBuffer> bufQ      = nil;     // A·p workspace
+    id<MTLBuffer> bufB      = nil;     // RHS (uploaded per solve)
+    id<MTLBuffer> bufDotDst = nil;     // dot_reduce (hi, lo) sink, length 2
+
+    // Per-kernel parameter buffers (rebound per dispatch).
+    id<MTLBuffer> bufSpmvParams = nil;   // { uint rows; }
+    id<MTLBuffer> bufSaxParams  = nil;   // { uint n; float alpha; float beta; }
+    id<MTLBuffer> bufDotParams  = nil;   // { uint n; }
+
+    bool ok = false;
+
+    static id<MTLLibrary> loadLib(id<MTLDevice> dev, const std::string& path,
+                                   const char* name) {
+        NSError* err = nil;
+        NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path.c_str()]];
+        id<MTLLibrary> lib = [dev newLibraryWithURL:url error:&err];
+        if (!lib) {
+            std::fprintf(stderr, "MetalCGSolver: failed to load %s from %s: %s\n",
+                         name, path.c_str(),
+                         err ? err.localizedDescription.UTF8String : "(null)");
+        }
+        return lib;
+    }
+
+    static id<MTLComputePipelineState> makePSO(id<MTLDevice> dev,
+                                                 id<MTLLibrary> lib,
+                                                 const char* fn,
+                                                 const char* tag) {
+        NSError* err = nil;
+        id<MTLFunction> f = [lib newFunctionWithName:[NSString stringWithUTF8String:fn]];
+        if (!f) {
+            std::fprintf(stderr, "MetalCGSolver: no fn %s in %s\n", fn, tag);
+            return nil;
+        }
+        id<MTLComputePipelineState> pso =
+            [dev newComputePipelineStateWithFunction:f error:&err];
+        if (!pso) {
+            std::fprintf(stderr, "MetalCGSolver: PSO %s failed: %s\n",
+                         tag, err ? err.localizedDescription.UTF8String : "(null)");
+        }
+        return pso;
+    }
+};
+
+namespace {
+struct SpmvParams { uint32_t rows; };
+struct SaxParams  { uint32_t n; float alpha; float beta; };
+struct DotParams  { uint32_t n; };
+}
+
+MetalCGSolver::MetalCGSolver(const CSRSpMatF& A, const char* metallibPath)
+    : impl_(new Impl()) {
+    impl_->device = MTLCreateSystemDefaultDevice();
+    if (!impl_->device) {
+        std::fprintf(stderr, "MetalCGSolver: no Metal device\n");
+        return;
+    }
+    impl_->queue = [impl_->device newCommandQueue];
+
+    std::string root = metallibPath;
+    if (!root.empty() && root.back() != '/') root.push_back('/');
+    id<MTLLibrary> libSpmv = Impl::loadLib(impl_->device, root + "spmv.metallib",       "spmv");
+    id<MTLLibrary> libSax  = Impl::loadLib(impl_->device, root + "saxpby.metallib",     "saxpby");
+    id<MTLLibrary> libDot  = Impl::loadLib(impl_->device, root + "dot_reduce.metallib", "dot_reduce");
+    if (!libSpmv || !libSax || !libDot) return;
+
+    impl_->psoSpmv = Impl::makePSO(impl_->device, libSpmv, "main_0", "spmv");
+    impl_->psoSax  = Impl::makePSO(impl_->device, libSax,  "main_0", "saxpby");
+    impl_->psoDot  = Impl::makePSO(impl_->device, libDot,  "main_0", "dot_reduce");
+    if (!impl_->psoSpmv || !impl_->psoSax || !impl_->psoDot) return;
+
+    impl_->rows = A.rows;
+    const uint32_t N    = A.rows;
+    const uint32_t nnz  = uint32_t(A.colIdx.size());
+    const NSUInteger bytesRow = (N + 1) * sizeof(int32_t);
+    const NSUInteger bytesNnz = nnz * sizeof(int32_t);
+    const NSUInteger bytesVal = nnz * sizeof(float);
+    const NSUInteger bytesVec = N * sizeof(float);
+
+    impl_->bufRowPtr = [impl_->device newBufferWithBytes:A.rowPtr.data()
+                                                  length:bytesRow
+                                                 options:MTLResourceStorageModeShared];
+    impl_->bufColIdx = [impl_->device newBufferWithBytes:A.colIdx.data()
+                                                  length:bytesNnz
+                                                 options:MTLResourceStorageModeShared];
+    impl_->bufVals   = [impl_->device newBufferWithBytes:A.values.data()
+                                                  length:bytesVal
+                                                 options:MTLResourceStorageModeShared];
+
+    impl_->bufX = [impl_->device newBufferWithLength:bytesVec options:MTLResourceStorageModeShared];
+    impl_->bufR = [impl_->device newBufferWithLength:bytesVec options:MTLResourceStorageModeShared];
+    impl_->bufP = [impl_->device newBufferWithLength:bytesVec options:MTLResourceStorageModeShared];
+    impl_->bufQ = [impl_->device newBufferWithLength:bytesVec options:MTLResourceStorageModeShared];
+    impl_->bufB = [impl_->device newBufferWithLength:bytesVec options:MTLResourceStorageModeShared];
+    impl_->bufDotDst = [impl_->device newBufferWithLength:2 * sizeof(float)
+                                                  options:MTLResourceStorageModeShared];
+
+    impl_->bufSpmvParams = [impl_->device newBufferWithLength:sizeof(SpmvParams)
+                                                      options:MTLResourceStorageModeShared];
+    impl_->bufSaxParams  = [impl_->device newBufferWithLength:sizeof(SaxParams)
+                                                      options:MTLResourceStorageModeShared];
+    impl_->bufDotParams  = [impl_->device newBufferWithLength:sizeof(DotParams)
+                                                      options:MTLResourceStorageModeShared];
+    *static_cast<SpmvParams*>(impl_->bufSpmvParams.contents) = {N};
+    *static_cast<DotParams*>(impl_->bufDotParams.contents)   = {N};
+
+    impl_->ok = true;
+}
+
+MetalCGSolver::~MetalCGSolver() { delete impl_; }
+
+bool MetalCGSolver::ok() const { return impl_ && impl_->ok; }
+
+int MetalCGSolver::solve(const std::vector<double>& b,
+                         std::vector<double>& x,
+                         double tol, int max_iter) {
+    if (!ok()) return -1;
+    const uint32_t N = impl_->rows;
+    if (b.size() != N) {
+        std::fprintf(stderr, "MetalCGSolver: b.size()=%zu != rows=%u\n",
+                     b.size(), N);
+        return -1;
+    }
+
+    // ---- Upload b (fp64 → fp32) -------------------------------------------
+    {
+        float* bptr = static_cast<float*>(impl_->bufB.contents);
+        for (uint32_t i = 0; i < N; ++i) bptr[i] = float(b[i]);
+    }
+    // Initial guess x₀ = 0; r₀ = b − A·0 = b; p₀ = r₀.
+    {
+        float* xptr = static_cast<float*>(impl_->bufX.contents);
+        float* rptr = static_cast<float*>(impl_->bufR.contents);
+        float* pptr = static_cast<float*>(impl_->bufP.contents);
+        float* bptr = static_cast<float*>(impl_->bufB.contents);
+        for (uint32_t i = 0; i < N; ++i) {
+            xptr[i] = 0.0f;
+            rptr[i] = bptr[i];
+            pptr[i] = bptr[i];
+        }
+    }
+
+    auto encDispatch = [&](id<MTLComputeCommandEncoder> enc,
+                           id<MTLComputePipelineState> pso,
+                           NSArray* buffers,
+                           MTLSize grid, MTLSize tg) {
+        [enc setComputePipelineState:pso];
+        for (NSUInteger i = 0; i < buffers.count; ++i) {
+            [enc setBuffer:buffers[i] offset:0 atIndex:i];
+        }
+        [enc dispatchThreads:grid threadsPerThreadgroup:tg];
+    };
+
+    auto dispatchDot = [&](id<MTLBuffer> a, id<MTLBuffer> bb) -> double {
+        id<MTLCommandBuffer> cb = [impl_->queue commandBuffer];
+        id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+        encDispatch(enc, impl_->psoDot,
+                    @[impl_->bufDotParams, a, bb, impl_->bufDotDst],
+                    MTLSizeMake(256, 1, 1), MTLSizeMake(256, 1, 1));
+        [enc endEncoding];
+        [cb commit];
+        [cb waitUntilCompleted];
+        const float* dst = static_cast<const float*>(impl_->bufDotDst.contents);
+        return double(dst[0]) + double(dst[1]);
+    };
+
+    double delta_new = dispatchDot(impl_->bufR, impl_->bufR);
+    const double delta_0 = delta_new;
+    if (delta_0 == 0.0) {
+        // b ≡ 0 → x ≡ 0 already satisfies A·x = b.
+        x.assign(N, 0.0);
+        return 0;
+    }
+
+    int iter = 0;
+    SaxParams* spy = static_cast<SaxParams*>(impl_->bufSaxParams.contents);
+    spy->n = N;
+
+    for (; iter < max_iter; ++iter) {
+        // q = A · p
+        {
+            id<MTLCommandBuffer> cb = [impl_->queue commandBuffer];
+            id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+            encDispatch(enc, impl_->psoSpmv,
+                        @[impl_->bufSpmvParams, impl_->bufRowPtr,
+                          impl_->bufColIdx, impl_->bufVals,
+                          impl_->bufP, impl_->bufQ],
+                        MTLSizeMake(N, 1, 1), MTLSizeMake(256, 1, 1));
+            [enc endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+        }
+
+        const double pq    = dispatchDot(impl_->bufP, impl_->bufQ);
+        const double alpha = delta_new / pq;
+
+        // x := x + α·p    (saxpby with α'=1, β'=α, src x, src p, dst x)
+        spy->alpha = 1.0f; spy->beta = float(alpha);
+        {
+            id<MTLCommandBuffer> cb = [impl_->queue commandBuffer];
+            id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+            encDispatch(enc, impl_->psoSax,
+                        @[impl_->bufSaxParams, impl_->bufX, impl_->bufP, impl_->bufX],
+                        MTLSizeMake(N, 1, 1), MTLSizeMake(256, 1, 1));
+            [enc endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+        }
+        // r := r − α·q
+        spy->alpha = 1.0f; spy->beta = float(-alpha);
+        {
+            id<MTLCommandBuffer> cb = [impl_->queue commandBuffer];
+            id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+            encDispatch(enc, impl_->psoSax,
+                        @[impl_->bufSaxParams, impl_->bufR, impl_->bufQ, impl_->bufR],
+                        MTLSizeMake(N, 1, 1), MTLSizeMake(256, 1, 1));
+            [enc endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+        }
+
+        const double delta_old = delta_new;
+        delta_new = dispatchDot(impl_->bufR, impl_->bufR);
+        if (delta_new < tol * tol * delta_0) { ++iter; break; }
+        const double beta = delta_new / delta_old;
+
+        // p := r + β·p   (saxpby with α'=1, β'=β, src r, src p, dst p)
+        spy->alpha = 1.0f; spy->beta = float(beta);
+        {
+            id<MTLCommandBuffer> cb = [impl_->queue commandBuffer];
+            id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+            encDispatch(enc, impl_->psoSax,
+                        @[impl_->bufSaxParams, impl_->bufR, impl_->bufP, impl_->bufP],
+                        MTLSizeMake(N, 1, 1), MTLSizeMake(256, 1, 1));
+            [enc endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+        }
+    }
+
+    // Read back x (fp32 → fp64).
+    x.resize(N);
+    const float* xptr = static_cast<const float*>(impl_->bufX.contents);
+    for (uint32_t i = 0; i < N; ++i) x[i] = double(xptr[i]);
+    return iter;
+}
+
+}  // namespace cloth

--- a/src/code/slang_solver/test_metal_cg_solver.cpp
+++ b/src/code/slang_solver/test_metal_cg_solver.cpp
@@ -1,0 +1,86 @@
+// Standalone correctness test for MetalCGSolver. Builds a tiny SPD
+// CSR matrix, solves A·x = b through the wrapper, and compares against
+// the analytic answer.
+//
+// System (same as cg_demo_test from #15):
+//
+//   A = [ 4 1 0 ]      b = [5, 7, 6]
+//       [ 1 3 0 ]      A⁻¹·b = [8/11, 23/11, 3]
+//       [ 0 0 2 ]               ≈ [0.7272727, 2.0909091, 3.0]
+//
+//   CSR:
+//     rowPtr = [0, 2, 4, 5]
+//     colIdx = [0, 1, 0, 1, 2]
+//     values = [4, 1, 1, 3, 2]
+//
+// CG on a 3×3 SPD matrix converges in ≤ 3 iters in exact arithmetic;
+// fp32 may need 4-5. Tolerance: 1e-4 absolute (loose because fp32).
+
+#include "MetalCGSolver.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+int main(int argc, char** argv) {
+    // Path to the directory containing spmv.metallib, saxpby.metallib,
+    // dot_reduce.metallib. Default points at our existing slang_validate
+    // build dir; can be overridden with argv[1].
+    std::string libDir =
+        "/Users/ernest.lee/Desktop/TOOL_cloth_dynamics/tests/slang_validate/build";
+    if (argc > 1) libDir = argv[1];
+
+    cloth::CSRSpMatF A;
+    A.rows    = 3;
+    A.rowPtr  = {0, 2, 4, 5};
+    A.colIdx  = {0, 1, 0, 1, 2};
+    A.values  = {4.0f, 1.0f, 1.0f, 3.0f, 2.0f};
+
+    cloth::MetalCGSolver solver(A, libDir.c_str());
+    if (!solver.ok()) {
+        std::fprintf(stderr, "test_metal_cg_solver: solver init failed.  "
+                              "Make sure metallibs exist in:\n  %s\n"
+                              "Run `make -C tests/slang_validate test` first.\n",
+                     libDir.c_str());
+        return 2;
+    }
+
+    std::vector<double> b = {5.0, 7.0, 6.0};
+    std::vector<double> x;
+
+    const auto t0 = std::chrono::steady_clock::now();
+    int iters = solver.solve(b, x, /*tol=*/1e-6, /*max_iter=*/50);
+    const double ms =
+        std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - t0).count();
+
+    if (iters < 0) {
+        std::fprintf(stderr, "test_metal_cg_solver: solve failed\n");
+        return 1;
+    }
+
+    const double expected[] = {8.0 / 11.0, 23.0 / 11.0, 3.0};
+    double max_diff = 0.0;
+    for (size_t i = 0; i < x.size(); ++i) {
+        const double d = std::fabs(x[i] - expected[i]);
+        if (d > max_diff) max_diff = d;
+    }
+
+    std::printf("test_metal_cg_solver: iters=%d  x=[%.6f, %.6f, %.6f]\n"
+                "                       expected=[%.6f, %.6f, %.6f]\n"
+                "                       max_abs_diff=%g  wall=%.2f ms\n",
+                iters, x[0], x[1], x[2],
+                expected[0], expected[1], expected[2],
+                max_diff, ms);
+
+    if (max_diff > 1e-4) {
+        std::fprintf(stderr, "test_metal_cg_solver: FAIL (diff %g > 1e-4)\n",
+                     max_diff);
+        return 1;
+    }
+    std::printf("test_metal_cg_solver: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

First step toward ripping out `Eigen::SimplicialLLT::solve()` in `Simulation.cpp`. Builds a pure-C++ interface that DiffCloth's Eigen-using code can call into without dragging Foundation/Metal headers into every Eigen-templated TU.

The actual swap-in (replacing `sysMat[id].solver.solve(b_tilde + r)` with `slangSolver->solve(...)`) is the next PR — this one just stands up the infrastructure and proves it works in isolation.

## Files

```
src/code/slang_solver/
  MetalCGSolver.h           pure-C++ interface (PIMPL)
  MetalCGSolver.mm          Obj-C++ Metal implementation
  test_metal_cg_solver.cpp  standalone correctness test
  Makefile                  builds + runs the test
```

## API

```cpp
namespace cloth {
struct CSRSpMatF {
    std::vector<int32_t> rowPtr;
    std::vector<int32_t> colIdx;
    std::vector<float>   values;
    uint32_t rows;
};

class MetalCGSolver {
public:
    MetalCGSolver(const CSRSpMatF& A, const char* metallibPath);
    int solve(const std::vector<double>& b, std::vector<double>& x,
              double tol = 1e-6, int max_iter = 200);
    bool ok() const;
};
}  // namespace cloth
```

`solve` accepts and returns `double` for API compatibility with DiffCloth's `VecXd` — but the CG runs in fp32 internally. The inner-product accumulator is df32 (via the parallel `dot_reduce` wired in #25), so the dot products don't lose precision.

## Correctness

Smoke test on a 3×3 SPD system (same as `cg_demo` from #15):

```
$ make -C src/code/slang_solver test
test_metal_cg_solver: iters=3  x=[0.727273, 2.090909, 3.000000]
                       expected=[0.727273, 2.090909, 3.000000]
                       max_abs_diff=2.38419e-07  wall=9.54 ms
test_metal_cg_solver: OK
```

Converged in 3 iters to the analytic answer at fp32 limits.

## Precision tradeoff (vs Eigen LLT)

DiffCloth uses fp64 throughout. Our kernels are fp32.

| | Eigen LLT (DiffCloth) | MetalCGSolver |
|---|---|---|
| Precision | fp64 | fp32 (with df32 inner products) |
| Solve algo | Direct, precomputed Cholesky | Iterative CG |
| Per-solve cost | O(nnz·avg fill) back-sub | O(K · spmv) |
| Failure mode | None (always exact for SPD) | Slow convergence if poorly conditioned |

Expected drift on real DiffCloth systems: ~1e-5..1e-7 relative. If this proves too loose, the EFT helpers from `dot_reduce` could extend to `spmv` and `saxpby` for a fully-df32 CG, but that's a bigger lift.

## Why the standalone Makefile

This PR deliberately doesn't touch `CMakeLists.txt`. The `src/code/slang_solver/Makefile` builds the wrapper + smoke test in isolation, so we can verify the C++↔Obj-C++↔Metal wiring works *before* tangling it into DiffCloth's main build. Once the next PR wires the wrapper into `Simulation::step()`, the CMake additions will be small and obvious.

## Test plan

- [x] `make -C tests/slang_validate test` — ensures `spmv.metallib`, `saxpby.metallib`, `dot_reduce.metallib` exist in the metallib search path.
- [x] `make -C src/code/slang_solver test` — wrapper builds, smoke test passes (3/3 verts within 2.4e-7 of analytic).
- [ ] CI: needs to either (a) run the wrapper test on macos-14, or (b) leave it untested for now since DiffCloth's CMake build doesn't include it. Going with (b) — wrapper has zero cost on `make test` of the slang_validate suite, so existing CI is unaffected.

## Roadmap

| | Step | Status |
|---|---|---|
| Tier-3b parallel dot_reduce on Metal | merged #25 |
| **MetalCGSolver wrapper (this PR)** | **this PR** |
| Wire into Simulation::step() behind -use-slang-cg flag | next |
| Compare per-step wall vs Eigen LLT on the same demo | follow-up |
| If fp32 too loose: extend df32 to spmv + saxpby | conditional |