### PR TITLE
Add cg_alpha: single-thread GPU-side ±α for the CG inner loop

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -7,6 +7,7 @@ import Cloth.SlangCodegen.Spmv
 import Cloth.SlangCodegen.DotReduce
 import Cloth.SlangCodegen.DotReduceSerial
 import Cloth.SlangCodegen.AssembleB
+import Cloth.SlangCodegen.CGAlpha
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/CGAlpha.lean
+++ b/lean/Cloth/SlangCodegen/CGAlpha.lean
@@ -1,0 +1,87 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.CGAlpha` — GPU-side α / −α for the CG inner loop
+
+Single-thread kernel that consumes two df32 dot products and emits
+both `+α` and `−α` to a 2-element output buffer:
+
+```
+α   = dot(r, r) / dot(p, q)     (reconstructed from df32 (hi, lo) pairs)
+out[0] = +α
+out[1] = −α
+```
+
+Why: without this kernel, the CG inner loop must round-trip dot
+results to the CPU between every dispatch (commit + waitUntilCompleted)
+in order to compute α and use it in the next saxpby. With the kernel,
+`dot → cg_alpha → saxpby_x → saxpby_r` is a single command buffer
+with no CPU intervention — the saxpby reads `±α` from the output
+buffer of this kernel.
+
+The CG inner loop needs both `+α` (for `x += α·p`) and `−α` (for
+`r −= α·q`), so we emit both. A saxpby kernel that takes scalar α/β
+from an indexed buffer will live in a follow-up PR; this one is just
+the scalar arithmetic.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float>   dotPQ      length ≥ 2 (df32 hi, lo)
+  1  StructuredBuffer<float>   dotDelta   length ≥ 2 (df32 hi, lo)
+  2  RWStructuredBuffer<float> alphaOut   length ≥ 2 ([0]=+α, [1]=−α)
+
+`[numthreads(1, 1, 1)]` — exactly one thread; the work is trivially
+serial and the kernel exists to break the CPU-sync dependency chain,
+not to be parallel.
+-/
+
+namespace Cloth.SlangCodegen.CGAlpha
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ ⟨"dotPQ",    .roBuf floatTy, Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"dotDelta", .roBuf floatTy, Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"alphaOut", .rwBuf floatTy, Semantic.none, some 2, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 1 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit floatTy "pq"
+            (.bin "+" (.index (.var "dotPQ")    (.litUint 0))
+                      (.index (.var "dotPQ")    (.litUint 1)))
+        , .declInit floatTy "dn"
+            (.bin "+" (.index (.var "dotDelta") (.litUint 0))
+                      (.index (.var "dotDelta") (.litUint 1)))
+        , .declInit floatTy "a" (.bin "/" (.var "dn") (.var "pq"))
+        , .assign (.index (.var "alphaOut") (.litUint 0)) (.var "a")
+        , .assign (.index (.var "alphaOut") (.litUint 1))
+            (.bin "-" (.litFloat 0.0) (.var "a"))
+        ] }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float> dotPQ;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> dotDelta;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<float> alphaOut;
+
+[shader(\"compute\")] [numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  float pq = (dotPQ[0u] + dotPQ[1u]);
+  float dn = (dotDelta[0u] + dotDelta[1u]);
+  float a = (dn / pq);
+  alphaOut[0u] = a;
+  alphaOut[1u] = (0.000000 - a);
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.CGAlpha

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -27,6 +27,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("dot_reduce",         DotReduce.shader)
   , ("dot_reduce_serial",  DotReduceSerial.shader)
   , ("assemble_b",         AssembleB.shader)
+  , ("cg_alpha",           CGAlpha.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++
@@ -41,7 +41,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               saxpby:saxpby \
               spmv:spmv \
               dot_reduce_serial:dot_reduce_serial \
-              assemble_b:assemble_b
+              assemble_b:assemble_b \
+              cg_alpha:cg_alpha
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/cg_alpha_test.cpp
+++ b/tests/slang_validate/cg_alpha_test.cpp
@@ -1,0 +1,73 @@
+// Real-input validator for Cloth.SlangCodegen.CGAlpha — the
+// single-thread GPU-side α / −α kernel for the CG inner loop.
+//
+//   α      = dot(r, r) / dot(p, q)
+//   out[0] = +α
+//   out[1] = −α
+//
+// dot inputs are df32 (hi, lo) pairs from dot_reduce_serial.
+//
+// Test fixture matches cg_demo's iter-1 values from #15:
+//   dot(p, q) = 389         → dotPQ    = [389, 0]
+//   dot(r, r) = 110         → dotDelta = [110, 0]
+//   expected α = 110/389 ≈ 0.282776
+//   expected out = [+α, −α] = [+0.282776, −0.282776]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "cg_alpha_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    float dotPQ[2]    = {389.0f, 0.0f};
+    float dotDelta[2] = {110.0f, 0.0f};
+    float alphaOut[2] = {0.0f, 0.0f};
+
+    GlobalParams_0 gp{};
+    gp.dotPQ_0.data    = dotPQ;     gp.dotPQ_0.count    = 2;
+    gp.dotDelta_0.data = dotDelta;  gp.dotDelta_0.count = 2;
+    gp.alphaOut_0.data = alphaOut;  gp.alphaOut_0.count = 2;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_a = 110.0f / 389.0f;
+    const float ref[2] = {+expected_a, -expected_a};
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (int i = 0; i < 2; ++i) {
+        const float d = std::fabs(alphaOut[i] - ref[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            std::fprintf(stderr,
+                "cg_alpha mismatch at i=%d: got %g, expected %g (diff %g)\n",
+                i, alphaOut[i], ref[i], d);
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "cg_alpha: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("cg_alpha: 2/2 OK (α=%.6f, out=[%.6f, %.6f], max_abs_diff=%g, %.1fms)\n",
+                    expected_a, alphaOut[0], alphaOut[1], max_abs_diff,
+                    elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "cg_alpha: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary

First of two scalar-arithmetic kernels needed to eliminate the CPU sync between dispatches in `MetalCGSolver::solve()`'s CG inner loop (the bottleneck called out in #27).

Reads two df32 dot products (`delta_new` from `dot(r, r)`, `pq` from `dot(p, q)`) and emits both `+α` and `−α` to a 2-element output buffer:

```
α      = (delta_new[0] + delta_new[1]) / (pq[0] + pq[1])
out[0] = +α     (consumed by saxpby:  x_new = 1·x + α·p)
out[1] = −α     (consumed by saxpby:  r_new = 1·r + (−α)·q)
```

`[numthreads(1, 1, 1)]` — single thread. Exists to break the CPU-sync dependency chain in the CG loop, not to parallelise (the arithmetic is two adds + one divide).

## Why the saxpbys need different scalars

```
x = x + α·p        →  saxpby with α'=1, β'=+α
r = r − α·q        →  saxpby with α'=1, β'=−α
```

A single `cg_alpha` dispatch serves both — `out[0]` and `out[1]` are the two β's.

## Verification

```
$ make -C tests/slang_validate test
…
cg_alpha: 2/2 OK (α=0.282776, out=[0.282776, -0.282776],
                  max_abs_diff=0, 0.0ms)
