### PR TITLE
Add triangle_membrane_force: AVBD in-plane stretch (PR-A cont.)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -13,6 +13,7 @@ import Cloth.SlangCodegen.SaxpbyIndirect
 import Cloth.SlangCodegen.SpmvDf32
 import Cloth.SlangCodegen.SaxpbyIndirectDf32
 import Cloth.SlangCodegen.SpringForce
+import Cloth.SlangCodegen.AttachmentForce
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -14,6 +14,7 @@ import Cloth.SlangCodegen.SpmvDf32
 import Cloth.SlangCodegen.SaxpbyIndirectDf32
 import Cloth.SlangCodegen.SpringForce
 import Cloth.SlangCodegen.AttachmentForce
+import Cloth.SlangCodegen.TriangleMembraneForce
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/AttachmentForce.lean
+++ b/lean/Cloth/SlangCodegen/AttachmentForce.lean
@@ -1,0 +1,128 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.AttachmentForce` — AVBD attachment force + Hessian
+
+Second constraint-force kernel for the AVBD port (todo.md PR-A). For
+each attachment `c` pinning vertex `v = vertIdx[c]` to world-space
+anchor `fixedPos[c]` with stiffness `k`:
+
+```
+gradV[c]      = k · (p_v − fixedPos[c])
+hessScalar[c] = k                          -- Hessian is k · I₃, fully
+                                              described by the scalar k
+```
+
+Attachment is the simplest constraint geometry: one vertex, no role
+question (it's always "this vertex"), and the Hessian is a scalar
+multiple of the identity, so the per-constraint write is just one
+float instead of `spring_force`'s packed 6-float block.
+
+Energy reference:
+
+```
+E_c = (1/2) · k · |p_v − fixedPos|²
+```
+
+Gradient on `p_v`:
+
+```
+∂E/∂p_v = k · (p_v − fixedPos)
+```
+
+Hessian on `p_v`:
+
+```
+∇²_v E = k · I₃
+```
+
+The per-vertex AVBD gather (PR-D) for an incident attachment `c` on
+vertex `v` adds `gradV[c]` to `g` and `hessScalar[c]` to each diagonal
+entry of the local 3x3 `H`.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions    length = N_verts
+  1  StructuredBuffer<uint>     vertIdx      length = N_attach
+  2  StructuredBuffer<float3>   fixedPos     length = N_attach
+  3  StructuredBuffer<float>    stiffness    length = N_attach
+  4  RWStructuredBuffer<float3> gradV        length = N_attach
+  5  RWStructuredBuffer<float>  hessScalar   length = N_attach
+-/
+
+namespace Cloth.SlangCodegen.AttachmentForce
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"   (.member (.var "tid") "x")
+  , .declInit u  "v"   (.index (.var "vertIdx") (.var "c"))
+  , .declInit f3 "p"   (.index (.var "positions") (.var "v"))
+  , .declInit f3 "fp"  (.index (.var "fixedPos") (.var "c"))
+  , .declInit f  "k"   (.index (.var "stiffness") (.var "c"))
+  , .assign (.index (.var "gradV") (.var "c"))
+      (.call "float3"
+        [ .bin "*" (.var "k")
+            (.bin "-" (.member (.var "p") "x") (.member (.var "fp") "x"))
+        , .bin "*" (.var "k")
+            (.bin "-" (.member (.var "p") "y") (.member (.var "fp") "y"))
+        , .bin "*" (.var "k")
+            (.bin "-" (.member (.var "p") "z") (.member (.var "fp") "z")) ])
+  , .assign (.index (.var "hessScalar") (.var "c")) (.var "k")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "vertIdx"    (.roBuf u)
+      , bnd 2 "fixedPos"   (.roBuf f3)
+      , bnd 3 "stiffness"  (.roBuf f)
+      , bnd 4 "gradV"      (.rwBuf f3)
+      , bnd 5 "hessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> vertIdx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float3> fixedPos;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float3> gradV;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> hessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint v = vertIdx[c];
+  float3 p = positions[v];
+  float3 fp = fixedPos[c];
+  float k = stiffness[c];
+  gradV[c] = float3((k * (p.x - fp.x)), (k * (p.y - fp.y)), (k * (p.z - fp.z)));
+  hessScalar[c] = k;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.AttachmentForce

--- a/lean/Cloth/SlangCodegen/TriangleMembraneForce.lean
+++ b/lean/Cloth/SlangCodegen/TriangleMembraneForce.lean
@@ -1,0 +1,254 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.TriangleMembraneForce` — AVBD triangle in-plane stretch
+
+Third constraint-force kernel for the AVBD port (todo.md PR-A). For
+each triangle `c` with vertex indices `(i0, i1, i2)` and stiffness `k`,
+computes the ARAP-style in-plane stretch force on each of the three
+vertices, plus the Gauss-Newton diagonal Hessian scalar for each.
+
+The energy is the standard 2D-ARAP / corotated stretch:
+
+```
+F   = [p1 − p0 | p2 − p0]                 -- 3×2 deformation gradient
+R   = newdeltaUV · R_2D                   -- closest-rotation projection
+                                              (same math as TriangleProject)
+E   = (k/2) · |F − R|²_F
+```
+
+Holding `R` fixed (the standard Gauss-Newton approximation for
+rotation-invariant elastic energies — exactly the trick PD's local
+step uses), the gradients are:
+
+```
+e0 = F.col(0) − R.col(0)     -- 3-vector
+e1 = F.col(1) − R.col(1)     -- 3-vector
+
+grad[3c+0] = −k · (e0 + e1)       (vertex 0 of the triangle)
+grad[3c+1] = +k · e0              (vertex 1)
+grad[3c+2] = +k · e1              (vertex 2)
+```
+
+And the diagonal Hessian blocks ∇²_v E are scalar multiples of `I₃`:
+
+```
+hessScalar[3c+0] = 2 · k     (vertex 0 contributes to both columns)
+hessScalar[3c+1] = k
+hessScalar[3c+2] = k
+```
+
+The per-vertex AVBD gather (PR-D) for an incident triangle `c` on a
+vertex of role `r` reads `grad[3c+r]` and adds `hessScalar[3c+r]` to
+each diagonal entry of the local 3x3 `H`.
+
+This kernel inherits the no-UV-mapping restriction from
+`TriangleProject` — `inv_deltaUV = I`, so `F` equals the raw edges.
+Restoring UV mapping is a follow-up that pre-multiplies `F` per
+triangle.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions   length = N_verts
+  1  StructuredBuffer<uint>     idx         length = 3 · N_tri
+  2  StructuredBuffer<float>    stiffness   length = N_tri
+  3  RWStructuredBuffer<float3> grad        length = 3 · N_tri
+  4  RWStructuredBuffer<float>  hessScalar  length = 3 · N_tri
+-/
+
+namespace Cloth.SlangCodegen.TriangleMembraneForce
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def pmv (s : String) (field : String) : SlangExpr :=
+  .member (.var s) field
+
+private def sum3 (a b c : SlangExpr) : SlangExpr :=
+  .bin "+" (.bin "+" a b) c
+
+private def len3 (x y z : SlangExpr) : SlangExpr :=
+  .call "sqrt" [ sum3 (.bin "*" x x) (.bin "*" y y) (.bin "*" z z) ]
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"    (.member (.var "tid") "x")
+  , .declInit u  "base" (.bin "*" (.var "c") (.litUint 3))
+  , .declInit u  "i0"   (.index (.var "idx") (.var "base"))
+  , .declInit u  "i1"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 1)))
+  , .declInit u  "i2"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 2)))
+  , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
+  , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
+  , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
+  , .declInit f "f0x" (.bin "-" (pmv "p1" "x") (pmv "p0" "x"))
+  , .declInit f "f0y" (.bin "-" (pmv "p1" "y") (pmv "p0" "y"))
+  , .declInit f "f0z" (.bin "-" (pmv "p1" "z") (pmv "p0" "z"))
+  , .declInit f "f1x" (.bin "-" (pmv "p2" "x") (pmv "p0" "x"))
+  , .declInit f "f1y" (.bin "-" (pmv "p2" "y") (pmv "p0" "y"))
+  , .declInit f "f1z" (.bin "-" (pmv "p2" "z") (pmv "p0" "z"))
+  , .declInit f "a"   (len3 (.var "f0x") (.var "f0y") (.var "f0z"))
+  , .declInit f "e1x" (.bin "/" (.var "f0x") (.var "a"))
+  , .declInit f "e1y" (.bin "/" (.var "f0y") (.var "a"))
+  , .declInit f "e1z" (.bin "/" (.var "f0z") (.var "a"))
+  , .declInit f "b"
+      (sum3 (.bin "*" (.var "e1x") (.var "f1x"))
+            (.bin "*" (.var "e1y") (.var "f1y"))
+            (.bin "*" (.var "e1z") (.var "f1z")))
+  , .declInit f "tx" (.bin "-" (.var "f1x") (.bin "*" (.var "b") (.var "e1x")))
+  , .declInit f "ty" (.bin "-" (.var "f1y") (.bin "*" (.var "b") (.var "e1y")))
+  , .declInit f "tz" (.bin "-" (.var "f1z") (.bin "*" (.var "b") (.var "e1z")))
+  , .declInit f "d"   (len3 (.var "tx") (.var "ty") (.var "tz"))
+  , .declInit f "e2x" (.bin "/" (.var "tx") (.var "d"))
+  , .declInit f "e2y" (.bin "/" (.var "ty") (.var "d"))
+  , .declInit f "e2z" (.bin "/" (.var "tz") (.var "d"))
+  , .declInit f "xv" (.bin "+" (.var "a") (.var "d"))
+  , .declInit f "yv" (.bin "-" (.litFloat 0.0) (.var "b"))
+  , .declInit f "rn"
+      (.call "sqrt" [.bin "+" (.bin "*" (.var "xv") (.var "xv"))
+                              (.bin "*" (.var "yv") (.var "yv"))])
+  , .declInit f "r00" (.bin "/" (.var "xv") (.var "rn"))
+  , .declInit f "r01" (.bin "/" (.var "b")  (.var "rn"))
+  , .declInit f "r10" (.bin "/" (.var "yv") (.var "rn"))
+  , .declInit f "r11" (.bin "/" (.var "xv") (.var "rn"))
+  , .declInit f "n0x" (.bin "+" (.bin "*" (.var "e1x") (.var "r00"))
+                                (.bin "*" (.var "e2x") (.var "r10")))
+  , .declInit f "n0y" (.bin "+" (.bin "*" (.var "e1y") (.var "r00"))
+                                (.bin "*" (.var "e2y") (.var "r10")))
+  , .declInit f "n0z" (.bin "+" (.bin "*" (.var "e1z") (.var "r00"))
+                                (.bin "*" (.var "e2z") (.var "r10")))
+  , .declInit f "n1x" (.bin "+" (.bin "*" (.var "e1x") (.var "r01"))
+                                (.bin "*" (.var "e2x") (.var "r11")))
+  , .declInit f "n1y" (.bin "+" (.bin "*" (.var "e1y") (.var "r01"))
+                                (.bin "*" (.var "e2y") (.var "r11")))
+  , .declInit f "n1z" (.bin "+" (.bin "*" (.var "e1z") (.var "r01"))
+                                (.bin "*" (.var "e2z") (.var "r11")))
+  , .declInit f "e0x" (.bin "-" (.var "f0x") (.var "n0x"))
+  , .declInit f "e0y" (.bin "-" (.var "f0y") (.var "n0y"))
+  , .declInit f "e0z" (.bin "-" (.var "f0z") (.var "n0z"))
+  , .declInit f "e1rx" (.bin "-" (.var "f1x") (.var "n1x"))
+  , .declInit f "e1ry" (.bin "-" (.var "f1y") (.var "n1y"))
+  , .declInit f "e1rz" (.bin "-" (.var "f1z") (.var "n1z"))
+  , .declInit f "k"   (.index (.var "stiffness") (.var "c"))
+  , .declInit u "gb"  (.bin "*" (.var "c") (.litUint 3))
+  , .assign (.index (.var "grad") (.var "gb"))
+      (.call "float3"
+        [ .bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
+            (.bin "+" (.var "e0x") (.var "e1rx"))
+        , .bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
+            (.bin "+" (.var "e0y") (.var "e1ry"))
+        , .bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
+            (.bin "+" (.var "e0z") (.var "e1rz")) ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 1)))
+      (.call "float3"
+        [ .bin "*" (.var "k") (.var "e0x")
+        , .bin "*" (.var "k") (.var "e0y")
+        , .bin "*" (.var "k") (.var "e0z") ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 2)))
+      (.call "float3"
+        [ .bin "*" (.var "k") (.var "e1rx")
+        , .bin "*" (.var "k") (.var "e1ry")
+        , .bin "*" (.var "k") (.var "e1rz") ])
+  , .assign (.index (.var "hessScalar") (.var "gb"))
+      (.bin "*" (.litFloat 2.0) (.var "k"))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 1)))
+      (.var "k")
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 2)))
+      (.var "k")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "idx"        (.roBuf u)
+      , bnd 2 "stiffness"  (.roBuf f)
+      , bnd 3 "grad"       (.rwBuf f3)
+      , bnd 4 "hessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(3, 0)]]
+RWStructuredBuffer<float3> grad;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float> hessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint base = (c * 3u);
+  uint i0 = idx[base];
+  uint i1 = idx[(base + 1u)];
+  uint i2 = idx[(base + 2u)];
+  float3 p0 = positions[i0];
+  float3 p1 = positions[i1];
+  float3 p2 = positions[i2];
+  float f0x = (p1.x - p0.x);
+  float f0y = (p1.y - p0.y);
+  float f0z = (p1.z - p0.z);
+  float f1x = (p2.x - p0.x);
+  float f1y = (p2.y - p0.y);
+  float f1z = (p2.z - p0.z);
+  float a = sqrt((((f0x * f0x) + (f0y * f0y)) + (f0z * f0z)));
+  float e1x = (f0x / a);
+  float e1y = (f0y / a);
+  float e1z = (f0z / a);
+  float b = (((e1x * f1x) + (e1y * f1y)) + (e1z * f1z));
+  float tx = (f1x - (b * e1x));
+  float ty = (f1y - (b * e1y));
+  float tz = (f1z - (b * e1z));
+  float d = sqrt((((tx * tx) + (ty * ty)) + (tz * tz)));
+  float e2x = (tx / d);
+  float e2y = (ty / d);
+  float e2z = (tz / d);
+  float xv = (a + d);
+  float yv = (0.000000 - b);
+  float rn = sqrt(((xv * xv) + (yv * yv)));
+  float r00 = (xv / rn);
+  float r01 = (b / rn);
+  float r10 = (yv / rn);
+  float r11 = (xv / rn);
+  float n0x = ((e1x * r00) + (e2x * r10));
+  float n0y = ((e1y * r00) + (e2y * r10));
+  float n0z = ((e1z * r00) + (e2z * r10));
+  float n1x = ((e1x * r01) + (e2x * r11));
+  float n1y = ((e1y * r01) + (e2y * r11));
+  float n1z = ((e1z * r01) + (e2z * r11));
+  float e0x = (f0x - n0x);
+  float e0y = (f0y - n0y);
+  float e0z = (f0z - n0z);
+  float e1rx = (f1x - n1x);
+  float e1ry = (f1y - n1y);
+  float e1rz = (f1z - n1z);
+  float k = stiffness[c];
+  uint gb = (c * 3u);
+  grad[gb] = float3(((0.000000 - k) * (e0x + e1rx)), ((0.000000 - k) * (e0y + e1ry)), ((0.000000 - k) * (e0z + e1rz)));
+  grad[(gb + 1u)] = float3((k * e0x), (k * e0y), (k * e0z));
+  grad[(gb + 2u)] = float3((k * e1rx), (k * e1ry), (k * e1rz));
+  hessScalar[gb] = (2.000000 * k);
+  hessScalar[(gb + 1u)] = k;
+  hessScalar[(gb + 2u)] = k;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.TriangleMembraneForce

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -34,6 +34,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("saxpby_indirect_df32", SaxpbyIndirectDf32.shader)
   , ("spring_force",       SpringForce.shader)
   , ("attachment_force",   AttachmentForce.shader)
