### PR TITLE
Add attachment_force: AVBD per-attachment force + Hessian (PR-A cont.)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -13,6 +13,7 @@ import Cloth.SlangCodegen.SaxpbyIndirect
 import Cloth.SlangCodegen.SpmvDf32
 import Cloth.SlangCodegen.SaxpbyIndirectDf32
 import Cloth.SlangCodegen.SpringForce
+import Cloth.SlangCodegen.AttachmentForce
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/AttachmentForce.lean
+++ b/lean/Cloth/SlangCodegen/AttachmentForce.lean
@@ -1,0 +1,128 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.AttachmentForce` — AVBD attachment force + Hessian
+
+Second constraint-force kernel for the AVBD port (todo.md PR-A). For
+each attachment `c` pinning vertex `v = vertIdx[c]` to world-space
+anchor `fixedPos[c]` with stiffness `k`:
+
+```
+gradV[c]      = k · (p_v − fixedPos[c])
+hessScalar[c] = k                          -- Hessian is k · I₃, fully
+                                              described by the scalar k
+```
+
+Attachment is the simplest constraint geometry: one vertex, no role
+question (it's always "this vertex"), and the Hessian is a scalar
+multiple of the identity, so the per-constraint write is just one
+float instead of `spring_force`'s packed 6-float block.
+
+Energy reference:
+
+```
+E_c = (1/2) · k · |p_v − fixedPos|²
+```
+
+Gradient on `p_v`:
+
+```
+∂E/∂p_v = k · (p_v − fixedPos)
+```
+
+Hessian on `p_v`:
+
+```
+∇²_v E = k · I₃
+```
+
+The per-vertex AVBD gather (PR-D) for an incident attachment `c` on
+vertex `v` adds `gradV[c]` to `g` and `hessScalar[c]` to each diagonal
+entry of the local 3x3 `H`.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions    length = N_verts
+  1  StructuredBuffer<uint>     vertIdx      length = N_attach
+  2  StructuredBuffer<float3>   fixedPos     length = N_attach
+  3  StructuredBuffer<float>    stiffness    length = N_attach
+  4  RWStructuredBuffer<float3> gradV        length = N_attach
+  5  RWStructuredBuffer<float>  hessScalar   length = N_attach
+-/
+
+namespace Cloth.SlangCodegen.AttachmentForce
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"   (.member (.var "tid") "x")
+  , .declInit u  "v"   (.index (.var "vertIdx") (.var "c"))
+  , .declInit f3 "p"   (.index (.var "positions") (.var "v"))
+  , .declInit f3 "fp"  (.index (.var "fixedPos") (.var "c"))
+  , .declInit f  "k"   (.index (.var "stiffness") (.var "c"))
+  , .assign (.index (.var "gradV") (.var "c"))
+      (.call "float3"
+        [ .bin "*" (.var "k")
+            (.bin "-" (.member (.var "p") "x") (.member (.var "fp") "x"))
+        , .bin "*" (.var "k")
+            (.bin "-" (.member (.var "p") "y") (.member (.var "fp") "y"))
+        , .bin "*" (.var "k")
+            (.bin "-" (.member (.var "p") "z") (.member (.var "fp") "z")) ])
+  , .assign (.index (.var "hessScalar") (.var "c")) (.var "k")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "vertIdx"    (.roBuf u)
+      , bnd 2 "fixedPos"   (.roBuf f3)
+      , bnd 3 "stiffness"  (.roBuf f)
+      , bnd 4 "gradV"      (.rwBuf f3)
+      , bnd 5 "hessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> vertIdx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float3> fixedPos;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float3> gradV;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> hessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint v = vertIdx[c];
+  float3 p = positions[v];
+  float3 fp = fixedPos[c];
+  float k = stiffness[c];
+  gradV[c] = float3((k * (p.x - fp.x)), (k * (p.y - fp.y)), (k * (p.z - fp.z)));
+  hessScalar[c] = k;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.AttachmentForce

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -33,6 +33,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("spmv_df32",          SpmvDf32.shader)
   , ("saxpby_indirect_df32", SaxpbyIndirectDf32.shader)
   , ("spring_force",       SpringForce.shader)
+  , ("attachment_force",   AttachmentForce.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -47,7 +47,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               saxpby_indirect:saxpby_indirect \
               spmv_df32:spmv_df32 \
               saxpby_indirect_df32:saxpby_indirect_df32 \
-              spring_force:spring_force
+              spring_force:spring_force \
+              attachment_force:attachment_force
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/attachment_force_test.cpp
+++ b/tests/slang_validate/attachment_force_test.cpp
@@ -1,0 +1,109 @@
+// Real-input validator for Cloth.SlangCodegen.AttachmentForce — AVBD
+// per-attachment force + Hessian primitive (PR-A of AVBD port).
+//
+// Per attachment c pinning vertex v=vertIdx[c] to fixedPos[c] with
+// stiffness k:
+//   gradV[c]      = k · (p_v − fixedPos[c])
+//   hessScalar[c] = k          (Hessian is k·I₃; one scalar suffices)
+//
+// Test fixture (2 attachments over 3 verts):
+//   v0 = (1,2,3),  v1 = (5,5,5),  v2 = (0,0,0)
+//   attach 0: pins v0 to (1,0,3), k=2.0
+//     → gradV[0] = 2 · ((1,2,3) − (1,0,3)) = (0, 4, 0)
+//     → hess[0]  = 2
+//   attach 1: pins v1 to (5,5,0), k=1.0
+//     → gradV[1] = 1 · ((5,5,5) − (5,5,0)) = (0, 0, 5)
+//     → hess[1]  = 1
+//
+// Padded slots (2..63): vertIdx=2 (valid, points at v2=(0,0,0)),
+// fixedPos=(0,0,0), k=0 → gradV=(0,0,0), hessScalar=0.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "attachment_force_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_ATTACH = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(1.0f, 2.0f, 3.0f),
+        Vector<float, 3>(5.0f, 5.0f, 5.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+    };
+
+    std::vector<uint32_t>         vertIdx(GROUP_SIZE, 2u);
+    std::vector<Vector<float, 3>> fixedPos(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> gradV(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hessScalar(GROUP_SIZE, 0.0f);
+
+    vertIdx[0]   = 0u;
+    fixedPos[0]  = Vector<float, 3>(1.0f, 0.0f, 3.0f);
+    stiffness[0] = 2.0f;
+    vertIdx[1]   = 1u;
+    fixedPos[1]  = Vector<float, 3>(5.0f, 5.0f, 0.0f);
+    stiffness[1] = 1.0f;
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.vertIdx_0.data    = vertIdx.data();    gp.vertIdx_0.count    = vertIdx.size();
+    gp.fixedPos_0.data   = fixedPos.data();   gp.fixedPos_0.count   = fixedPos.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.gradV_0.data      = gradV.data();      gp.gradV_0.count      = gradV.size();
+    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_grad[N_ATTACH][3] = {
+        {0.0f, 4.0f, 0.0f},
+        {0.0f, 0.0f, 5.0f},
+    };
+    const float expected_hess[N_ATTACH] = {2.0f, 1.0f};
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t c, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "attachment_force %s mismatch at c=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, c, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_ATTACH; ++c) {
+        for (int axis = 0; axis < 3; ++axis) check(gradV[c][axis], expected_grad[c][axis], "gradV", c, axis);
+        check(hessScalar[c], expected_hess[c], "hessScalar", c, 0);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "attachment_force: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("attachment_force: %u/%u attachments OK (max_abs_diff=%g, %.1fms)\n",
+                    N_ATTACH, N_ATTACH, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "attachment_force: %d FAIL out of %u checks\n",
+                 fails, N_ATTACH * 4u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Second constraint-force kernel for the AVBD port (#42). Per attachment c pinning vertex v=vertIdx[c] to fixedPos[c] with stiffness k:

\`\`\`
gradV[c]      = k · (p_v − fixedPos)     -- ∇_v E
hessScalar[c] = k                        -- Hessian is k · I₃
\`\`\`

Simplest constraint geometry: one vertex per constraint, no role flip, Hessian is k·I (one float instead of \`spring_force\`'s packed 6-float symmetric 3×3 block).

## Verification
\`\`\`
attachment_force: 2/2 attachments OK (max_abs_diff=0, 0.0ms)
\`\`\`

## Roadmap (#42)
- PR-A spring_force — merged #43
- PR-A **attachment_force** — this PR
- PR-A triangle_membrane_force — next
- PR-A triangle_bending_force
- PR-B vertex adjacency CSR
- PR-C vertex graph coloring
- PR-D vertex-block-update kernel
- ...

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact match on 2-attachment fixture
- [ ] CI: lean-slang validate