### PR TITLE
Add triangle_bending_force: AVBD dihedral bending (PR-A complete)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -15,6 +15,7 @@ import Cloth.SlangCodegen.SaxpbyIndirectDf32
 import Cloth.SlangCodegen.SpringForce
 import Cloth.SlangCodegen.AttachmentForce
 import Cloth.SlangCodegen.TriangleMembraneForce
+import Cloth.SlangCodegen.TriangleBendingForce
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/TriangleBendingForce.lean
+++ b/lean/Cloth/SlangCodegen/TriangleBendingForce.lean
@@ -1,0 +1,228 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.TriangleBendingForce` — AVBD dihedral bending force
+
+Fourth and final per-constraint force kernel for the AVBD port
+(todo.md PR-A). For each bending constraint `c` (4-vertex stencil
+over the two triangles sharing an edge, with bind-time cotangent
+Laplacian weights `w[4c+r]`), with rest bending magnitude `n_target`
+and stiffness `k`:
+
+```
+s        = Σ_{r=0..3}  w[4c+r] · positions[idx[4c+r]]
+target   = (n_target / |s|) · s             -- closest point on
+                                               |·| = n_target sphere
+resid    = s − target = s · (1 − n_target/|s|)
+
+E_c      = (k/2) · |s − target|²
+∂E/∂p_v  = k · w[role(v,c)] · resid          -- ∂s/∂p_v = w · I₃
+
+grad[4c+r]       = k · w[4c+r] · resid       -- 4 per-vertex gradients
+hessScalar[4c+r] = k · (w[4c+r])²            -- diagonal block scalar
+```
+
+The Gauss-Newton Hessian holds `target` fixed (the same R-fixed trick
+PD's local step uses for rotation-invariant elastic energies). Each
+diagonal block ∇²_v E reduces to a scalar multiple of `I₃`.
+
+Degenerate stencils — bind-time collinear neighbors — are marked by
+`n_target = 0` (matching the PD `TriangleBending` convention). In that
+case the constraint is skipped: grad and hess scalars all write zero.
+We implement this cleanly by reading weights unconditionally and
+gating the effective stiffness on `n_target > 1e-6`:
+
+```
+k_eff = (n_target > 1e-6) ? stiffness[c] : 0
+```
+
+Reading weight[base..base+3] outside the if-branch is safe even on
+padded slots — multiplying by `k_eff = 0` zeroes everything, no UB.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions    length = N_verts
+  1  StructuredBuffer<uint>     idx          length = 4 · N_bend
+  2  StructuredBuffer<float>    weight       length = 4 · N_bend
+  3  StructuredBuffer<float>    nTarget      length = N_bend
+  4  StructuredBuffer<float>    stiffness    length = N_bend
+  5  RWStructuredBuffer<float3> grad         length = 4 · N_bend
+  6  RWStructuredBuffer<float>  hessScalar   length = 4 · N_bend
+-/
+
+namespace Cloth.SlangCodegen.TriangleBendingForce
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"    (.member (.var "tid") "x")
+  , .declInit f  "n_c"  (.index (.var "nTarget") (.var "c"))
+  , .declInit u  "base" (.bin "*" (.var "c") (.litUint 4))
+  , .declInit f  "w0"   (.index (.var "weight") (.var "base"))
+  , .declInit f  "w1"   (.index (.var "weight") (.bin "+" (.var "base") (.litUint 1)))
+  , .declInit f  "w2"   (.index (.var "weight") (.bin "+" (.var "base") (.litUint 2)))
+  , .declInit f  "w3"   (.index (.var "weight") (.bin "+" (.var "base") (.litUint 3)))
+  , .declInit f  "ex"   (.litFloat 0.0)
+  , .declInit f  "ey"   (.litFloat 0.0)
+  , .declInit f  "ez"   (.litFloat 0.0)
+  , .declInit f  "k_eff" (.litFloat 0.0)
+  , .ifNoElse (.bin ">" (.var "n_c") (.litFloat 0.000001))
+      [ .declInit u  "i0"   (.index (.var "idx") (.var "base"))
+      , .declInit u  "i1"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 1)))
+      , .declInit u  "i2"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 2)))
+      , .declInit u  "i3"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 3)))
+      , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
+      , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
+      , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
+      , .declInit f3 "p3"   (.index (.var "positions") (.var "i3"))
+      , .declInit f  "sx"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "x"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "x")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "x"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "x"))))
+      , .declInit f  "sy"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "y"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "y")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "y"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "y"))))
+      , .declInit f  "sz"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "z"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "z")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "z"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "z"))))
+      , .declInit f  "len"
+          (.call "sqrt"
+            [ .bin "+"
+                (.bin "+" (.bin "*" (.var "sx") (.var "sx"))
+                          (.bin "*" (.var "sy") (.var "sy")))
+                (.bin "*" (.var "sz") (.var "sz")) ])
+      , .declInit f  "scale" (.bin "/" (.var "n_c") (.var "len"))
+      , .declInit f  "om"    (.bin "-" (.litFloat 1.0) (.var "scale"))
+      , .assign (.var "ex")  (.bin "*" (.var "sx") (.var "om"))
+      , .assign (.var "ey")  (.bin "*" (.var "sy") (.var "om"))
+      , .assign (.var "ez")  (.bin "*" (.var "sz") (.var "om"))
+      , .assign (.var "k_eff") (.index (.var "stiffness") (.var "c"))
+      ]
+  , .assign (.index (.var "grad") (.var "base"))
+      (.call "float3"
+        [ .bin "*" (.bin "*" (.var "k_eff") (.var "w0")) (.var "ex")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w0")) (.var "ey")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w0")) (.var "ez") ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "base") (.litUint 1)))
+      (.call "float3"
+        [ .bin "*" (.bin "*" (.var "k_eff") (.var "w1")) (.var "ex")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w1")) (.var "ey")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w1")) (.var "ez") ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "base") (.litUint 2)))
+      (.call "float3"
+        [ .bin "*" (.bin "*" (.var "k_eff") (.var "w2")) (.var "ex")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w2")) (.var "ey")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w2")) (.var "ez") ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "base") (.litUint 3)))
+      (.call "float3"
+        [ .bin "*" (.bin "*" (.var "k_eff") (.var "w3")) (.var "ex")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w3")) (.var "ey")
+        , .bin "*" (.bin "*" (.var "k_eff") (.var "w3")) (.var "ez") ])
+  , .assign (.index (.var "hessScalar") (.var "base"))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w0") (.var "w0")))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "base") (.litUint 1)))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w1") (.var "w1")))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "base") (.litUint 2)))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w2") (.var "w2")))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "base") (.litUint 3)))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w3") (.var "w3")))
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "idx"        (.roBuf u)
+      , bnd 2 "weight"     (.roBuf f)
+      , bnd 3 "nTarget"    (.roBuf f)
+      , bnd 4 "stiffness"  (.roBuf f)
+      , bnd 5 "grad"       (.rwBuf f3)
+      , bnd 6 "hessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> weight;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> nTarget;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> grad;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float> hessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  float n_c = nTarget[c];
+  uint base = (c * 4u);
+  float w0 = weight[base];
+  float w1 = weight[(base + 1u)];
+  float w2 = weight[(base + 2u)];
+  float w3 = weight[(base + 3u)];
+  float ex = 0.000000;
+  float ey = 0.000000;
+  float ez = 0.000000;
+  float k_eff = 0.000000;
+  if ((n_c > 0.000001)) {
+    uint i0 = idx[base];
+    uint i1 = idx[(base + 1u)];
+    uint i2 = idx[(base + 2u)];
+    uint i3 = idx[(base + 3u)];
+    float3 p0 = positions[i0];
+    float3 p1 = positions[i1];
+    float3 p2 = positions[i2];
+    float3 p3 = positions[i3];
+    float sx = (((w0 * p0.x) + (w1 * p1.x)) + ((w2 * p2.x) + (w3 * p3.x)));
+    float sy = (((w0 * p0.y) + (w1 * p1.y)) + ((w2 * p2.y) + (w3 * p3.y)));
+    float sz = (((w0 * p0.z) + (w1 * p1.z)) + ((w2 * p2.z) + (w3 * p3.z)));
+    float len = sqrt((((sx * sx) + (sy * sy)) + (sz * sz)));
+    float scale = (n_c / len);
+    float om = (1.000000 - scale);
+    ex = (sx * om);
+    ey = (sy * om);
+    ez = (sz * om);
+    k_eff = stiffness[c];
+  }
+  grad[base] = float3(((k_eff * w0) * ex), ((k_eff * w0) * ey), ((k_eff * w0) * ez));
+  grad[(base + 1u)] = float3(((k_eff * w1) * ex), ((k_eff * w1) * ey), ((k_eff * w1) * ez));
+  grad[(base + 2u)] = float3(((k_eff * w2) * ex), ((k_eff * w2) * ey), ((k_eff * w2) * ez));
+  grad[(base + 3u)] = float3(((k_eff * w3) * ex), ((k_eff * w3) * ey), ((k_eff * w3) * ez));
+  hessScalar[base] = (k_eff * (w0 * w0));
+  hessScalar[(base + 1u)] = (k_eff * (w1 * w1));
+  hessScalar[(base + 2u)] = (k_eff * (w2 * w2));
+  hessScalar[(base + 3u)] = (k_eff * (w3 * w3));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.TriangleBendingForce

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -35,6 +35,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("spring_force",       SpringForce.shader)
   , ("attachment_force",   AttachmentForce.shader)
   , ("triangle_membrane_force", TriangleMembraneForce.shader)
+  , ("triangle_bending_force", TriangleBendingForce.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -49,7 +49,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               saxpby_indirect_df32:saxpby_indirect_df32 \
               spring_force:spring_force \
               attachment_force:attachment_force \
-              triangle_membrane_force:triangle_membrane_force
+              triangle_membrane_force:triangle_membrane_force \
+              triangle_bending_force:triangle_bending_force
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/triangle_bending_force_test.cpp
+++ b/tests/slang_validate/triangle_bending_force_test.cpp
@@ -1,0 +1,136 @@
+// Real-input validator for Cloth.SlangCodegen.TriangleBendingForce —
+// AVBD per-constraint dihedral bending force (PR-A cont. of AVBD port).
+//
+// Per bending constraint c with 4-vertex weighted-sum stencil:
+//   s        = Σ_r w[4c+r] · positions[idx[4c+r]]
+//   target   = (n_target/|s|) · s          if |s| > 0 and n_target > eps
+//   resid    = s − target = s · (1 − n_target/|s|)
+//   grad[4c+r]       = k · w[4c+r] · resid
+//   hessScalar[4c+r] = k · w[4c+r]²
+//
+// When n_target ≤ 1e-6 (degenerate stencil from bind time), k_eff = 0
+// → all grad and hess outputs are zero.
+//
+// Test fixture (2 constraints over 4 verts):
+//
+// c0 (non-degenerate, k=1, n_target=1):
+//   v0=(0,0,0), v1=(0,0,0), v2=(0,0,0), v3=(0,0,2)
+//   w = (1, 1, −1, −1)
+//   s = 1·(0,0,0) + 1·(0,0,0) − 1·(0,0,0) − 1·(0,0,2) = (0,0,−2)
+//   |s| = 2, scale = 1/2 = 0.5, om = 1 − 0.5 = 0.5
+//   resid = (0,0,−1)
+//   grad = [(0,0,−1), (0,0,−1), (0,0,1), (0,0,1)]
+//   hess = [1, 1, 1, 1]
+//
+// c1 (degenerate, n_target=0, k=1):
+//   grad = [(0,0,0)] × 4
+//   hess = [0, 0, 0, 0]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "triangle_bending_force_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_BEND     = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 2.0f),
+    };
+
+    std::vector<uint32_t>         idx(4 * GROUP_SIZE, 0u);
+    std::vector<float>            weight(4 * GROUP_SIZE, 0.0f);
+    std::vector<float>            nTarget(GROUP_SIZE, 0.0f);
+    std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> grad(4 * GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hessScalar(4 * GROUP_SIZE, 0.0f);
+
+    // c0: non-degenerate
+    for (int r = 0; r < 4; ++r) idx[4*0 + r] = uint32_t(r);
+    weight[0] = 1.0f; weight[1] = 1.0f; weight[2] = -1.0f; weight[3] = -1.0f;
+    nTarget[0] = 1.0f; stiffness[0] = 1.0f;
+
+    // c1: degenerate (nTarget=0)
+    for (int r = 0; r < 4; ++r) idx[4*1 + r] = uint32_t(r);
+    weight[4] = 1.0f; weight[5] = 1.0f; weight[6] = -1.0f; weight[7] = -1.0f;
+    nTarget[1] = 0.0f; stiffness[1] = 1.0f;
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.idx_0.data        = idx.data();        gp.idx_0.count        = idx.size();
+    gp.weight_0.data     = weight.data();     gp.weight_0.count     = weight.size();
+    gp.nTarget_0.data    = nTarget.data();    gp.nTarget_0.count    = nTarget.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.grad_0.data       = grad.data();       gp.grad_0.count       = grad.size();
+    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_grad[N_BEND][4][3] = {
+        { {0.0f, 0.0f, -1.0f},
+          {0.0f, 0.0f, -1.0f},
+          {0.0f, 0.0f,  1.0f},
+          {0.0f, 0.0f,  1.0f} },
+        { {0.0f, 0.0f, 0.0f},
+          {0.0f, 0.0f, 0.0f},
+          {0.0f, 0.0f, 0.0f},
+          {0.0f, 0.0f, 0.0f} },
+    };
+    const float expected_hess[N_BEND][4] = {
+        {1.0f, 1.0f, 1.0f, 1.0f},
+        {0.0f, 0.0f, 0.0f, 0.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t c, int r, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "triangle_bending_force %s mismatch at c=%u, r=%d, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, c, r, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_BEND; ++c) {
+        for (int r = 0; r < 4; ++r) {
+            for (int axis = 0; axis < 3; ++axis) {
+                check(grad[4*c + r][axis], expected_grad[c][r][axis], "grad", c, r, axis);
+            }
+            check(hessScalar[4*c + r], expected_hess[c][r], "hess", c, r, 0);
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "triangle_bending_force: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("triangle_bending_force: %u/%u constraints OK (max_abs_diff=%g, %.1fms)\n",
+                    N_BEND, N_BEND, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "triangle_bending_force: %d FAIL out of %u checks\n",
+                 fails, N_BEND * 16u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Fourth and final per-constraint force kernel for the AVBD port (#42). Completes PR-A.

Per bending constraint c with 4-vertex stencil and bind-time cotangent Laplacian weights:

\`\`\`
s        = Σ_r  w[4c+r] · positions[idx[4c+r]]
target   = (n_target/|s|) · s          -- closest point on |·|=n_target
resid    = s − target = s · (1 − n_target/|s|)

grad[4c+r]       = k · w[4c+r] · resid
hessScalar[4c+r] = k · w[4c+r]²
\`\`\`

Diagonal Hessian blocks are scalar·I₃ (same shape as the other force kernels). Degenerate stencils (\`nTarget = 0\` from bind time) gate \`k_eff = 0\`, zeroing grad and hess outputs — matches the PD \`TriangleBending\` convention.

## Verification
\`\`\`
triangle_bending_force: 2/2 constraints OK (max_abs_diff=0, 0.0ms)
\`\`\`

2 constraints over 4 verts: c0 non-degenerate with weighted sum producing \`resid=(0,0,-1)\`, c1 degenerate (\`nTarget=0\`). Bit-exact for both.

## PR-A status
- spring_force                 merged #43
- attachment_force             merged #44
- triangle_membrane_force      merged #45
- **triangle_bending_force**   this PR  ← **PR-A complete**

## Next up
- PR-B vertex adjacency CSR precompute (Lean module, no runtime change)
- PR-C vertex graph coloring
- PR-D vertex-block-update kernel
- ...