+  , ("triangle_membrane_force", TriangleMembraneForce.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -33,6 +33,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("spmv_df32",          SpmvDf32.shader)
   , ("saxpby_indirect_df32", SaxpbyIndirectDf32.shader)
   , ("spring_force",       SpringForce.shader)
+  , ("attachment_force",   AttachmentForce.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -48,7 +48,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               spmv_df32:spmv_df32 \
               saxpby_indirect_df32:saxpby_indirect_df32 \
               spring_force:spring_force \
-              attachment_force:attachment_force
+              attachment_force:attachment_force \
+              triangle_membrane_force:triangle_membrane_force
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -47,7 +47,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               saxpby_indirect:saxpby_indirect \
               spmv_df32:spmv_df32 \
               saxpby_indirect_df32:saxpby_indirect_df32 \
-              spring_force:spring_force
+              spring_force:spring_force \
+              attachment_force:attachment_force
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/attachment_force_test.cpp
+++ b/tests/slang_validate/attachment_force_test.cpp
@@ -1,0 +1,109 @@
+// Real-input validator for Cloth.SlangCodegen.AttachmentForce — AVBD
+// per-attachment force + Hessian primitive (PR-A of AVBD port).
+//
+// Per attachment c pinning vertex v=vertIdx[c] to fixedPos[c] with
+// stiffness k:
+//   gradV[c]      = k · (p_v − fixedPos[c])
+//   hessScalar[c] = k          (Hessian is k·I₃; one scalar suffices)
+//
+// Test fixture (2 attachments over 3 verts):
+//   v0 = (1,2,3),  v1 = (5,5,5),  v2 = (0,0,0)
+//   attach 0: pins v0 to (1,0,3), k=2.0
+//     → gradV[0] = 2 · ((1,2,3) − (1,0,3)) = (0, 4, 0)
+//     → hess[0]  = 2
+//   attach 1: pins v1 to (5,5,0), k=1.0
+//     → gradV[1] = 1 · ((5,5,5) − (5,5,0)) = (0, 0, 5)
+//     → hess[1]  = 1
+//
+// Padded slots (2..63): vertIdx=2 (valid, points at v2=(0,0,0)),
+// fixedPos=(0,0,0), k=0 → gradV=(0,0,0), hessScalar=0.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "attachment_force_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_ATTACH = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(1.0f, 2.0f, 3.0f),
+        Vector<float, 3>(5.0f, 5.0f, 5.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+    };
+
+    std::vector<uint32_t>         vertIdx(GROUP_SIZE, 2u);
+    std::vector<Vector<float, 3>> fixedPos(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> gradV(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hessScalar(GROUP_SIZE, 0.0f);
+
+    vertIdx[0]   = 0u;
+    fixedPos[0]  = Vector<float, 3>(1.0f, 0.0f, 3.0f);
+    stiffness[0] = 2.0f;
+    vertIdx[1]   = 1u;
+    fixedPos[1]  = Vector<float, 3>(5.0f, 5.0f, 0.0f);
+    stiffness[1] = 1.0f;
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.vertIdx_0.data    = vertIdx.data();    gp.vertIdx_0.count    = vertIdx.size();
+    gp.fixedPos_0.data   = fixedPos.data();   gp.fixedPos_0.count   = fixedPos.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.gradV_0.data      = gradV.data();      gp.gradV_0.count      = gradV.size();
+    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_grad[N_ATTACH][3] = {
+        {0.0f, 4.0f, 0.0f},
+        {0.0f, 0.0f, 5.0f},
+    };
+    const float expected_hess[N_ATTACH] = {2.0f, 1.0f};
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t c, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "attachment_force %s mismatch at c=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, c, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_ATTACH; ++c) {
+        for (int axis = 0; axis < 3; ++axis) check(gradV[c][axis], expected_grad[c][axis], "gradV", c, axis);
+        check(hessScalar[c], expected_hess[c], "hessScalar", c, 0);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "attachment_force: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("attachment_force: %u/%u attachments OK (max_abs_diff=%g, %.1fms)\n",
+                    N_ATTACH, N_ATTACH, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "attachment_force: %d FAIL out of %u checks\n",
+                 fails, N_ATTACH * 4u);
+    return 1;
+}

--- a/tests/slang_validate/triangle_membrane_force_test.cpp
+++ b/tests/slang_validate/triangle_membrane_force_test.cpp
@@ -1,0 +1,132 @@
+// Real-input validator for Cloth.SlangCodegen.TriangleMembraneForce —
+// AVBD per-triangle in-plane stretch force (PR-A of AVBD port).
+//
+// Per triangle c with vertices (i0,i1,i2) and stiffness k:
+//   F = [p1-p0 | p2-p0],  R = closest-rotation-in-image-plane(F)
+//   e0 = F.col(0) − R.col(0)
+//   e1 = F.col(1) − R.col(1)
+//   grad[3c+0] = −k · (e0 + e1)
+//   grad[3c+1] = +k · e0
+//   grad[3c+2] = +k · e1
+//   hessScalar[3c+0] = 2·k
+//   hessScalar[3c+1] = k
+//   hessScalar[3c+2] = k
+//
+// Test fixture (2 triangles, 6 verts):
+//
+// Triangle 0 — stretched 2x in x and y, k=1:
+//   v0=(0,0,0), v1=(2,0,0), v2=(0,2,0)
+//   F = [(2,0,0)|(0,2,0)], 2D form [2,0;0,2], closest rot = I
+//   R = [(1,0,0)|(0,1,0)]
+//   e0=(1,0,0), e1=(0,1,0)
+//   grad[0] = (−1, −1, 0)
+//   grad[1] = (1, 0, 0)
+//   grad[2] = (0, 1, 0)
+//   hess = [2, 1, 1]
+//
+// Triangle 1 — unit rest triangle, k=3:
+//   v3=(10,10,10), v4=(11,10,10), v5=(10,11,10)
+//   F = [(1,0,0)|(0,1,0)] = R, so e0=e1=(0,0,0)
+//   grad = [(0,0,0)] × 3
+//   hess = [6, 3, 3]
+//
+// Padding (slots 2..63): idx=(0,1,2), k=0 → safe rotation math + zero grad/hess.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "triangle_membrane_force_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_TRI = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),    // v0
+        Vector<float, 3>(2.0f, 0.0f, 0.0f),    // v1
+        Vector<float, 3>(0.0f, 2.0f, 0.0f),    // v2
+        Vector<float, 3>(10.0f, 10.0f, 10.0f), // v3
+        Vector<float, 3>(11.0f, 10.0f, 10.0f), // v4
+        Vector<float, 3>(10.0f, 11.0f, 10.0f), // v5
+    };
+
+    std::vector<uint32_t>         idx(3 * GROUP_SIZE, 0u);
+    std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> grad(3 * GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hessScalar(3 * GROUP_SIZE, 0.0f);
+
+    // Default padding: idx = (0, 1, 2) (well-defined positions), k = 0
+    for (uint32_t c = 0; c < GROUP_SIZE; ++c) {
+        idx[3*c + 0] = 0u; idx[3*c + 1] = 1u; idx[3*c + 2] = 2u;
+    }
+
+    idx[0] = 0u; idx[1] = 1u; idx[2] = 2u; stiffness[0] = 1.0f;
+    idx[3] = 3u; idx[4] = 4u; idx[5] = 5u; stiffness[1] = 3.0f;
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.idx_0.data        = idx.data();        gp.idx_0.count        = idx.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.grad_0.data       = grad.data();       gp.grad_0.count       = grad.size();
+    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_grad[N_TRI][3][3] = {
+        { {-1.0f, -1.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f} },
+        { { 0.0f,  0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f} },
+    };
+    const float expected_hess[N_TRI][3] = {
+        {2.0f, 1.0f, 1.0f},
+        {6.0f, 3.0f, 3.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t c, int r, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "triangle_membrane_force %s mismatch at c=%u, r=%d, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, c, r, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_TRI; ++c) {
+        for (int r = 0; r < 3; ++r) {
+            for (int axis = 0; axis < 3; ++axis) {
+                check(grad[3*c + r][axis], expected_grad[c][r][axis], "grad", c, r, axis);
+            }
+            check(hessScalar[3*c + r], expected_hess[c][r], "hess", c, r, 0);
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "triangle_membrane_force: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("triangle_membrane_force: %u/%u tris OK (max_abs_diff=%g, %.1fms)\n",
+                    N_TRI, N_TRI, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "triangle_membrane_force: %d FAIL out of %u checks\n",
+                 fails, N_TRI * 12u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Third constraint-force kernel for the AVBD port (#42). Per triangle c with vertex indices (i0, i1, i2) and stiffness k, ARAP-style in-plane stretch:

\`\`\`
F   = [p1−p0 | p2−p0]              -- 3x2 deformation gradient
R   = closest-rotation(F)          -- same projection math as TriangleProject
e0  = F.col(0) − R.col(0)
e1  = F.col(1) − R.col(1)

grad[3c+0] = −k · (e0 + e1)        -- vertex 0 (sits on both columns)
grad[3c+1] = +k · e0               -- vertex 1
grad[3c+2] = +k · e1               -- vertex 2

hessScalar[3c+0] = 2·k
hessScalar[3c+1] = k
hessScalar[3c+2] = k
\`\`\`

Holding R fixed is the standard Gauss-Newton trick for rotation-invariant elastic energies (same one PD's local step uses). The diagonal Hessian blocks reduce to scalar·I₃, so each per-vertex output is just one float.

## Verification
\`\`\`
triangle_membrane_force: 2/2 tris OK (max_abs_diff=0, 0.0ms)
\`\`\`

2 triangles, 6 verts: T0 stretched 2× both axes (k=1), T1 unit rest pose (k=3). Both bit-exact against hand-computed reference for grad and hess.

## Roadmap (#42)
- PR-A spring_force          — merged #43
- PR-A attachment_force      — open #44
- PR-A **triangle_membrane_force** — this PR
- PR-A triangle_bending_force — next
- PR-B vertex adjacency CSR
- PR-C vertex graph coloring
- PR-D vertex-block-update kernel