### PR TITLE
cg_beta: clamp β = 0 on δ_old underflow (over-convergence robustness)

### DIFF
--- a/lean/Cloth/SlangCodegen/CGBeta.lean
+++ b/lean/Cloth/SlangCodegen/CGBeta.lean
@@ -50,7 +50,13 @@ def shader : SlangShaderModule :=
         , .declInit floatTy "dold"
             (.bin "+" (.index (.var "dotOld") (.litUint 0))
                       (.index (.var "dotOld") (.litUint 1)))
-        , .declInit floatTy "b" (.bin "/" (.var "dnew") (.var "dold"))
+        -- Underflow clamp: when dold is below ε, β = 0 so the next
+        -- saxpby `p = r + β·p` reduces to `p = r` (a soft restart).
+        -- Avoids 0/0 = NaN when CG over-converges past max_iter.
+        , .declInit floatTy "b"
+            (.ternary (.bin ">" (.var "dold") (.litFloat 1e-20))
+              (.bin "/" (.var "dnew") (.var "dold"))
+              (.litFloat 0.0))
         , .assign (.index (.var "betaOut") (.litUint 0)) (.var "b")
         , .assign (.index (.var "dotOld") (.litUint 0))
             (.index (.var "dotNew") (.litUint 0))
@@ -70,7 +76,7 @@ RWStructuredBuffer<float> betaOut;
 void main(uint3 tid : SV_DispatchThreadID) {
   float dnew = (dotNew[0u] + dotNew[1u]);
   float dold = (dotOld[0u] + dotOld[1u]);
-  float b = (dnew / dold);
+  float b = ((dold > 0.000000) ? (dnew / dold) : 0.000000);
   betaOut[0u] = b;
   dotOld[0u] = dotNew[0u];
   dotOld[1u] = dotNew[1u];

--- a/tests/slang_validate/cg_beta_test.cpp
+++ b/tests/slang_validate/cg_beta_test.cpp
@@ -22,21 +22,6 @@ static constexpr double kBudgetSeconds = 5.0;
 int main() {
     const auto t0 = std::chrono::steady_clock::now();
 
-    float dotNew[2] = { 50.0f, 0.0f};
-    float dotOld[2] = {110.0f, 0.0f};
-    float betaOut[1] = {0.0f};
-
-    GlobalParams_0 gp{};
-    gp.dotNew_0.data  = dotNew;   gp.dotNew_0.count  = 2;
-    gp.dotOld_0.data  = dotOld;   gp.dotOld_0.count  = 2;
-    gp.betaOut_0.data = betaOut;  gp.betaOut_0.count = 1;
-
-    ComputeVaryingInput vi{};
-    vi.startGroupID = uint3(0, 0, 0);
-    vi.endGroupID   = uint3(1, 1, 1);
-    main_0(&vi, nullptr, &gp);
-
-    const float expected_b = 50.0f / 110.0f;
     int   fails        = 0;
     float max_abs_diff = 0.0f;
 
@@ -51,9 +36,55 @@ int main() {
         }
     };
 
-    check("betaOut[0]", betaOut[0], expected_b);
-    check("dotOld[0]",  dotOld[0],  50.0f);
-    check("dotOld[1]",  dotOld[1],   0.0f);
+    // -------- Normal case: nonzero dold ----------------------------------
+    {
+        float dotNew[2] = { 50.0f, 0.0f};
+        float dotOld[2] = {110.0f, 0.0f};
+        float betaOut[1] = {0.0f};
+
+        GlobalParams_0 gp{};
+        gp.dotNew_0.data  = dotNew;   gp.dotNew_0.count  = 2;
+        gp.dotOld_0.data  = dotOld;   gp.dotOld_0.count  = 2;
+        gp.betaOut_0.data = betaOut;  gp.betaOut_0.count = 1;
+
+        ComputeVaryingInput vi{};
+        vi.startGroupID = uint3(0, 0, 0);
+        vi.endGroupID   = uint3(1, 1, 1);
+        main_0(&vi, nullptr, &gp);
+
+        const float expected_b = 50.0f / 110.0f;
+        check("normal.betaOut[0]", betaOut[0], expected_b);
+        check("normal.dotOld[0]",  dotOld[0],  50.0f);
+        check("normal.dotOld[1]",  dotOld[1],   0.0f);
+    }
+
+    // -------- Underflow case: dold == 0 (CG over-convergence) ------------
+    // Without the ternary clamp this would give NaN from 0/0. With it,
+    // β should be 0 — making the downstream saxpby `p = r + 0·p = r`,
+    // which is a soft CG restart.
+    {
+        float dotNew[2] = {1e-12f, 0.0f};
+        float dotOld[2] = {0.0f,   0.0f};
+        float betaOut[1] = {0.0f};
+
+        GlobalParams_0 gp{};
+        gp.dotNew_0.data  = dotNew;   gp.dotNew_0.count  = 2;
+        gp.dotOld_0.data  = dotOld;   gp.dotOld_0.count  = 2;
+        gp.betaOut_0.data = betaOut;  gp.betaOut_0.count = 1;
+
+        ComputeVaryingInput vi{};
+        vi.startGroupID = uint3(0, 0, 0);
+        vi.endGroupID   = uint3(1, 1, 1);
+        main_0(&vi, nullptr, &gp);
+
+        if (std::isnan(betaOut[0])) {
+            std::fprintf(stderr, "cg_beta underflow: betaOut[0] is NaN (clamp not effective)\n");
+            ++fails;
+        }
+        check("underflow.betaOut[0]", betaOut[0], 0.0f);
+        check("underflow.dotOld[0]",  dotOld[0],  1e-12f);
+        check("underflow.dotOld[1]",  dotOld[1],  0.0f);
+    }
 
     const auto t1 = std::chrono::steady_clock::now();
     const double elapsed = std::chrono::duration<double>(t1 - t0).count();
@@ -63,10 +94,9 @@ int main() {
         return 2;
     }
     if (fails == 0) {
-        std::printf("cg_beta: 3/3 OK (β=%.6f, dotOld now=[%.1f, %.1f], "
+        std::printf("cg_beta: 6/6 OK (normal + underflow clamp, "
                     "max_abs_diff=%g, %.1fms)\n",
-                    betaOut[0], dotOld[0], dotOld[1], max_abs_diff,
-                    elapsed * 1000.0);
+                    max_abs_diff, elapsed * 1000.0);
         return 0;
     }
     std::fprintf(stderr, "cg_beta: %d FAIL\n", fails);


### PR DESCRIPTION
## Summary

PR #31 documented that `MetalCGSolver` could NaN-out when CG over-converges past `max_iter`:

```
δ_old underflows to exact zero
β = δ_new / δ_old = 0/0 = NaN
next saxpby fills p with NaN
everything cascades
```

Fix: wrap the divide in a ternary clamp:

```slang
b = (dold > 0.000000) ? (dnew / dold) : 0.0;
```

When `δ_old == 0`, `β = 0` makes the downstream saxpby

```
p = r + β·p  →  p = r
```

a soft CG restart. Solver keeps progressing instead of producing NaN.

## Threshold note

LeanSlang's `Float.toString` uses 6-decimal fixed format for normal numbers, so `.litFloat 1e-20` rounds to the string `"0.000000"`. The comparison `dold > 0.000000` ends up being **`dold > 0`** in fp32 — which is exactly the pathological case we want to catch. For typical CG δ_old values (well above 0), the divide proceeds normally; only the exact-zero underflow gets clamped.

If we ever want to clamp at a larger threshold (e.g. to also catch near-Inf β from very-small-but-nonzero δ_old), LeanSlang's emitter would need a way to produce scientific-notation float literals. That's a LeanSlang change, not a Cloth change.

## Test coverage

`tests/slang_validate/cg_beta_test.cpp` now covers both branches:

| | dotOld | dotNew | expected β | post-state dotOld |
|---|---|---|---|---|
| Normal | (110, 0) | (50, 0) | 50/110 ≈ 0.4545 | (50, 0) |
| Underflow | (0, 0) | (1e-12, 0) | 0 (clamped) | (1e-12, 0) |

```
$ make -C tests/slang_validate test
…
cg_beta: 6/6 OK (normal + underflow clamp, max_abs_diff=0, 0.0ms)
all kernels OK
```

## Test plan

- [x] `cd lean && lake build` — native_decide pin updated, accepts new ternary emit.
- [x] `make -C tests/slang_validate test` — both branches green; no NaN observed on underflow path.
- [ ] CI re-runs all three layers on `macos-14`.

## Roadmap status

| | Step | Status |
|---|---|---|
| MetalCGSolver fused CG iter | merged #31 |
| **cg_beta underflow clamp** | **this PR** |
| Per-step wall vs Eigen LLT on the same DiffCloth demo | next |
| Real DiffCloth integration sanity check (correctness across many timesteps) | next |