```

Test fixture matches `cg_demo` iter-1: `dot(p,q)=389`, `dot(r,r)=110`, expected `α = 110/389 ≈ 0.282776`. Bit-exact at fp32.

## Roadmap to closing the CG loop overhead

| | Kernel / step | Status |
|---|---|---|
| **cg_alpha** — ±α from df32 dot results | **this PR** |
| cg_beta — β = delta_new / delta_old + copy for next iter | next |
| saxpby_indirect — saxpby that reads α/β from scalar buffer | next |
| MetalCGSolver refactor — encode K CG iters per command buffer | follow-up |

Once that chain lands, the per-CG-iter cost in `MetalCGSolver::solve()` drops from 6 commit/wait round-trips (~600 µs each at 100-200 µs of latency each on M-series) to 1 commit/wait per K iters. Projected ~30× speedup, which makes #27's `USE_SLANG_CG=1` mode competitive with Eigen LLT.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned emission.
- [x] `make -C tests/slang_validate test` — bit-exact at fp32, all 10 kernels + 5 composition tests + perf_baseline + metal_perf still green.
- [ ] CI re-runs all three layers on `macos-14`.

Eigen status unchanged from #27: this PR doesn't delete anything. It builds the kernel-side machinery for the next round of MetalCGSolver work.