### PR TITLE
Add cg_beta: single-thread GPU-side β + in-place dotOld update

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -8,6 +8,7 @@ import Cloth.SlangCodegen.DotReduce
 import Cloth.SlangCodegen.DotReduceSerial
 import Cloth.SlangCodegen.AssembleB
 import Cloth.SlangCodegen.CGAlpha
+import Cloth.SlangCodegen.CGBeta
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/CGBeta.lean
+++ b/lean/Cloth/SlangCodegen/CGBeta.lean
@@ -1,0 +1,82 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.CGBeta` — GPU-side β for the CG inner loop
+
+Sibling to `cg_alpha`. Single-thread kernel that consumes two df32 dot
+products (the previous and current `dot(r, r)`) and emits β plus
+overwrites `δ_old` so the next iter doesn't need a CPU-side copy:
+
+```
+β        = (dotNew[0] + dotNew[1]) / (dotOld[0] + dotOld[1])
+betaOut  = +β
+dotOld  := dotNew       (in-place; next iter's "old" is this iter's "new")
+```
+
+After this dispatch the orchestrator can rebind `dotOld` directly as
+the new `dot(r, r)` target for the next iter — no CPU ping-pong of
+buffers required.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float>   dotNew   length ≥ 2 (df32 hi, lo; current iter)
+  1  RWStructuredBuffer<float> dotOld   length ≥ 2 (read THEN written in place)
+  2  RWStructuredBuffer<float> betaOut  length ≥ 1 ([0] = β)
+
+`[numthreads(1, 1, 1)]` — one thread. The read-before-write on
+`dotOld` is sequentially safe inside a single thread.
+-/
+
+namespace Cloth.SlangCodegen.CGBeta
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ ⟨"dotNew",  .roBuf floatTy, Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"dotOld",  .rwBuf floatTy, Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"betaOut", .rwBuf floatTy, Semantic.none, some 2, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 1 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit floatTy "dnew"
+            (.bin "+" (.index (.var "dotNew") (.litUint 0))
+                      (.index (.var "dotNew") (.litUint 1)))
+        , .declInit floatTy "dold"
+            (.bin "+" (.index (.var "dotOld") (.litUint 0))
+                      (.index (.var "dotOld") (.litUint 1)))
+        , .declInit floatTy "b" (.bin "/" (.var "dnew") (.var "dold"))
+        , .assign (.index (.var "betaOut") (.litUint 0)) (.var "b")
+        , .assign (.index (.var "dotOld") (.litUint 0))
+            (.index (.var "dotNew") (.litUint 0))
+        , .assign (.index (.var "dotOld") (.litUint 1))
+            (.index (.var "dotNew") (.litUint 1))
+        ] }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float> dotNew;
+[[vk::binding(1, 0)]]
+RWStructuredBuffer<float> dotOld;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<float> betaOut;
+
+[shader(\"compute\")] [numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  float dnew = (dotNew[0u] + dotNew[1u]);
+  float dold = (dotOld[0u] + dotOld[1u]);
+  float b = (dnew / dold);
+  betaOut[0u] = b;
+  dotOld[0u] = dotNew[0u];
+  dotOld[1u] = dotNew[1u];
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.CGBeta

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -28,6 +28,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("dot_reduce_serial",  DotReduceSerial.shader)
   , ("assemble_b",         AssembleB.shader)
   , ("cg_alpha",           CGAlpha.shader)
+  , ("cg_beta",            CGBeta.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++
@@ -42,7 +42,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               spmv:spmv \
               dot_reduce_serial:dot_reduce_serial \
               assemble_b:assemble_b \
-              cg_alpha:cg_alpha
+              cg_alpha:cg_alpha \
+              cg_beta:cg_beta
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/cg_beta_test.cpp
+++ b/tests/slang_validate/cg_beta_test.cpp
@@ -1,0 +1,74 @@
+// Real-input validator for Cloth.SlangCodegen.CGBeta — the
+// single-thread GPU-side β kernel + in-place dotOld update for the
+// CG inner loop.
+//
+//   β        = dot_new / dot_old   (each reconstructed from df32 hi+lo)
+//   betaOut  = +β
+//   dotOld  := dotNew              (in-place; sets up next iter)
+//
+// Test fixture: dotNew = (50, 0), dotOld = (110, 0).
+//   expected β = 50/110 ≈ 0.4545454...
+//   after the dispatch, dotOld should equal dotNew = (50, 0).
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "cg_beta_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    float dotNew[2] = { 50.0f, 0.0f};
+    float dotOld[2] = {110.0f, 0.0f};
+    float betaOut[1] = {0.0f};
+
+    GlobalParams_0 gp{};
+    gp.dotNew_0.data  = dotNew;   gp.dotNew_0.count  = 2;
+    gp.dotOld_0.data  = dotOld;   gp.dotOld_0.count  = 2;
+    gp.betaOut_0.data = betaOut;  gp.betaOut_0.count = 1;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_b = 50.0f / 110.0f;
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+
+    auto check = [&](const char* what, float got, float ref) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            std::fprintf(stderr,
+                "cg_beta mismatch (%s): got %g, expected %g (diff %g)\n",
+                what, got, ref, d);
+            ++fails;
+        }
+    };
+
+    check("betaOut[0]", betaOut[0], expected_b);
+    check("dotOld[0]",  dotOld[0],  50.0f);
+    check("dotOld[1]",  dotOld[1],   0.0f);
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "cg_beta: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("cg_beta: 3/3 OK (β=%.6f, dotOld now=[%.1f, %.1f], "
+                    "max_abs_diff=%g, %.1fms)\n",
+                    betaOut[0], dotOld[0], dotOld[1], max_abs_diff,
+                    elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "cg_beta: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Sibling to `cg_alpha` (#28). Single-thread kernel that consumes two df32 dot products and emits β plus overwrites `dot_old` so the next CG iter doesn't need a CPU-side copy:

```
β       = (dotNew[0]+dotNew[1]) / (dotOld[0]+dotOld[1])
betaOut = β
dotOld := dotNew      ← in-place; orchestrator does not need to ping-pong buffers
```

After this dispatch the next CG iter can write its `dot(r, r)` into a fresh "new" buffer while `dotOld` already holds the previous iter's value. No CPU intervention.

## Verification

```
$ make -C tests/slang_validate test
…
cg_alpha: 2/2 OK (α=0.282776, out=[0.282776, -0.282776], max_abs_diff=0, 0.0ms)
cg_beta:  3/3 OK (β=0.454545, dotOld now=[50.0, 0.0], max_abs_diff=0, 0.0ms)
all kernels OK
```

Test fixture: `dotNew=(50, 0)`, `dotOld=(110, 0)`. Expected β = 50/110 ≈ 0.454545, dotOld after dispatch = (50, 0). Bit-exact at fp32 on both axes.

## Roadmap progress

| | Step | Status |
|---|---|---|
| `cg_alpha` — ±α from df32 dot results | merged #28 |
| **`cg_beta` — β + in-place dotOld update** | **this PR** |
| `saxpby_indirect` — saxpby that reads scalar α/β from a buffer | next |
| `MetalCGSolver` refactor — encode K CG iters per command buffer | follow-up |

Once `saxpby_indirect` lands, `MetalCGSolver::solve()` can fuse the entire CG iter into one command buffer:

```
spmv → dot(p,q) → cg_alpha → saxpby_x → saxpby_r → dot(r,r) → cg_beta → saxpby_p
```

…all encoded together. Commit + wait once per iter (or per K-iter batch). Projected ~30× over today's per-dispatch-bound implementation that #27 showed couldn't complete a step in 60 s.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned emission.
- [x] `make -C tests/slang_validate test` — bit-exact at fp32 for both β computation and in-place dotOld copy.
- [ ] CI re-runs all three layers on `macos-14`.