### PR TITLE
Add spring_force: AVBD per-spring force + GN Hessian (PR-A of AVBD port)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -12,6 +12,7 @@ import Cloth.SlangCodegen.CGBeta
 import Cloth.SlangCodegen.SaxpbyIndirect
 import Cloth.SlangCodegen.SpmvDf32
 import Cloth.SlangCodegen.SaxpbyIndirectDf32
+import Cloth.SlangCodegen.SpringForce
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/SpringForce.lean
+++ b/lean/Cloth/SlangCodegen/SpringForce.lean
@@ -1,0 +1,192 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.SpringForce` — AVBD spring force + GN Hessian
+
+First kernel for the AVBD port (see `todo.md`). For each spring `i`
+with endpoints `(a, b)`, rest length `L`, and stiffness `k`, computes:
+
+```
+d   = p_a − p_b
+len = |d|
+c   = len − L                  -- constraint value (signed)
+n   = d / len                  -- unit edge direction
+
+gradA[i] = k · c · n           -- ∇_a E for the spring's energy
+                                  (vertex b gets −gradA at gather time)
+
+hess[6i..6i+5] = packed sym 3x3  Hess block = k · (d ⊗ d) / len²
+                                  (Gauss-Newton approximation; the
+                                  diagonal block ∇²_a E = ∇²_b E shares
+                                  this matrix, no sign flip needed.)
+```
+
+This is the per-constraint primitive AVBD's vertex-block-update kernel
+will gather over a vertex's incident springs. One thread per spring,
+output indexed by constraint id — same dispatch shape as the
+PD-local-step `SpringProject` kernel. The vertex gather (and the role
+sign flip on the gradient) is a later PR.
+
+Energy reference:
+
+```
+E_i = (1/2) · k · (|p_a − p_b| − L)²
+```
+
+Gradient on `p_a`:
+
+```
+∂E/∂p_a = k · (len − L) · (d / len) = k · c · n
+```
+
+Newton's 3rd: ∂E/∂p_b = −∂E/∂p_a. Vertex-block update reads `gradA[i]`
+and negates it if the gathering vertex's role for spring `i` is `b`.
+
+Gauss-Newton Hessian (drops the `c · ∂n/∂p_a` term, which is the
+geometric stiffness):
+
+```
+∇²_a E ≈ k · (n n^T) = k · (d d^T) / len²
+```
+
+The same matrix sits on both diagonal blocks (`∇²_a E = ∇²_b E`).
+The off-diagonal block is `−k · n n^T`, but the per-vertex update only
+needs the diagonal — that's why we write the GN block once and let the
+gather use it for whichever endpoint is being updated.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions   length = N_verts
+  1  StructuredBuffer<uint>     p1Idx       length = N_springs
+  2  StructuredBuffer<uint>     p2Idx       length = N_springs
+  3  StructuredBuffer<float>    restLen     length = N_springs
+  4  StructuredBuffer<float>    stiffness   length = N_springs
+  5  RWStructuredBuffer<float3> gradA       length = N_springs
+  6  RWStructuredBuffer<float>  hess        length = 6 · N_springs
+
+Hess packing order: `[xx, xy, xz, yy, yz, zz]` (upper-triangle row-major
+of a symmetric 3x3). Per spring: 6 floats starting at offset `6·i`.
+-/
+
+namespace Cloth.SlangCodegen.SpringForce
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "i"   (.member (.var "tid") "x")
+  , .declInit u  "a"   (.index (.var "p1Idx") (.var "i"))
+  , .declInit u  "b"   (.index (.var "p2Idx") (.var "i"))
+  , .declInit f3 "p1"  (.index (.var "positions") (.var "a"))
+  , .declInit f3 "p2"  (.index (.var "positions") (.var "b"))
+  , .declInit f  "dx"  (.bin "-" (.member (.var "p1") "x")
+                                 (.member (.var "p2") "x"))
+  , .declInit f  "dy"  (.bin "-" (.member (.var "p1") "y")
+                                 (.member (.var "p2") "y"))
+  , .declInit f  "dz"  (.bin "-" (.member (.var "p1") "z")
+                                 (.member (.var "p2") "z"))
+  , .declInit f  "len2"
+      (.bin "+"
+        (.bin "+" (.bin "*" (.var "dx") (.var "dx"))
+                  (.bin "*" (.var "dy") (.var "dy")))
+        (.bin "*" (.var "dz") (.var "dz")))
+  , .declInit f  "len" (.call "sqrt" [.var "len2"])
+  , .declInit f  "k"   (.index (.var "stiffness") (.var "i"))
+  , .declInit f  "L"   (.index (.var "restLen")   (.var "i"))
+  , .declInit f  "c"   (.bin "-" (.var "len") (.var "L"))
+  , .declInit f  "gScale"
+      (.bin "/" (.bin "*" (.var "k") (.var "c")) (.var "len"))
+  , .assign (.index (.var "gradA") (.var "i"))
+      (.call "float3"
+        [ .bin "*" (.var "gScale") (.var "dx")
+        , .bin "*" (.var "gScale") (.var "dy")
+        , .bin "*" (.var "gScale") (.var "dz") ])
+  , .declInit f  "h" (.bin "/" (.var "k") (.var "len2"))
+  , .declInit u  "h0" (.bin "*" (.litUint 6) (.var "i"))
+  , .assign (.index (.var "hess") (.var "h0"))
+      (.bin "*" (.var "h") (.bin "*" (.var "dx") (.var "dx")))
+  , .assign (.index (.var "hess") (.bin "+" (.var "h0") (.litUint 1)))
+      (.bin "*" (.var "h") (.bin "*" (.var "dx") (.var "dy")))
+  , .assign (.index (.var "hess") (.bin "+" (.var "h0") (.litUint 2)))
+      (.bin "*" (.var "h") (.bin "*" (.var "dx") (.var "dz")))
+  , .assign (.index (.var "hess") (.bin "+" (.var "h0") (.litUint 3)))
+      (.bin "*" (.var "h") (.bin "*" (.var "dy") (.var "dy")))
+  , .assign (.index (.var "hess") (.bin "+" (.var "h0") (.litUint 4)))
+      (.bin "*" (.var "h") (.bin "*" (.var "dy") (.var "dz")))
+  , .assign (.index (.var "hess") (.bin "+" (.var "h0") (.litUint 5)))
+      (.bin "*" (.var "h") (.bin "*" (.var "dz") (.var "dz")))
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "p1Idx"      (.roBuf u)
+      , bnd 2 "p2Idx"      (.roBuf u)
+      , bnd 3 "restLen"    (.roBuf f)
+      , bnd 4 "stiffness"  (.roBuf f)
+      , bnd 5 "gradA"      (.rwBuf f3)
+      , bnd 6 "hess"       (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> p1Idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<uint> p2Idx;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> restLen;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> gradA;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float> hess;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  uint a = p1Idx[i];
+  uint b = p2Idx[i];
+  float3 p1 = positions[a];
+  float3 p2 = positions[b];
+  float dx = (p1.x - p2.x);
+  float dy = (p1.y - p2.y);
+  float dz = (p1.z - p2.z);
+  float len2 = (((dx * dx) + (dy * dy)) + (dz * dz));
+  float len = sqrt(len2);
+  float k = stiffness[i];
+  float L = restLen[i];
+  float c = (len - L);
+  float gScale = ((k * c) / len);
+  gradA[i] = float3((gScale * dx), (gScale * dy), (gScale * dz));
+  float h = (k / len2);
+  uint h0 = (6u * i);
+  hess[h0] = (h * (dx * dx));
+  hess[(h0 + 1u)] = (h * (dx * dy));
+  hess[(h0 + 2u)] = (h * (dx * dz));
+  hess[(h0 + 3u)] = (h * (dy * dy));
+  hess[(h0 + 4u)] = (h * (dy * dz));
+  hess[(h0 + 5u)] = (h * (dz * dz));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.SpringForce

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -32,6 +32,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("saxpby_indirect",    SaxpbyIndirect.shader)
   , ("spmv_df32",          SpmvDf32.shader)
   , ("saxpby_indirect_df32", SaxpbyIndirectDf32.shader)
+  , ("spring_force",       SpringForce.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++
@@ -46,7 +46,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               cg_beta:cg_beta \
               saxpby_indirect:saxpby_indirect \
               spmv_df32:spmv_df32 \
-              saxpby_indirect_df32:saxpby_indirect_df32
+              saxpby_indirect_df32:saxpby_indirect_df32 \
+              spring_force:spring_force
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/spring_force_test.cpp
+++ b/tests/slang_validate/spring_force_test.cpp
@@ -1,0 +1,116 @@
+// Real-input validator for Cloth.SlangCodegen.SpringForce — first AVBD
+// constraint-force primitive (PR-A of the AVBD port; see todo.md).
+//
+// Per spring i with endpoints (a, b), rest length L, stiffness k:
+//   d   = p_a − p_b
+//   len = |d|
+//   c   = len − L
+//   gradA[i] = (k · c / len) · d     -- ∇_a E
+//   hess[6i..6i+5] packed sym 3x3 = k · (d ⊗ d) / len²
+//
+// Test fixture (2 real springs over 3 verts):
+//   v0 = (0,0,0), v1 = (3,0,0), v2 = (0,4,0)
+//   spring 0: a=1, b=0, L=2.0, k=1.0
+//     d=(3,0,0), len=3, c=1, gScale=1/3 → gradA=(1,0,0)
+//     hess = (1/9) · [9,0,0,0,0,0] = [1,0,0,0,0,0]
+//   spring 1: a=2, b=0, L=2.0, k=1.0
+//     d=(0,4,0), len=4, c=2, gScale=1/2 → gradA=(0,2,0)
+//     hess = (1/16) · [0,0,0,16,0,0] = [0,0,0,1,0,0]
+//
+// Padding (slots 2..63): a=1, b=0 (distinct positions → nonzero len),
+// L=0, k=0 → gradA=(0,0,0), hess=zeros. Safe filler.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "spring_force_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_SPRINGS = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(3.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 4.0f, 0.0f),
+    };
+
+    std::vector<Vector<float, 3>> gradA(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hess(6 * GROUP_SIZE, 0.0f);
+
+    std::vector<uint32_t> p1Idx(GROUP_SIZE, 1u);
+    std::vector<uint32_t> p2Idx(GROUP_SIZE, 0u);
+    std::vector<float>    restLen(GROUP_SIZE, 0.0f);
+    std::vector<float>    stiffness(GROUP_SIZE, 0.0f);
+
+    p1Idx[0] = 1u; p2Idx[0] = 0u; restLen[0] = 2.0f; stiffness[0] = 1.0f;
+    p1Idx[1] = 2u; p2Idx[1] = 0u; restLen[1] = 2.0f; stiffness[1] = 1.0f;
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.p1Idx_0.data      = p1Idx.data();      gp.p1Idx_0.count      = p1Idx.size();
+    gp.p2Idx_0.data      = p2Idx.data();      gp.p2Idx_0.count      = p2Idx.size();
+    gp.restLen_0.data    = restLen.data();    gp.restLen_0.count    = restLen.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.gradA_0.data      = gradA.data();      gp.gradA_0.count      = gradA.size();
+    gp.hess_0.data       = hess.data();       gp.hess_0.count       = hess.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    // Reference: independent CPU evaluation.
+    const float expected_grad[N_SPRINGS][3] = {
+        {1.0f, 0.0f, 0.0f},
+        {0.0f, 2.0f, 0.0f},
+    };
+    const float expected_hess[N_SPRINGS][6] = {
+        // spring 0: d=(3,0,0), k=1, len2=9 → k/len2 * d⊗d = (1/9)*[9,0,0,0,0,0]
+        {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+        // spring 1: d=(0,4,0), k=1, len2=16 → (1/16)*[0,0,0,16,0,0]
+        {0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t s, int c) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "spring_force %s mismatch at s=%u, c=%d: got %g, expected %g (diff %g)\n",
+                    label, s, c, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t s = 0; s < N_SPRINGS; ++s) {
+        for (int c = 0; c < 3; ++c) check(gradA[s][c], expected_grad[s][c], "gradA", s, c);
+        for (int c = 0; c < 6; ++c) check(hess[6*s + c], expected_hess[s][c], "hess", s, c);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "spring_force: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("spring_force: %u/%u springs OK (max_abs_diff=%g, %.1fms)\n",
+                    N_SPRINGS, N_SPRINGS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "spring_force: %d FAIL out of %u checks\n",
+                 fails, N_SPRINGS * 9u);
+    return 1;
+}


### PR DESCRIPTION
## Summary

First constraint-force kernel for the AVBD port planned in #42. Per spring (one thread per constraint), writes:

\`\`\`
gradA[i]       = (k · c / len) · d         -- ∇_a E
hess[6i..6i+5] = (k / len²) · packed d⊗d   -- GN diagonal block
\`\`\`

Newton's 3rd handles endpoint b at gather time (gradB = −gradA); the GN diagonal-block Hessian is the same matrix for both endpoints with no sign flip, so we write it once.

Same dispatch shape as \`spring_project\` — one thread per constraint, output indexed by constraint id. The per-vertex gather (PR-D in the roadmap) reads these arrays via a CSR adjacency that PR-B will precompute.

## Verification

\`\`\`
spring_force: 2/2 springs OK (max_abs_diff=0, 0.0ms)
\`\`\`

2-spring 3-vertex fixture, bit-exact match against hand-computed reference for both \`gradA\` and \`hess\` components.

## Roadmap position

Roadmap from #42:
- **PR-A — spring_force** (this PR)
- PR-A continued — triangle_membrane_force, triangle_bending_force, attachment_force
- PR-B — vertex adjacency CSR
- PR-C — vertex graph coloring
- PR-D — vertex-block-update kernel
- PR-E — outer iteration loop in Simulation.cpp
- PR-F — augmented Lagrangian dual update
- PR-G — differentiable adjoint
- PR-H — dress demo validation

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact match on 2-spring fixture
- [ ] CI: lean-slang workflow validates emit text + cpp test