### PR TITLE
Add vbd_init: AVBD inertial scratch-init kernel (PR-D part 1)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -16,6 +16,7 @@ import Cloth.SlangCodegen.SpringForce
 import Cloth.SlangCodegen.AttachmentForce
 import Cloth.SlangCodegen.TriangleMembraneForce
 import Cloth.SlangCodegen.TriangleBendingForce
+import Cloth.SlangCodegen.VbdInit
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/VbdInit.lean
+++ b/lean/Cloth/SlangCodegen/VbdInit.lean
@@ -1,0 +1,137 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdInit` — AVBD vertex-update inertial init (PR-D part 1)
+
+First kernel in the AVBD vertex-block-update pipeline (`todo.md` PR-D).
+Initializes per-vertex scratch buffers with the implicit-Euler
+inertial term before the per-constraint gather kernels add their
+contributions.
+
+Per vertex `v` with mass `m`, current position `x`, predictor `x̃`, and
+time-step `h`:
+
+```
+w        = m / h²                               -- inertial weight
+
+gScratch[v]            = w · (x − x̃)            -- ∂E_inertia/∂x_v
+hScratch[6v..6v+5]     = [w, 0, 0, w, 0, w]     -- packed sym 3x3
+                                                   (w · I₃, the
+                                                   inertial Hessian)
+```
+
+The packed sym 3x3 layout is `[Hxx, Hxy, Hxz, Hyy, Hyz, Hzz]`, the
+same order spring_force uses. Per-constraint gather kernels (PR-D
+part 2: vbd_gather_spring, etc.) read this layout and accumulate
+their own contributions on top before the solve+apply kernel (PR-D
+part 3) inverts the 3x3 and writes `x ← x − H⁻¹ g`.
+
+`invHSquared = 1/h²` is uniform across vertices and lives in a small
+constant buffer (`VbdInitParams`).
+
+Bindings (set 0):
+
+  0  ConstantBuffer<VbdInitParams> { float invHSquared; }
+  1  StructuredBuffer<float3>      positions    length = N_verts
+  2  StructuredBuffer<float3>      predicted    length = N_verts
+  3  StructuredBuffer<float>       mass         length = N_verts
+  4  RWStructuredBuffer<float3>    gScratch     length = N_verts
+  5  RWStructuredBuffer<float>     hScratch     length = 6 · N_verts
+-/
+
+namespace Cloth.SlangCodegen.VbdInit
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def body : List SlangStmt :=
+  [ .declInit u  "v"   (.member (.var "tid") "x")
+  , .declInit f3 "x"   (.index (.var "positions") (.var "v"))
+  , .declInit f3 "px"  (.index (.var "predicted") (.var "v"))
+  , .declInit f  "m"   (.index (.var "mass") (.var "v"))
+  , .declInit f  "w"   (.bin "*" (.var "m")
+                                 (.member (.var "params") "invHSquared"))
+  , .assign (.index (.var "gScratch") (.var "v"))
+      (.call "float3"
+        [ .bin "*" (.var "w")
+            (.bin "-" (.member (.var "x") "x") (.member (.var "px") "x"))
+        , .bin "*" (.var "w")
+            (.bin "-" (.member (.var "x") "y") (.member (.var "px") "y"))
+        , .bin "*" (.var "w")
+            (.bin "-" (.member (.var "x") "z") (.member (.var "px") "z")) ])
+  , .declInit u "hb" (.bin "*" (.litUint 6) (.var "v"))
+  , .assign (.index (.var "hScratch") (.var "hb")) (.var "w")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 1)))
+      (.litFloat 0.0)
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 2)))
+      (.litFloat 0.0)
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3)))
+      (.var "w")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 4)))
+      (.litFloat 0.0)
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5)))
+      (.var "w")
+  ]
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "VbdInitParams"
+        , fields := [⟨"invHSquared", f, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params",    .const "VbdInitParams", Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"positions", .roBuf f3,              Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"predicted", .roBuf f3,              Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"mass",      .roBuf f,               Semantic.none, some 3, some 0, .qIn⟩
+      , ⟨"gScratch",  .rwBuf f3,              Semantic.none, some 4, some 0, .qIn⟩
+      , ⟨"hScratch",  .rwBuf f,               Semantic.none, some 5, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"struct VbdInitParams {
+  float invHSquared;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<VbdInitParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float3> predicted;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> mass;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float3> gScratch;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> hScratch;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint v = tid.x;
+  float3 x = positions[v];
+  float3 px = predicted[v];
+  float m = mass[v];
+  float w = (m * params.invHSquared);
+  gScratch[v] = float3((w * (x.x - px.x)), (w * (x.y - px.y)), (w * (x.z - px.z)));
+  uint hb = (6u * v);
+  hScratch[hb] = w;
+  hScratch[(hb + 1u)] = 0.000000;
+  hScratch[(hb + 2u)] = 0.000000;
+  hScratch[(hb + 3u)] = w;
+  hScratch[(hb + 4u)] = 0.000000;
+  hScratch[(hb + 5u)] = w;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdInit

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -36,6 +36,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("attachment_force",   AttachmentForce.shader)
   , ("triangle_membrane_force", TriangleMembraneForce.shader)
   , ("triangle_bending_force", TriangleBendingForce.shader)
+  , ("vbd_init",           VbdInit.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force vbd_init
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++
@@ -50,7 +50,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               spring_force:spring_force \
               attachment_force:attachment_force \
               triangle_membrane_force:triangle_membrane_force \
-              triangle_bending_force:triangle_bending_force
+              triangle_bending_force:triangle_bending_force \
+              vbd_init:vbd_init
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/vbd_init_test.cpp
+++ b/tests/slang_validate/vbd_init_test.cpp
@@ -1,0 +1,107 @@
+// Real-input validator for Cloth.SlangCodegen.VbdInit — first kernel
+// of the AVBD vertex-block-update pipeline (PR-D part 1).
+//
+// Per vertex v: writes the inertial term to scratch buffers:
+//   w = m · invHSquared
+//   gScratch[v]            = w · (x − x̃)
+//   hScratch[6v..6v+5]     = [w, 0, 0, w, 0, w]    (packed sym 3x3 = w·I)
+//
+// Test fixture (2 verts):
+//   v0:  x=(0,0,0)  pred=(1,2,3)  m=2, invH²=2  → w=4
+//        g = 4 · (-1,-2,-3) = (-4,-8,-12)
+//        H = [4, 0, 0, 4, 0, 4]
+//   v1:  x=(5,5,5)  pred=(5,5,5)  m=1, invH²=2  → w=2
+//        g = 2 · (0,0,0) = (0,0,0)
+//        H = [2, 0, 0, 2, 0, 2]
+//
+// Padded slots 2..63: x=pred=(0,0,0), m=0 → w=0, all outputs zero.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "vbd_init_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_VERTS   = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    VbdInitParams_0 params{};
+    params.invHSquared_0 = 2.0f;
+
+    std::vector<Vector<float, 3>> positions(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<Vector<float, 3>> predicted(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            mass(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> gScratch(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hScratch(6 * GROUP_SIZE, 0.0f);
+
+    positions[0] = Vector<float, 3>(0.0f, 0.0f, 0.0f);
+    predicted[0] = Vector<float, 3>(1.0f, 2.0f, 3.0f);
+    mass[0]      = 2.0f;
+
+    positions[1] = Vector<float, 3>(5.0f, 5.0f, 5.0f);
+    predicted[1] = Vector<float, 3>(5.0f, 5.0f, 5.0f);
+    mass[1]      = 1.0f;
+
+    GlobalParams_0 gp{};
+    gp.params_0       = &params;
+    gp.positions_0.data = positions.data(); gp.positions_0.count = positions.size();
+    gp.predicted_0.data = predicted.data(); gp.predicted_0.count = predicted.size();
+    gp.mass_0.data      = mass.data();      gp.mass_0.count      = mass.size();
+    gp.gScratch_0.data  = gScratch.data();  gp.gScratch_0.count  = gScratch.size();
+    gp.hScratch_0.data  = hScratch.data();  gp.hScratch_0.count  = hScratch.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_g[N_VERTS][3] = {
+        {-4.0f, -8.0f, -12.0f},
+        { 0.0f,  0.0f,   0.0f},
+    };
+    const float expected_h[N_VERTS][6] = {
+        {4.0f, 0.0f, 0.0f, 4.0f, 0.0f, 4.0f},
+        {2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 2.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t v, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vbd_init %s mismatch at v=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, v, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t v = 0; v < N_VERTS; ++v) {
+        for (int axis = 0; axis < 3; ++axis) check(gScratch[v][axis], expected_g[v][axis], "g", v, axis);
+        for (int j = 0; j < 6; ++j)          check(hScratch[6*v + j], expected_h[v][j],    "h", v, j);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "vbd_init: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("vbd_init: %u/%u verts OK (max_abs_diff=%g, %.1fms)\n",
+                    N_VERTS, N_VERTS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "vbd_init: %d FAIL out of %u checks\n", fails, N_VERTS * 9u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
First kernel of the AVBD vertex-block-update pipeline (#42 PR-D). Initializes per-vertex scratch buffers with the implicit-Euler inertial term before the per-constraint gather kernels accumulate their contributions.

Per vertex \`v\` with mass \`m\`, position \`x\`, predictor \`x̃\`, time-step \`h\`:

\`\`\`
w                  = m / h²
gScratch[v]        = w · (x − x̃)              -- inertial gradient
hScratch[6v..6v+5] = [w, 0, 0, w, 0, w]       -- packed sym 3x3 = w·I
\`\`\`

The packed sym 3x3 layout \`[Hxx, Hxy, Hxz, Hyy, Hyz, Hzz]\` matches what \`spring_force\` writes. Later gather kernels accumulate onto this layout, and the solve+apply kernel reads it to invert the 3x3 and write \`x ← x − H⁻¹ g\`.

\`invHSquared = 1/h²\` lives in a small \`ConstantBuffer<VbdInitParams>\`.

## Verification
\`\`\`
vbd_init: 2/2 verts OK (max_abs_diff=0, 0.0ms)
\`\`\`

## Roadmap (#42) — PR-D progress

- ✅ PR-A four constraint-force kernels (#43-46)
- ✅ PR-B AdjacencySpring (#47), K-arity adjacency (#48)
- ✅ PR-C vertex graph coloring (#49)
- **PR-D part 1 vbd_init** — this PR
- PR-D part 2 vbd_gather_spring (next)
- PR-D part 3 vbd_solve_apply
- PR-D continued vbd_gather_attachment / triangle / bending

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on 2-vert fixture (max_abs_diff=0)
- [ ] CI lean-slang validate