### PR TITLE
Add spmv_df32: df32-accumulating SpMV to attack the 3.5× fp32-precision-floor gap

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -10,6 +10,7 @@ import Cloth.SlangCodegen.AssembleB
 import Cloth.SlangCodegen.CGAlpha
 import Cloth.SlangCodegen.CGBeta
 import Cloth.SlangCodegen.SaxpbyIndirect
+import Cloth.SlangCodegen.SpmvDf32
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/SpmvDf32.lean
+++ b/lean/Cloth/SlangCodegen/SpmvDf32.lean
@@ -1,0 +1,242 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.SpmvDf32` — sparse CSR matrix-vector with df32 accumulation
+
+Like `Cloth.SlangCodegen.Spmv` but accumulates each row's sum as a
+df32 pair `(s_hi, s_lo)` via the Knuth/Dekker EFT helpers
+(`two_prod`, `df_add`). Output is fp32 — `y[i] = s_hi + s_lo` —
+matching the original `Spmv` ABI exactly, so it's a drop-in
+replacement for `MetalCGSolver`'s spmv pipeline.
+
+Why this exists: PR #38 found that the CG-iter-count amplification
+hits an fp32 precision floor around `tol ≈ 1e-4`. The dominant source
+of fp32 error inside a CG iter is the per-row spmv sum — for a
+typical Laplacian row with ~7 nnz, the fp32 accumulation builds up
+~7·ε of error per row, which compounds over CG iters into a per-iter
+residual floor that DiffCloth's PD outer convergence test can't
+push past.
+
+df32 accumulation drops the per-row error from ~7·ε to ~7·ε² which
+is negligible. The output is still fp32 (the (hi, lo) pair is
+collapsed at the end), so downstream `saxpby` etc. doesn't need to
+change. Cost per row: one extra `two_prod` + one `df_add` per nnz
+≈ 5 extra fp ops per nnz vs the original `fma`. Per element this is
+~5× the kernel arithmetic; on M-series GPU this is fully bandwidth-
+bound for spmv so the wall impact should be small.
+
+Bindings are identical to `Spmv`:
+
+  0  ConstantBuffer<SpmvDf32Params> { uint rows; }
+  1  StructuredBuffer<int>       rowPtr   length = rows + 1
+  2  StructuredBuffer<int>       colIdx   length = nnz
+  3  StructuredBuffer<float>     values   length = nnz
+  4  StructuredBuffer<float>     x        length = cols
+  5  RWStructuredBuffer<float>   y        length = rows
+
+EFT helpers (two_prod, df_add, two_sum, quick_two_sum) inlined as
+private fn decls — same pattern as DotReduce.
+-/
+
+namespace Cloth.SlangCodegen.SpmvDf32
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+
+private def fIn  (name : String) : SlangBinding :=
+  ⟨name, floatTy, Semantic.none, none, none, .qIn⟩
+private def fOut (name : String) : SlangBinding :=
+  ⟨name, floatTy, Semantic.none, none, none, .qOut⟩
+
+private def two_sum : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "two_sum"
+  , params  := [fIn "a", fIn "b", fOut "hi", fOut "lo"]
+  , body    :=
+      [ .declInit floatTy "h"    (.bin "+" (.var "a") (.var "b"))
+      , .declInit floatTy "bb"   (.bin "-" (.var "h") (.var "a"))
+      , .declInit floatTy "ah"   (.bin "-" (.var "h") (.var "bb"))
+      , .declInit floatTy "lo_a" (.bin "-" (.var "a") (.var "ah"))
+      , .declInit floatTy "lo_b" (.bin "-" (.var "b") (.var "bb"))
+      , .assign (.var "hi") (.var "h")
+      , .assign (.var "lo") (.bin "+" (.var "lo_a") (.var "lo_b"))
+      , .ret none ] }
+
+private def quick_two_sum : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "quick_two_sum"
+  , params  := [fIn "a", fIn "b", fOut "hi", fOut "lo"]
+  , body    :=
+      [ .declInit floatTy "h" (.bin "+" (.var "a") (.var "b"))
+      , .declInit floatTy "t" (.bin "-" (.var "h") (.var "a"))
+      , .assign (.var "hi") (.var "h")
+      , .assign (.var "lo") (.bin "-" (.var "b") (.var "t"))
+      , .ret none ] }
+
+private def two_prod : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "two_prod"
+  , params  := [fIn "a", fIn "b", fOut "hi", fOut "lo"]
+  , body    :=
+      [ .declInit floatTy "h" (.bin "*" (.var "a") (.var "b"))
+      , .assign (.var "hi") (.var "h")
+      , .assign (.var "lo")
+          (.call "fma" [.var "a", .var "b", .un "-" (.var "h")])
+      , .ret none ] }
+
+private def df_add : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "df_add"
+  , params  :=
+      [ fIn "x_hi", fIn "x_lo", fIn "y_hi", fIn "y_lo"
+      , fOut "z_hi", fOut "z_lo" ]
+  , body    :=
+      [ .declare floatTy "sh" none
+      , .declare floatTy "sl" none
+      , .expr (.call "two_sum"
+          [.var "x_hi", .var "y_hi", .var "sh", .var "sl"])
+      , .declInit floatTy "xy_lo" (.bin "+" (.var "x_lo") (.var "y_lo"))
+      , .declInit floatTy "sl2"   (.bin "+" (.var "sl")  (.var "xy_lo"))
+      , .expr (.call "quick_two_sum"
+          [.var "sh", .var "sl2", .var "z_hi", .var "z_lo"])
+      , .ret none ] }
+
+private def mainEntry : SlangFunctionDecl :=
+  { attrs  := [.shaderCompute, .numthreads 256 1 1]
+  , name   := "main"
+  , params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+  , body   :=
+      [ .declInit uintTy "i" (.member (.var "tid") "x")
+      , .ifNoElse (.bin ">=" (.var "i") (.member (.var "params") "rows"))
+          [ .ret none ]
+      , .declInit uintTy "rs"
+          (.call "uint" [.index (.var "rowPtr") (.var "i")])
+      , .declInit uintTy "re"
+          (.call "uint" [.index (.var "rowPtr")
+            (.bin "+" (.var "i") (.litUint 1))])
+      , .declInit floatTy "s_hi" (.litFloat 0.0)
+      , .declInit floatTy "s_lo" (.litFloat 0.0)
+      , .forCount "p" (.var "rs") (.var "re")
+          [ .declInit floatTy "v"  (.index (.var "values") (.var "p"))
+          , .declInit floatTy "xc"
+              (.index (.var "x")
+                (.call "uint" [.index (.var "colIdx") (.var "p")]))
+          , .declare floatTy "t_hi" none
+          , .declare floatTy "t_lo" none
+          , .expr (.call "two_prod"
+              [.var "v", .var "xc", .var "t_hi", .var "t_lo"])
+          , .declare floatTy "n_hi" none
+          , .declare floatTy "n_lo" none
+          , .expr (.call "df_add"
+              [.var "s_hi", .var "s_lo"
+              , .var "t_hi", .var "t_lo"
+              , .var "n_hi", .var "n_lo"])
+          , .assign (.var "s_hi") (.var "n_hi")
+          , .assign (.var "s_lo") (.var "n_lo") ]
+      , .assign (.index (.var "y") (.var "i"))
+          (.bin "+" (.var "s_hi") (.var "s_lo"))
+      , .ret none ] }
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "SpmvDf32Params"
+        , fields := [⟨"rows", .scalar .uint, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params", .const "SpmvDf32Params",  Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"rowPtr", .roBuf (.scalar .int),    Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"colIdx", .roBuf (.scalar .int),    Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"values", .roBuf (.scalar .float),  Semantic.none, some 3, some 0, .qIn⟩
+      , ⟨"x",      .roBuf (.scalar .float),  Semantic.none, some 4, some 0, .qIn⟩
+      , ⟨"y",      .rwBuf (.scalar .float),  Semantic.none, some 5, some 0, .qIn⟩ ]
+  , functions := [two_sum, quick_two_sum, two_prod, df_add, mainEntry] }
+
+def expected : String :=
+"struct SpmvDf32Params {
+  uint rows;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<SpmvDf32Params> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<int> rowPtr;
+[[vk::binding(2, 0)]]
+StructuredBuffer<int> colIdx;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> values;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> x;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> y;
+
+void two_sum(float a, float b, out float hi, out float lo) {
+  float h = (a + b);
+  float bb = (h - a);
+  float ah = (h - bb);
+  float lo_a = (a - ah);
+  float lo_b = (b - bb);
+  hi = h;
+  lo = (lo_a + lo_b);
+  return;
+}
+
+void quick_two_sum(float a, float b, out float hi, out float lo) {
+  float h = (a + b);
+  float t = (h - a);
+  hi = h;
+  lo = (b - t);
+  return;
+}
+
+void two_prod(float a, float b, out float hi, out float lo) {
+  float h = (a * b);
+  hi = h;
+  lo = fma(a, b, (-h));
+  return;
+}
+
+void df_add(float x_hi, float x_lo, float y_hi, float y_lo, out float z_hi, out float z_lo) {
+  float sh;
+  float sl;
+  two_sum(x_hi, y_hi, sh, sl);
+  float xy_lo = (x_lo + y_lo);
+  float sl2 = (sl + xy_lo);
+  quick_two_sum(sh, sl2, z_hi, z_lo);
+  return;
+}
+
+[shader(\"compute\")] [numthreads(256, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  if ((i >= params.rows)) {
+    return;
+  }
+  uint rs = uint(rowPtr[i]);
+  uint re = uint(rowPtr[(i + 1u)]);
+  float s_hi = 0.000000;
+  float s_lo = 0.000000;
+  for (uint p = rs; p < re; ++p) {
+    float v = values[p];
+    float xc = x[uint(colIdx[p])];
+    float t_hi;
+    float t_lo;
+    two_prod(v, xc, t_hi, t_lo);
+    float n_hi;
+    float n_lo;
+    df_add(s_hi, s_lo, t_hi, t_lo, n_hi, n_lo);
+    s_hi = n_hi;
+    s_lo = n_lo;
+  }
+  y[i] = (s_hi + s_lo);
+  return;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.SpmvDf32

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -30,6 +30,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("cg_alpha",           CGAlpha.shader)
   , ("cg_beta",            CGBeta.shader)
   , ("saxpby_indirect",    SaxpbyIndirect.shader)
+  , ("spmv_df32",          SpmvDf32.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++
@@ -44,7 +44,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               assemble_b:assemble_b \
               cg_alpha:cg_alpha \
               cg_beta:cg_beta \
-              saxpby_indirect:saxpby_indirect
+              saxpby_indirect:saxpby_indirect \
+              spmv_df32:spmv_df32
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/spmv_df32_test.cpp
+++ b/tests/slang_validate/spmv_df32_test.cpp
@@ -1,0 +1,95 @@
+// Real-input validator for Cloth.SlangCodegen.SpmvDf32 — the df32-
+// accumulating sparse matrix-vector kernel.
+//
+// Should produce the same result as the original fp32 Spmv (#13) on
+// the same fixture — at this small N (3x3, 6 nnz) the fp32 round-off
+// is far below 1e-6 so both kernels land at the same answer.
+//
+// The win for SpmvDf32 only shows up at scale: large N or
+// ill-conditioned matrices where the per-row sum builds up enough
+// fp32 error to matter. That win is observable in CG iter count
+// rather than per-spmv accuracy.
+//
+// Test fixture: 3x3 sparse matrix
+//
+//   A = [ 2 0 1 ]      x = [1, 2, 3]
+//       [ 0 3 0 ]      y = A*x = [5, 6, 32]
+//       [ 4 5 6 ]
+//
+//   CSR:
+//     rowPtr = [0, 2, 3, 6]
+//     colIdx = [0, 2, 1, 0, 1, 2]
+//     values = [2, 1, 3, 4, 5, 6]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "spmv_df32_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t ROWS = 3;
+    constexpr uint32_t NNZ  = 6;
+
+    SpmvDf32Params_0 params{ROWS};
+
+    int32_t rowPtr[ROWS + 1] = {0, 2, 3, 6};
+    int32_t colIdx[NNZ]      = {0, 2, 1, 0, 1, 2};
+    float   values[NNZ]      = {2.0f, 1.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    float   x[ROWS]          = {1.0f, 2.0f, 3.0f};
+    float   y[ROWS]          = {0.0f, 0.0f, 0.0f};
+
+    const float expected[ROWS] = {
+        2.0f * 1.0f + 1.0f * 3.0f,                    // = 5
+        3.0f * 2.0f,                                  // = 6
+        4.0f * 1.0f + 5.0f * 2.0f + 6.0f * 3.0f,      // = 32
+    };
+
+    GlobalParams_0 gp{};
+    gp.params_0      = &params;
+    gp.rowPtr_0.data = rowPtr;   gp.rowPtr_0.count = ROWS + 1;
+    gp.colIdx_0.data = colIdx;   gp.colIdx_0.count = NNZ;
+    gp.values_0.data = values;   gp.values_0.count = NNZ;
+    gp.x_0.data      = x;        gp.x_0.count      = ROWS;
+    gp.y_0.data      = y;        gp.y_0.count      = ROWS;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t i = 0; i < ROWS; ++i) {
+        const float d = std::fabs(y[i] - expected[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "spmv_df32 mismatch at i=%u: got %g, expected %g (diff %g)\n",
+                    i, y[i], expected[i], d);
+            }
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "spmv_df32: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("spmv_df32: %u/%u rows OK (nnz=%u, max_abs_diff=%g, %.1fms)\n",
+                    ROWS, ROWS, NNZ, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "spmv_df32: %d FAIL out of %u\n", fails, ROWS);
+    return 1;
+}


### PR DESCRIPTION
## Summary

PR #38's sweep identified the remaining 3.5× gap vs Eigen LLT as the **fp32 precision floor**: CG can't push residual below ~1e-4 at any tol setting because each CG iter's per-row SpMV accumulates ~7·ε of fp32 error, and the error compounds across iters.

This kernel upgrades just **SpMV's row accumulation to df32** using the same Knuth/Dekker EFT helpers `DotReduce` uses (`two_sum`, `two_prod`, `df_add`, `quick_two_sum`). Output is still fp32 — `y[i] = s_hi + s_lo` — so the rest of the pipeline (saxpby, etc.) doesn't need to change. **Drop-in replacement for `Spmv` in `MetalCGSolver`.**

## What changes per kernel invocation

```
Original Spmv (fp32):
  float s = 0.0;
  for (uint p = rs; p < re; ++p) {
    s = fma(values[p], x[colIdx[p]], s);     // 1 fma per nnz
  }
  y[i] = s;

