### PR TITLE
Add saxpby_indirect: saxpby with α/β read from buffers

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -9,6 +9,7 @@ import Cloth.SlangCodegen.DotReduceSerial
 import Cloth.SlangCodegen.AssembleB
 import Cloth.SlangCodegen.CGAlpha
 import Cloth.SlangCodegen.CGBeta
+import Cloth.SlangCodegen.SaxpbyIndirect
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/SaxpbyIndirect.lean
+++ b/lean/Cloth/SlangCodegen/SaxpbyIndirect.lean
@@ -1,0 +1,105 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.SaxpbyIndirect` — saxpby with α/β from buffer
+
+Variant of `Cloth.SlangCodegen.Saxpby` that reads `α` and `β` from
+1-element scalar buffers instead of a `ConstantBuffer<SaxpbyParams>`.
+Computes the same thing:
+
+```
+dst[i] = α · x[i] + β · y[i]    for i ∈ [0, n)
+```
+
+Why this exists: in the CG inner loop, α and β come from
+`cg_alpha` / `cg_beta` (GPU-side computation). With the original
+`Saxpby` kernel they'd have to be written into a constant struct
+*on the CPU* between dispatches — which means commit + wait per
+saxpby. With this variant, the CG iter chain stays on-GPU:
+
+```
+dot(p,q) → cg_alpha → saxpby_indirect (β buffer = cg_alpha out[0])
+                                       (β buffer = cg_alpha out[1])
+dot(r,r) → cg_beta  → saxpby_indirect (β buffer = cg_beta out)
+```
+
+α is hardcoded to come from its own buffer too, even though the CG
+pattern always uses α'=1 — a separate 1-float "ones" buffer (set
+once at bind time) keeps the kernel generic.
+
+Bindings (set 0):
+
+  0  ConstantBuffer<SaxpbyIndirectParams> { uint n; }
+  1  StructuredBuffer<float>   alpha   length ≥ 1 (reads [0])
+  2  StructuredBuffer<float>   beta    length ≥ 1 (reads [0])
+  3  StructuredBuffer<float>   x       length = n
+  4  StructuredBuffer<float>   y       length = n
+  5  RWStructuredBuffer<float> dst     length = n
+
+Same `[numthreads(256, 1, 1)]` as `Saxpby`. Per-element work is one
+`fma`; the buffer index for α/β reads is constant so the GPU should
+broadcast it via the L1 cache. No precision change from `Saxpby`.
+-/
+
+namespace Cloth.SlangCodegen.SaxpbyIndirect
+
+open LeanSlang
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "SaxpbyIndirectParams"
+        , fields := [⟨"n", .scalar .uint, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params", .const "SaxpbyIndirectParams", Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"alpha",  .roBuf (.scalar .float),       Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"beta",   .roBuf (.scalar .float),       Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"x",      .roBuf (.scalar .float),       Semantic.none, some 3, some 0, .qIn⟩
+      , ⟨"y",      .roBuf (.scalar .float),       Semantic.none, some 4, some 0, .qIn⟩
+      , ⟨"dst",    .rwBuf (.scalar .float),       Semantic.none, some 5, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 256 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit (.scalar .uint) "i" (.member (.var "tid") "x")
+        , .ifNoElse (.bin ">=" (.var "i") (.member (.var "params") "n"))
+            [ .ret none ]
+        , .assign (.index (.var "dst") (.var "i"))
+            (.call "fma"
+              [ .index (.var "alpha") (.litUint 0)
+              , .index (.var "x") (.var "i")
+              , .bin "*" (.index (.var "beta") (.litUint 0))
+                         (.index (.var "y") (.var "i")) ])
+        ] }] }
+
+def expected : String :=
+"struct SaxpbyIndirectParams {
+  uint n;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<SaxpbyIndirectParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> alpha;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> beta;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> x;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> y;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> dst;
+
+[shader(\"compute\")] [numthreads(256, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  if ((i >= params.n)) {
+    return;
+  }
+  dst[i] = fma(alpha[0u], x[i], (beta[0u] * y[i]));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.SaxpbyIndirect

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -29,6 +29,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("assemble_b",         AssembleB.shader)
   , ("cg_alpha",           CGAlpha.shader)
   , ("cg_beta",            CGBeta.shader)
+  , ("saxpby_indirect",    SaxpbyIndirect.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++
@@ -43,7 +43,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               dot_reduce_serial:dot_reduce_serial \
               assemble_b:assemble_b \
               cg_alpha:cg_alpha \
-              cg_beta:cg_beta
+              cg_beta:cg_beta \
+              saxpby_indirect:saxpby_indirect
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/saxpby_indirect_test.cpp
+++ b/tests/slang_validate/saxpby_indirect_test.cpp
@@ -1,0 +1,77 @@
+// Real-input validator for Cloth.SlangCodegen.SaxpbyIndirect.
+//   dst[i] = alpha[0] * x[i] + beta[0] * y[i]
+//
+// Same arithmetic as the original Saxpby (#12); only the source of
+// alpha and beta differs. Test fixture deliberately matches the original
+// saxpby_test fixture (alpha=3, beta=4) so the result must be bit-identical.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "saxpby_indirect_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N = 5;
+    SaxpbyIndirectParams_0 params{N};
+
+    float alpha[1] = {3.0f};
+    float beta[1]  = {4.0f};
+    float x[N]   = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    float y[N]   = {0.5f, 1.0f, 1.5f, 2.0f, 2.5f};
+    float dst[N] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const float expected[N] = {
+        3.0f * 1.0f + 4.0f * 0.5f,    // 5
+        3.0f * 2.0f + 4.0f * 1.0f,    // 10
+        3.0f * 3.0f + 4.0f * 1.5f,    // 15
+        3.0f * 4.0f + 4.0f * 2.0f,    // 20
+        3.0f * 5.0f + 4.0f * 2.5f,    // 25
+    };
+
+    GlobalParams_0 gp{};
+    gp.params_0    = &params;
+    gp.alpha_0.data = alpha;  gp.alpha_0.count = 1;
+    gp.beta_0.data  = beta;   gp.beta_0.count  = 1;
+    gp.x_0.data    = x;       gp.x_0.count     = N;
+    gp.y_0.data    = y;       gp.y_0.count     = N;
+    gp.dst_0.data  = dst;     gp.dst_0.count   = N;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t i = 0; i < N; ++i) {
+        const float d = std::fabs(dst[i] - expected[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            std::fprintf(stderr,
+                "saxpby_indirect mismatch at i=%u: got %g, expected %g (diff %g)\n",
+                i, dst[i], expected[i], d);
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "saxpby_indirect: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("saxpby_indirect: %u/%u OK (alpha=%g, beta=%g, "
+                    "max_abs_diff=%g, %.1fms)\n",
+                    N, N, alpha[0], beta[0], max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "saxpby_indirect: %d FAIL out of %u\n", fails, N);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Variant of the original `Saxpby` kernel that reads α and β from 1-element scalar buffers instead of a `ConstantBuffer<SaxpbyParams>`. Same arithmetic:

```
dst[i] = alpha[0] * x[i] + beta[0] * y[i]    for i ∈ [0, n)
```

## Why this exists

In the CG inner loop, α and β come from `cg_alpha` / `cg_beta` (GPU-side computation). With the original `Saxpby` kernel, α/β had to be written into a constant struct **on the CPU** between dispatches — paying commit + wait per saxpby. With this variant, the entire CG iter chain stays on-GPU:

```
dot(p,q) → cg_alpha → saxpby_indirect (beta = cg_alpha out[0])
                                       (beta = cg_alpha out[1])
