### PR TITLE
Add saxpby_indirect_df32: df32 saxpby companion to spmv_df32 (#39)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -11,6 +11,7 @@ import Cloth.SlangCodegen.CGAlpha
 import Cloth.SlangCodegen.CGBeta
 import Cloth.SlangCodegen.SaxpbyIndirect
 import Cloth.SlangCodegen.SpmvDf32
+import Cloth.SlangCodegen.SaxpbyIndirectDf32
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/SaxpbyIndirectDf32.lean
+++ b/lean/Cloth/SlangCodegen/SaxpbyIndirectDf32.lean
@@ -1,0 +1,226 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.SaxpbyIndirectDf32` — df32 saxpby with α/β from buffer
+
+Second kernel attacking the fp32 precision floor from PR #38, paired
+with `SpmvDf32` from PR #39. Same ABI as `SaxpbyIndirect` so it's a
+drop-in replacement in `MetalCGSolver`.
+
+```
+dst[i] = α · x[i] + β · y[i]    for i ∈ [0, n)
+```
+
+The computation accumulates via the Knuth/Dekker EFTs (`two_prod`,
+`df_add`) so each per-element output has df32 precision before being
+collapsed to fp32 for storage. Per-element cost: 2 `two_prod` +
+1 `df_add` ≈ 8 extra fp ops vs the original 1 fma. saxpby is
+bandwidth-bound so the wall impact is small relative to the
+precision win.
+
+Bindings identical to `SaxpbyIndirect`:
+
+  0  ConstantBuffer<SaxpbyIndirectDf32Params> { uint n; }
+  1  StructuredBuffer<float>   alpha   length ≥ 1 (reads [0])
+  2  StructuredBuffer<float>   beta    length ≥ 1 (reads [0])
+  3  StructuredBuffer<float>   x       length = n
+  4  StructuredBuffer<float>   y       length = n
+  5  RWStructuredBuffer<float> dst     length = n
+
+EFT helpers (two_sum, quick_two_sum, two_prod, df_add) inlined as
+private fn decls — same pattern as `SpmvDf32` and `DotReduce`.
+-/
+
+namespace Cloth.SlangCodegen.SaxpbyIndirectDf32
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+
+private def fIn  (name : String) : SlangBinding :=
+  ⟨name, floatTy, Semantic.none, none, none, .qIn⟩
+private def fOut (name : String) : SlangBinding :=
+  ⟨name, floatTy, Semantic.none, none, none, .qOut⟩
+
+private def two_sum : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "two_sum"
+  , params  := [fIn "a", fIn "b", fOut "hi", fOut "lo"]
+  , body    :=
+      [ .declInit floatTy "h"    (.bin "+" (.var "a") (.var "b"))
+      , .declInit floatTy "bb"   (.bin "-" (.var "h") (.var "a"))
+      , .declInit floatTy "ah"   (.bin "-" (.var "h") (.var "bb"))
+      , .declInit floatTy "lo_a" (.bin "-" (.var "a") (.var "ah"))
+      , .declInit floatTy "lo_b" (.bin "-" (.var "b") (.var "bb"))
+      , .assign (.var "hi") (.var "h")
+      , .assign (.var "lo") (.bin "+" (.var "lo_a") (.var "lo_b"))
+      , .ret none ] }
+
+private def quick_two_sum : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "quick_two_sum"
+  , params  := [fIn "a", fIn "b", fOut "hi", fOut "lo"]
+  , body    :=
+      [ .declInit floatTy "h" (.bin "+" (.var "a") (.var "b"))
+      , .declInit floatTy "t" (.bin "-" (.var "h") (.var "a"))
+      , .assign (.var "hi") (.var "h")
+      , .assign (.var "lo") (.bin "-" (.var "b") (.var "t"))
+      , .ret none ] }
+
+private def two_prod : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "two_prod"
+  , params  := [fIn "a", fIn "b", fOut "hi", fOut "lo"]
+  , body    :=
+      [ .declInit floatTy "h" (.bin "*" (.var "a") (.var "b"))
+      , .assign (.var "hi") (.var "h")
+      , .assign (.var "lo")
+          (.call "fma" [.var "a", .var "b", .un "-" (.var "h")])
+      , .ret none ] }
+
+private def df_add : SlangFunctionDecl :=
+  { attrs   := []
+  , retType := .named "void"
+  , name    := "df_add"
+  , params  :=
+      [ fIn "x_hi", fIn "x_lo", fIn "y_hi", fIn "y_lo"
+      , fOut "z_hi", fOut "z_lo" ]
+  , body    :=
+      [ .declare floatTy "sh" none
+      , .declare floatTy "sl" none
+      , .expr (.call "two_sum"
+          [.var "x_hi", .var "y_hi", .var "sh", .var "sl"])
+      , .declInit floatTy "xy_lo" (.bin "+" (.var "x_lo") (.var "y_lo"))
+      , .declInit floatTy "sl2"   (.bin "+" (.var "sl")  (.var "xy_lo"))
+      , .expr (.call "quick_two_sum"
+          [.var "sh", .var "sl2", .var "z_hi", .var "z_lo"])
+      , .ret none ] }
+
+private def mainEntry : SlangFunctionDecl :=
+  { attrs  := [.shaderCompute, .numthreads 256 1 1]
+  , name   := "main"
+  , params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+  , body   :=
+      [ .declInit uintTy "i" (.member (.var "tid") "x")
+      , .ifNoElse (.bin ">=" (.var "i") (.member (.var "params") "n"))
+          [ .ret none ]
+      , .declInit floatTy "a"  (.index (.var "alpha") (.litUint 0))
+      , .declInit floatTy "b"  (.index (.var "beta")  (.litUint 0))
+      , .declInit floatTy "xi" (.index (.var "x")     (.var "i"))
+      , .declInit floatTy "yi" (.index (.var "y")     (.var "i"))
+      , .declare floatTy "a_hi" none
+      , .declare floatTy "a_lo" none
+      , .expr (.call "two_prod"
+          [.var "a", .var "xi", .var "a_hi", .var "a_lo"])
+      , .declare floatTy "b_hi" none
+      , .declare floatTy "b_lo" none
+      , .expr (.call "two_prod"
+          [.var "b", .var "yi", .var "b_hi", .var "b_lo"])
+      , .declare floatTy "s_hi" none
+      , .declare floatTy "s_lo" none
+      , .expr (.call "df_add"
+          [.var "a_hi", .var "a_lo"
+          , .var "b_hi", .var "b_lo"
+          , .var "s_hi", .var "s_lo"])
+      , .assign (.index (.var "dst") (.var "i"))
+          (.bin "+" (.var "s_hi") (.var "s_lo"))
+      , .ret none ] }
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "SaxpbyIndirectDf32Params"
+        , fields := [⟨"n", .scalar .uint, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params", .const "SaxpbyIndirectDf32Params", Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"alpha",  .roBuf floatTy,                    Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"beta",   .roBuf floatTy,                    Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"x",      .roBuf floatTy,                    Semantic.none, some 3, some 0, .qIn⟩
+      , ⟨"y",      .roBuf floatTy,                    Semantic.none, some 4, some 0, .qIn⟩
+      , ⟨"dst",    .rwBuf floatTy,                    Semantic.none, some 5, some 0, .qIn⟩ ]
+  , functions := [two_sum, quick_two_sum, two_prod, df_add, mainEntry] }
+
+def expected : String :=
+"struct SaxpbyIndirectDf32Params {
+  uint n;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<SaxpbyIndirectDf32Params> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> alpha;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> beta;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> x;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> y;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> dst;
+
+void two_sum(float a, float b, out float hi, out float lo) {
+  float h = (a + b);
+  float bb = (h - a);
+  float ah = (h - bb);
+  float lo_a = (a - ah);
+  float lo_b = (b - bb);
+  hi = h;
+  lo = (lo_a + lo_b);
+  return;
+}
+
+void quick_two_sum(float a, float b, out float hi, out float lo) {
+  float h = (a + b);
+  float t = (h - a);
+  hi = h;
+  lo = (b - t);
+  return;
+}
+
+void two_prod(float a, float b, out float hi, out float lo) {
+  float h = (a * b);
+  hi = h;
+  lo = fma(a, b, (-h));
+  return;
+}
+
+void df_add(float x_hi, float x_lo, float y_hi, float y_lo, out float z_hi, out float z_lo) {
+  float sh;
+  float sl;
+  two_sum(x_hi, y_hi, sh, sl);
+  float xy_lo = (x_lo + y_lo);
+  float sl2 = (sl + xy_lo);
+  quick_two_sum(sh, sl2, z_hi, z_lo);
+  return;
+}
+
+[shader(\"compute\")] [numthreads(256, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  if ((i >= params.n)) {
+    return;
+  }
+  float a = alpha[0u];
+  float b = beta[0u];
+  float xi = x[i];
+  float yi = y[i];
+  float a_hi;
+  float a_lo;
+  two_prod(a, xi, a_hi, a_lo);
+  float b_hi;
+  float b_lo;
+  two_prod(b, yi, b_hi, b_lo);
+  float s_hi;
+  float s_lo;
+  df_add(a_hi, a_lo, b_hi, b_lo, s_hi, s_lo);
+  dst[i] = (s_hi + s_lo);
+  return;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.SaxpbyIndirectDf32

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -31,6 +31,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("cg_beta",            CGBeta.shader)
   , ("saxpby_indirect",    SaxpbyIndirect.shader)
   , ("spmv_df32",          SpmvDf32.shader)
+  , ("saxpby_indirect_df32", SaxpbyIndirectDf32.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++
@@ -45,7 +45,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               cg_alpha:cg_alpha \
               cg_beta:cg_beta \
               saxpby_indirect:saxpby_indirect \
-              spmv_df32:spmv_df32
+              spmv_df32:spmv_df32 \
+              saxpby_indirect_df32:saxpby_indirect_df32
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/saxpby_indirect_df32_test.cpp
+++ b/tests/slang_validate/saxpby_indirect_df32_test.cpp
@@ -1,0 +1,81 @@
+// Real-input validator for Cloth.SlangCodegen.SaxpbyIndirectDf32.
+//   dst[i] = alpha[0] * x[i] + beta[0] * y[i]    (accumulated via df32)
+//
+// Same arithmetic as saxpby_indirect (#30); only the accumulation
+// precision differs. At small N + friendly values, fp32 and df32
+// produce bit-identical output, so this is a smoke test rather than
+// a precision demonstration.
+//
+// Fixture matches saxpby_indirect_test for direct comparability:
+// alpha=3, beta=4 against the same x/y vectors.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "saxpby_indirect_df32_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N = 5;
+    SaxpbyIndirectDf32Params_0 params{N};
+
+    float alpha[1] = {3.0f};
+    float beta[1]  = {4.0f};
+    float x[N]   = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    float y[N]   = {0.5f, 1.0f, 1.5f, 2.0f, 2.5f};
+    float dst[N] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const float expected[N] = {
+        3.0f * 1.0f + 4.0f * 0.5f,    // 5
+        3.0f * 2.0f + 4.0f * 1.0f,    // 10
+        3.0f * 3.0f + 4.0f * 1.5f,    // 15
+        3.0f * 4.0f + 4.0f * 2.0f,    // 20
+        3.0f * 5.0f + 4.0f * 2.5f,    // 25
+    };
+
+    GlobalParams_0 gp{};
+    gp.params_0    = &params;
+    gp.alpha_0.data = alpha;  gp.alpha_0.count = 1;
+    gp.beta_0.data  = beta;   gp.beta_0.count  = 1;
+    gp.x_0.data    = x;       gp.x_0.count     = N;
+    gp.y_0.data    = y;       gp.y_0.count     = N;
+    gp.dst_0.data  = dst;     gp.dst_0.count   = N;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t i = 0; i < N; ++i) {
+        const float d = std::fabs(dst[i] - expected[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            std::fprintf(stderr,
+                "saxpby_indirect_df32 mismatch at i=%u: got %g, expected %g (diff %g)\n",
+                i, dst[i], expected[i], d);
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "saxpby_indirect_df32: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("saxpby_indirect_df32: %u/%u OK (alpha=%g, beta=%g, "
+                    "max_abs_diff=%g, %.1fms)\n",
+                    N, N, alpha[0], beta[0], max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "saxpby_indirect_df32: %d FAIL out of %u\n", fails, N);
+    return 1;
+}


### PR DESCRIPTION
## Summary
- Second kernel in the df32 chain attacking PR #38's 3.5× fp32 precision-floor gap (paired with #39's `spmv_df32`).
- Same ABI as `saxpby_indirect` (#30) — drop-in replacement in `MetalCGSolver`.
- Per-element: 2 `two_prod` + 1 `df_add` ≈ 8 extra fp ops vs original 1 fma. saxpby is bandwidth-bound so wall impact should be small.

## What's here
- `lean/Cloth/SlangCodegen/SaxpbyIndirectDf32.lean` — new kernel module, EFT helpers (`two_sum` / `quick_two_sum` / `two_prod` / `df_add`) inlined as private fn decls, same pattern as `SpmvDf32` / `DotReduce`.
- Wired into the codegen umbrella (`Cloth.SlangCodegen`) and `emit_shaders` exe.
- `tests/slang_validate/saxpby_indirect_df32_test.cpp` mirrors `saxpby_indirect_test` fixture (alpha=3, beta=4, N=5).
- Makefile updated: test added to `TESTS`, kernel added to `METAL_KERNELS`.

## Verification

\`\`\`
# lean side
cd lean && lake build              # native_decide green
lake exe emit_shaders /tmp/...     # writes saxpby_indirect_df32.slang

# cpp validator
make -C tests/slang_validate build/saxpby_indirect_df32_test
./tests/slang_validate/build/saxpby_indirect_df32_test
# → saxpby_indirect_df32: 5/5 OK (alpha=3, beta=4, max_abs_diff=0, 0.0ms)
\`\`\`

Bit-identical to fp32 `saxpby_indirect` on the small fixture — that's expected at this scale; the df32 win shows up when paired with `spmv_df32` and run through the full CG loop on the dress demo.

## Roadmap status
- spmv_df32 — merged #39
- saxpby_indirect_df32 — this PR
- MetalCGSolver swap — next: rewire to use spmv_df32 + saxpby_indirect_df32
- Re-measure dress sweep — ideally CG iter count drops, total/step drops

## Test plan
- [x] \`lake build\` green
- [x] saxpby_indirect_df32 cpp validator passes (5/5, max_abs_diff=0)
- [ ] CI: full Metal pipeline (\`xcrun metal\` toolchain is throwing "missing Metal Toolchain" locally; CI should run cleanly)