SpmvDf32 (df32 accumulation):
  float s_hi = 0.0;
  float s_lo = 0.0;
  for (uint p = rs; p < re; ++p) {
    two_prod(values[p], x[colIdx[p]], t_hi, t_lo);    // exact product
    df_add(s_hi, s_lo, t_hi, t_lo, s_hi, s_lo);       // df32 sum
  }
  y[i] = s_hi + s_lo;
```

Per-nnz cost: ~5 extra fp ops vs the original `fma`. On Apple Silicon GPU SpMV is bandwidth-bound, so wall impact should be small relative to the precision win.

## Correctness

```
$ make -C tests/slang_validate build/spmv_df32_test && tests/slang_validate/build/spmv_df32_test
spmv_df32: 3/3 rows OK (nnz=6, max_abs_diff=0, 0.0ms)
```

Bit-exact match with the original `Spmv` on the same 3×3 fixture (small N means fp32 accumulation has no observable error to fix). The win shows up at scale — needs to wire into `MetalCGSolver` and re-run the dress sweep.

## Roadmap

| | Step | Status |
|---|---|---|
| **`spmv_df32` kernel** | **this PR** |
| `saxpby_df32` (analogous df32 upgrade) | next |
| `MetalCGSolver` swap: use df32 kernels instead of fp32 | next |
| Re-run dress sweep; ideally see another 2-3× drop in per-step wall | next |

If `spmv_df32` + `saxpby_df32` together push the fp32 precision floor down by ~1000× (from `1e-4` to `1e-7` or better), the per-step gap should close from today's 5.2× → likely 2× or under. Combined with PR #34's GPU-resident outer loop work, **parity becomes plausible**.

## Test plan

- [x] `cd lean && lake build` — `native_decide` accepts the pinned emission.
- [x] `tests/slang_validate/build/spmv_df32_test` — 3/3 rows OK, max_abs_diff=0.
- [ ] Local `make test` for Metal kernels: blocked today by a transient `xcrun metal` toolchain issue on my Mac (`cannot execute tool 'metal' due to missing Metal Toolchain`). The slangc-cpp path is unaffected; CI runs both layers cleanly per #25.

## Where this leaves things

The fp32 precision floor identified in PR #38 was the biggest remaining bottleneck after the tol sweep. This PR ships the kernel-side machinery to attack it. Wiring + re-measurement come next.