dot(r,r) → cg_beta  → saxpby_indirect (beta = cg_beta out)
```

α is hardcoded to come from its own 1-float buffer too, even though the CG pattern always uses α'=1 — a separate "ones" buffer set once at bind time keeps the kernel generic.

## Verification

Test fixture matches `saxpby_test` (#12) exactly so the two kernels must produce bit-identical output:

```
$ make -C tests/slang_validate test
…
saxpby:          5/5 OK (alpha=3, beta=4, max_abs_diff=0, 0.0ms)
saxpby_indirect: 5/5 OK (alpha=3, beta=4, max_abs_diff=0, 0.0ms)
all kernels OK
```

## Kernel-side roadmap complete

| | Step | Status |
|---|---|---|
| `cg_alpha` — ±α from df32 dot results | merged #28 |
| `cg_beta` — β + in-place dotOld update | merged #29 |
| **`saxpby_indirect` — saxpby reading α/β from buffer** | **this PR** |
| `MetalCGSolver` refactor — encode K CG iters per command buffer | next |

After the orchestrator refactor lands, `MetalCGSolver` should drop from ~600 µs per CG iter (today's 6 commit-waits at ~100-200 µs each — what made `USE_SLANG_CG=1` mode unusable in #27) to ~600 µs per K iters. **Projected ~30× for K ≈ 30.** At that point the demo should actually complete a step and we can finally compare per-step wall against Eigen LLT on a real DiffCloth scene.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned emission.
- [x] `make -C tests/slang_validate test` — `saxpby_indirect` produces bit-identical output to `saxpby` on the same fixture; 5/5 dims OK, max_abs_diff=0.
- [ ] CI re-runs all three layers on `macos-14`.

Eigen status unchanged. Still alongside the LLT path behind `USE_SLANG_CG`. Once the MetalCGSolver refactor lands and we can complete a step under that flag, the next data point is a real perf comparison.