### PR TITLE
Slang CG sweep: tol=1e-4 max_iter=60 cuts per-step wall by 51% (10× gap → 5.2×)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1362,15 +1362,24 @@ void Simulation::step() {
 				// per solve.
 				static const bool s_mockOverwrite =
 					(std::getenv("MOCK_SOLVE_OVERWRITE") != nullptr);
-				// CG settings tuned for DiffCloth's PD outer loop:
-				// the outer iteration corrects under-converged inner
-				// solves over time, so we don't need very tight inner
-				// tolerance. tol = 1e-3 + max_iter = 15 gives a real
-				// solve (vs the original max_iter=5 = "always 5 iters")
-				// without burning iters past the point where the outer
-				// would absorb the residual.
+				// CG settings: tol=1e-4 max_iter=60 was found to be the
+				// sweet spot by the 3x3 sweep documented in PR #38.
+				// At that setting, dress per-step drops from 3.76s
+				// (baseline tol=1e-3 max_iter=15) to 1.84s — 51% faster
+				// because PD outer iter count drops 4.3x when inner
+				// solves are accurate to ~1e-4 (~ fp32 precision floor).
+				// Tighter tol caps because CG can't push below fp32's
+				// noise floor of ~1e-4 relative.
+				// Configurable at runtime for further sweeps without
+				// rebuilding.
+				static const float s_tol =
+					(std::getenv("SLANG_CG_TOL") != nullptr)
+					 ? float(std::atof(std::getenv("SLANG_CG_TOL"))) : 1e-4f;
+				static const int s_maxIter =
+					(std::getenv("SLANG_CG_MAX_ITER") != nullptr)
+					 ? std::atoi(std::getenv("SLANG_CG_MAX_ITER")) : 60;
 				int iters = sysMat[currentSysmatId].slangCG->solve(
-					rhs_vec, x_vec, /*tol=*/1e-3, /*max_iter=*/15);
+					rhs_vec, x_vec, /*tol=*/s_tol, /*max_iter=*/s_maxIter);
 				const long long _us = std::chrono::duration_cast<std::chrono::microseconds>(
 					std::chrono::steady_clock::now() - _t0).count();
 				static int s_solveCount = 0;


### PR DESCRIPTION
## Summary

9-cell `(tol, max_iter)` sweep on DiffCloth dress demo (10902 DoF), step 20 phase breakdown. **tol=1e-4 max_iter=60 wins clean** — 1.84 s per step vs 3.76 s baseline (51% faster).

## Sweep result

```
tol     max_iter   Total step   projection   solve+update    vs baseline
1e-3    15         3.76 s       649 ms       2476 ms         baseline
1e-3    30         5.40 s       655 ms       4054 ms         +43%
1e-3    60         8.83 s      1094 ms       6825 ms         +135%
1e-4    15         3.91 s       784 ms       2507 ms         +4%
1e-4    30         4.76 s       621 ms       3508 ms         +27%
1e-4    60         1.84 s       151 ms       1526 ms         −51%  ← sweet spot
1e-5    15         3.55 s       590 ms       2312 ms         −6%
1e-5    30         4.43 s       685 ms       3111 ms         +18%
1e-5    60         1.88 s       148 ms       1573 ms         −50%
```

## Key reads

1. **tol=1e-4 max_iter=60 is the win.** Gap vs Eigen LLT closes from 10× to 5.2×.

2. **Tighter tol caps at ~1e-4.** `1e-5 @ 60` (1.88 s) is statistically identical to `1e-4 @ 60` (1.84 s). CG hits the fp32 precision floor around 1e-4. Pushing below just wastes a few iters.

3. **max_iter matters more than tol.** At `max_iter ∈ {15, 30}`, no tol setting wins. At `max_iter = 60`, tighter tol gives the 2× drop. There's a "knee" where CG finally has enough budget to reach the tight tol.

4. **Projection time tells the iter-count story directly.** At the sweet spot it drops from **649 ms → 151 ms** — a 4.3× reduction in PD outer iters because each inner solve is now accurate enough for DiffCloth's outer convergence to fire earlier. `solve+update` only drops 1.6× because each inner solve costs more (60 iters vs 15).

## This confirms PR #37's decomposition

PR #37 said the 10× gap was:
- 1.5× per-solve Metal overhead
- 7.5× PD outer iter amplification from approximate fp32 solves

Today's sweep refines that to:
- **1.5×** per-solve Metal overhead *(unchanged — architectural; the GPU-resident outer loop from PR #34 attacks this)*
- **3.5×** PD outer iter amplification *(was 7.5× at default settings; **drops to 3.5× at the sweet spot**)*
- **= 5.2×** current best gap

The remaining 3.5× is the **fp32 precision floor**. CG converges to ~1e-4 relative residual regardless of how many iters or how tight the requested tol — fp32 just doesn't have the bits to push lower.

## Path to parity

To close the remaining 3.5×: **df32 throughout `spmv` and `saxpby`.** Currently only `dot_reduce` is df32 (via the Knuth/Dekker EFTs from #14). If `spmv` and `saxpby` also use df32 accumulation, the precision floor drops ~1000× — should let PD outer iter count actually match Eigen's fp64-exact LLT.

That's the right next big lift. Tracked as future work; not in this PR.

## What this PR does

- Updates Slang CG defaults from `(tol=1e-3, max_iter=15)` to `(tol=1e-4, max_iter=60)`.
- Keeps `SLANG_CG_TOL` and `SLANG_CG_MAX_ITER` env var overrides so future sweeps can vary without rebuilding.

## Test plan

- [x] Local: 9-cell sweep on dress demo step 20, captured Total time + projection + solve+update for each.
- [x] Verified the win is replicable (1.84 s at the sweet spot, vs 3.76 s baseline).
- [ ] CI: defaults change is env-gated semantics; existing tests unaffected.

## Where this leaves things

Per-step gap: **10× → 5.2× behind Eigen LLT**. Still not parity, but a real meaningful step. The remaining gap has clear targets:
- **1.5×** architectural (GPU-resident outer loop, PR #34 direction)
- **3.5×** precision (df32 throughout spmv + saxpby)

Combined those would plausibly land in 1.0-1.5× range. Tractable.