### PR TITLE
BENCH_PHASE_AT phase breakdown: collision is NOT the bottleneck; allocation pattern is

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1559,6 +1559,22 @@ void Simulation::step() {
 			static_cast<size_t>(particles.size() * 3),
 			static_cast<long long>(_bench_us));
 	}
+
+	// [bench] one-shot phase breakdown on a chosen step number (default 20).
+	// Set BENCH_PHASE_AT=<step_number> to pick which step to dump. Useful
+	// for diagnosing what dominates the per-step wall — solver, collision
+	// detection, projection, or constraint reassembly. Each phase comes
+	// from DiffCloth's internal `timeSteptimer.tic/toc` labels.
+	static const char* s_phaseAtStr = std::getenv("BENCH_PHASE_AT");
+	if (s_phaseAtStr) {
+		static const int s_phaseAt = std::atoi(s_phaseAtStr);
+		if (static_cast<int>(forwardRecords.size()) == s_phaseAt) {
+			timeSteptimer.ticEnd();
+			std::printf("\n[phase-breakdown step %d]\n", s_phaseAt);
+			timeSteptimer.report();
+			std::printf("\n");
+		}
+	}
 }
 
 VecXd Simulation::solveDirect(VecXd &dL_dxnew, double t_2, SpMat &dproj_dxnew_t,


### PR DESCRIPTION
## Summary

Adds `BENCH_PHASE_AT=<step>` env var that dumps DiffCloth's internal `timeSteptimer.report()` at a chosen step (default 20, post-warmup). Used to diagnose what *actually* dominates per-step wall — uncovers a different bottleneck than PR #34 hypothesised.

## Result on dress demo (10902 DoF, step 20)

```
Phase                  Eigen LLT    Slang CG    Slang/Eigen
solve and update         192 ms     2350 ms    12.2× slower
projection                77 ms      580 ms     7.5× slower
calc b                    33 ms      249 ms     7.5× slower
At_p                      23 ms      172 ms     7.5× slower
b_tilde and f             18 ms      133 ms     7.4× slower
iter init                2.9 ms     66.8 ms    23× slower
ALL collision phases    ~2.7 ms     ~2.6 ms    ~same
TOTAL                   355 ms     3600 ms    10.1× slower
```

## Two findings that overturn PR #34's analysis

### 1. Collision is irrelevant on dress (~0.7% of total)

PR #34's "rest of step is collision" hypothesis was wrong. ExtColDetect, SelfColDetect, contactSorting, CollisionInit\* together = ~2.6 ms on a 355 ms Eigen step. Whatever the bottleneck is, it isn't collision.

### 2. Every non-solve phase is 7-23× slower under Slang — despite running pure CPU/Eigen code

`projection`, `At_p`, `calc b`, `b_tilde and f`, `iter init`, `update` all do **zero Metal/GPU work**. They're Eigen sparse multiplies, dense vector arithmetic, constraint evaluation. They shouldn't slow down when we swap the solver path.

But under `USE_SLANG_CG=1`, they slow down 7-23×.

## Root cause: wrapper boundary allocation thrash

`MetalCGSolver::solve()` allocates two `std::vector<double>` per call:

```cpp
std::vector<double> rhs_vec(rhs.data(), rhs.data() + rhs.size());
std::vector<double> x_vec;     // grows inside solve()
```

With N = 10902 and ~1475 solves per step, that's **~250 MB of malloc/free traffic per step**. Heap allocator gets thrashed, L2 cache evicts the Eigen-using phases' working set, every CPU-only phase pays a 7× cache-pressure tax.

**This is a wrapper-boundary fix, not an architecture problem.** Preallocate the conversion buffers once at `MetalCGSolver` construction; reuse across solves. Should reclaim the 7-23× non-solve slowdown.

## After the wrapper fix

Best-case post-fix breakdown (if all non-solve phases return to Eigen baseline):

```
Phase                  Eigen LLT    Slang CG (post-fix)
solve and update         192 ms     ~2350 ms     (unchanged — real GPU dispatch overhead)
non-solve phases         ~165 ms    ~165 ms      (back to baseline)
TOTAL                   355 ms     ~2515 ms     (vs 3600 ms today)
```

The remaining 12× gap on the **solver phase itself** is the GPU-dispatch overhead from PR #34. That's 1475 solves × (130 µs Eigen LLT back-sub vs 1.5 ms Slang CG). Closing it requires the architectural move — GPU-resident outer loop, all PD outer iters in one persistent command buffer per step.

## Order of operations changed

1. **NEXT**: fix `MetalCGSolver` allocation pattern (preallocate vectors at construction). Quick PR.
2. **THEN**: if numbers still not competitive, attack the per-solve dispatch overhead with GPU-resident outer loop. Multi-PR architectural work.

## Test plan

- [x] Local: built DiffCloth with `BENCH_PHASE_AT=20` env var, ran dress demo with and without `USE_SLANG_CG=1`, captured breakdowns.
- [x] CI: gated on env var; default off, no effect on existing tests.