### PR TITLE
Add vbd_solve_apply: 3x3 inverse + position update (PR-D part 2)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -17,6 +17,7 @@ import Cloth.SlangCodegen.AttachmentForce
 import Cloth.SlangCodegen.TriangleMembraneForce
 import Cloth.SlangCodegen.TriangleBendingForce
 import Cloth.SlangCodegen.VbdInit
+import Cloth.SlangCodegen.VbdSolveApply
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/VbdSolveApply.lean
+++ b/lean/Cloth/SlangCodegen/VbdSolveApply.lean
@@ -1,0 +1,181 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdSolveApply` — AVBD per-vertex 3x3 solve + apply (PR-D part 2)
+
+Final kernel of the AVBD vertex-block-update pipeline. After `vbd_init`
+seeds inertial scratch and the per-constraint gather kernels accumulate
+their contributions (one per constraint type in PR-D part 3+), this
+kernel closes the loop: for each vertex `v`, invert the local 3x3
+Hessian, compute `Δx = −H⁻¹ g`, and update the position in place.
+
+```
+Read   g = gScratch[v]                        (float3)
+Read   H = hScratch[6v..6v+5]                 (packed sym 3x3)
+
+Compute adjugate of H (symmetric, so adj is also symmetric):
+  adj00 = Hyy·Hzz − Hyz²
+  adj11 = Hxx·Hzz − Hxz²
+  adj22 = Hxx·Hyy − Hxy²
+  adj01 = Hxz·Hyz − Hxy·Hzz
+  adj02 = Hxy·Hyz − Hxz·Hyy
+  adj12 = Hxy·Hxz − Hxx·Hyz
+
+det     = Hxx·adj00 + Hxy·adj01 + Hxz·adj02
+invDet  = 1.0 / det
+
+Δx_i    = −invDet · (adj_i0 · g.x + adj_i1 · g.y + adj_i2 · g.z)
+        = −invDet · adj · g                  -- standard adj/det
+                                                inverse, symmetric adj
+
+x_new   = positions[v] + Δx
+```
+
+Caller responsibility: ensure `H` is positive definite (well-defined
+in the AVBD step from the inertial term `m/h²·I` plus PSD constraint
+Hessians). If a constraint contributes an indefinite block, the host
+must regularize (clamp eigenvalues or add `ε·I`) before this kernel
+runs.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   gScratch    length = N_verts
+  1  StructuredBuffer<float>    hScratch    length = 6 · N_verts
+  2  RWStructuredBuffer<float3> positions   length = N_verts
+
+This kernel takes no parameter buffer — the dispatcher's launch size
+covers the active-vertex range. For coloring-aware dispatch the host
+slices the launch over `vertPerm[colorOffsets[k]..k+1)` per color.
+-/
+
+namespace Cloth.SlangCodegen.VbdSolveApply
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def body : List SlangStmt :=
+  [ .declInit u  "v"   (.member (.var "tid") "x")
+  , .declInit u  "hb"  (.bin "*" (.litUint 6) (.var "v"))
+  , .declInit f3 "g"   (.index (.var "gScratch") (.var "v"))
+  , .declInit f  "Hxx" (.index (.var "hScratch") (.var "hb"))
+  , .declInit f  "Hxy" (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 1)))
+  , .declInit f  "Hxz" (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 2)))
+  , .declInit f  "Hyy" (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3)))
+  , .declInit f  "Hyz" (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 4)))
+  , .declInit f  "Hzz" (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5)))
+  , .declInit f  "a00"
+      (.bin "-" (.bin "*" (.var "Hyy") (.var "Hzz"))
+                (.bin "*" (.var "Hyz") (.var "Hyz")))
+  , .declInit f  "a11"
+      (.bin "-" (.bin "*" (.var "Hxx") (.var "Hzz"))
+                (.bin "*" (.var "Hxz") (.var "Hxz")))
+  , .declInit f  "a22"
+      (.bin "-" (.bin "*" (.var "Hxx") (.var "Hyy"))
+                (.bin "*" (.var "Hxy") (.var "Hxy")))
+  , .declInit f  "a01"
+      (.bin "-" (.bin "*" (.var "Hxz") (.var "Hyz"))
+                (.bin "*" (.var "Hxy") (.var "Hzz")))
+  , .declInit f  "a02"
+      (.bin "-" (.bin "*" (.var "Hxy") (.var "Hyz"))
+                (.bin "*" (.var "Hxz") (.var "Hyy")))
+  , .declInit f  "a12"
+      (.bin "-" (.bin "*" (.var "Hxy") (.var "Hxz"))
+                (.bin "*" (.var "Hxx") (.var "Hyz")))
+  , .declInit f  "det"
+      (.bin "+"
+        (.bin "+" (.bin "*" (.var "Hxx") (.var "a00"))
+                  (.bin "*" (.var "Hxy") (.var "a01")))
+        (.bin "*" (.var "Hxz") (.var "a02")))
+  , .declInit f  "invDet" (.bin "/" (.litFloat 1.0) (.var "det"))
+  , .declInit f  "gx" (.member (.var "g") "x")
+  , .declInit f  "gy" (.member (.var "g") "y")
+  , .declInit f  "gz" (.member (.var "g") "z")
+  , .declInit f  "dx"
+      (.bin "*" (.bin "-" (.litFloat 0.0) (.var "invDet"))
+                (.bin "+"
+                  (.bin "+" (.bin "*" (.var "a00") (.var "gx"))
+                            (.bin "*" (.var "a01") (.var "gy")))
+                  (.bin "*" (.var "a02") (.var "gz"))))
+  , .declInit f  "dy"
+      (.bin "*" (.bin "-" (.litFloat 0.0) (.var "invDet"))
+                (.bin "+"
+                  (.bin "+" (.bin "*" (.var "a01") (.var "gx"))
+                            (.bin "*" (.var "a11") (.var "gy")))
+                  (.bin "*" (.var "a12") (.var "gz"))))
+  , .declInit f  "dz"
+      (.bin "*" (.bin "-" (.litFloat 0.0) (.var "invDet"))
+                (.bin "+"
+                  (.bin "+" (.bin "*" (.var "a02") (.var "gx"))
+                            (.bin "*" (.var "a12") (.var "gy")))
+                  (.bin "*" (.var "a22") (.var "gz"))))
+  , .declInit f3 "p" (.index (.var "positions") (.var "v"))
+  , .assign (.index (.var "positions") (.var "v"))
+      (.call "float3"
+        [ .bin "+" (.member (.var "p") "x") (.var "dx")
+        , .bin "+" (.member (.var "p") "y") (.var "dy")
+        , .bin "+" (.member (.var "p") "z") (.var "dz") ])
+  ]
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "gScratch"  (.roBuf f3)
+      , bnd 1 "hScratch"  (.roBuf f)
+      , bnd 2 "positions" (.rwBuf f3)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> gScratch;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> hScratch;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<float3> positions;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint v = tid.x;
+  uint hb = (6u * v);
+  float3 g = gScratch[v];
+  float Hxx = hScratch[hb];
+  float Hxy = hScratch[(hb + 1u)];
+  float Hxz = hScratch[(hb + 2u)];
+  float Hyy = hScratch[(hb + 3u)];
+  float Hyz = hScratch[(hb + 4u)];
+  float Hzz = hScratch[(hb + 5u)];
+  float a00 = ((Hyy * Hzz) - (Hyz * Hyz));
+  float a11 = ((Hxx * Hzz) - (Hxz * Hxz));
+  float a22 = ((Hxx * Hyy) - (Hxy * Hxy));
+  float a01 = ((Hxz * Hyz) - (Hxy * Hzz));
+  float a02 = ((Hxy * Hyz) - (Hxz * Hyy));
+  float a12 = ((Hxy * Hxz) - (Hxx * Hyz));
+  float det = (((Hxx * a00) + (Hxy * a01)) + (Hxz * a02));
+  float invDet = (1.000000 / det);
+  float gx = g.x;
+  float gy = g.y;
+  float gz = g.z;
+  float dx = ((0.000000 - invDet) * (((a00 * gx) + (a01 * gy)) + (a02 * gz)));
+  float dy = ((0.000000 - invDet) * (((a01 * gx) + (a11 * gy)) + (a12 * gz)));
+  float dz = ((0.000000 - invDet) * (((a02 * gx) + (a12 * gy)) + (a22 * gz)));
+  float3 p = positions[v];
+  positions[v] = float3((p.x + dx), (p.y + dy), (p.z + dz));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdSolveApply

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -37,6 +37,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("triangle_membrane_force", TriangleMembraneForce.shader)
   , ("triangle_bending_force", TriangleBendingForce.shader)
   , ("vbd_init",           VbdInit.shader)
+  , ("vbd_solve_apply",    VbdSolveApply.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -51,7 +51,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               attachment_force:attachment_force \
               triangle_membrane_force:triangle_membrane_force \
               triangle_bending_force:triangle_bending_force \
-              vbd_init:vbd_init
+              vbd_init:vbd_init \
+              vbd_solve_apply:vbd_solve_apply
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/vbd_solve_apply_test.cpp
+++ b/tests/slang_validate/vbd_solve_apply_test.cpp
@@ -1,0 +1,131 @@
+// Real-input validator for Cloth.SlangCodegen.VbdSolveApply —
+// final kernel of the AVBD vertex-block-update pipeline (PR-D part 2).
+//
+// Per vertex v, read g and packed sym 3x3 H from scratch, compute
+// Δx = −H⁻¹ g via closed-form adjugate/det, write positions[v] += Δx.
+//
+// Test fixture (3 verts, three different H/g combinations):
+//
+// v0:  H = 2·I (diagonal), g = (−4, −8, −12)
+//      x_start = (0, 0, 0)
+//      H⁻¹ = (1/2)·I
+//      Δx = −H⁻¹·g = (2, 4, 6)
+//      x_end = (2, 4, 6)
+//
+// v1:  H = I (diagonal), g = (0, 0, 0)   -- no displacement
+//      x_start = (5, 5, 5)
+//      Δx = 0
+//      x_end = (5, 5, 5)
+//
+// v2:  H = [[4,1,0],[1,3,0],[0,0,5]] (sym, off-diag), g = (8, 3, 10)
+//      adj00 = 3·5 − 0² = 15
+//      adj11 = 4·5 − 0² = 20
+//      adj22 = 4·3 − 1² = 11
+//      adj01 = 0·0 − 1·5 = −5
+//      adj02 = 1·0 − 0·3 = 0
+//      adj12 = 1·0 − 4·0 = 0
+//      det   = 4·15 + 1·(−5) + 0·0 = 55
+//      Δx_x  = −(1/55)·(15·8 + (−5)·3 + 0·10) = −(1/55)·(120 − 15) = −(1/55)·105 = −21/11
+//      Δx_y  = −(1/55)·((−5)·8 + 20·3 + 0·10) = −(1/55)·(−40 + 60) = −20/55 = −4/11
+//      Δx_z  = −(1/55)·(0·8 + 0·3 + 11·10) = −(1/55)·110 = −2
+//      x_start = (10, 10, 10)
+//      x_end ≈ (10 − 21/11, 10 − 4/11, 10 − 2) = (8.0909..., 9.6363..., 8)
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "vbd_solve_apply_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_VERTS   = 3;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<Vector<float, 3>> gScratch(GROUP_SIZE, Vector<float, 3>(0.0f));
+    // hScratch defaults to identity matrix per slot so padded threads
+    // don't hit a singular Hessian (det != 0).
+    std::vector<float>            hScratch(6 * GROUP_SIZE, 0.0f);
+    for (uint32_t i = 0; i < GROUP_SIZE; ++i) {
+        hScratch[6*i + 0] = 1.0f;  // Hxx
+        hScratch[6*i + 3] = 1.0f;  // Hyy
+        hScratch[6*i + 5] = 1.0f;  // Hzz
+    }
+
+    // v0
+    positions[0] = Vector<float, 3>(0.0f, 0.0f, 0.0f);
+    gScratch[0]  = Vector<float, 3>(-4.0f, -8.0f, -12.0f);
+    hScratch[0]  = 2.0f;  hScratch[3] = 2.0f;  hScratch[5] = 2.0f;
+    hScratch[1]  = 0.0f;  hScratch[2] = 0.0f;  hScratch[4] = 0.0f;
+
+    // v1
+    positions[1] = Vector<float, 3>(5.0f, 5.0f, 5.0f);
+    gScratch[1]  = Vector<float, 3>(0.0f, 0.0f, 0.0f);
+    // hScratch[6..11] stays at identity from above
+
+    // v2 with off-diagonal Hessian.
+    positions[2] = Vector<float, 3>(10.0f, 10.0f, 10.0f);
+    gScratch[2]  = Vector<float, 3>(8.0f, 3.0f, 10.0f);
+    hScratch[12] = 4.0f;  // Hxx
+    hScratch[13] = 1.0f;  // Hxy
+    hScratch[14] = 0.0f;  // Hxz
+    hScratch[15] = 3.0f;  // Hyy
+    hScratch[16] = 0.0f;  // Hyz
+    hScratch[17] = 5.0f;  // Hzz
+
+    GlobalParams_0 gp{};
+    gp.gScratch_0.data  = gScratch.data();  gp.gScratch_0.count  = gScratch.size();
+    gp.hScratch_0.data  = hScratch.data();  gp.hScratch_0.count  = hScratch.size();
+    gp.positions_0.data = positions.data(); gp.positions_0.count = positions.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_pos[N_VERTS][3] = {
+        {2.0f, 4.0f, 6.0f},
+        {5.0f, 5.0f, 5.0f},
+        {10.0f - 21.0f/11.0f, 10.0f - 4.0f/11.0f, 8.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t v = 0; v < N_VERTS; ++v) {
+        for (int axis = 0; axis < 3; ++axis) {
+            const float got = positions[v][axis];
+            const float ref = expected_pos[v][axis];
+            const float d   = std::fabs(got - ref);
+            if (d > max_abs_diff) max_abs_diff = d;
+            if (d > 1e-5f) {
+                if (fails < 5) {
+                    std::fprintf(stderr,
+                        "vbd_solve_apply mismatch at v=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                        v, axis, got, ref, d);
+                }
+                ++fails;
+            }
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "vbd_solve_apply: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("vbd_solve_apply: %u/%u verts OK (max_abs_diff=%g, %.1fms)\n",
+                    N_VERTS, N_VERTS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "vbd_solve_apply: %d FAIL out of %u checks\n", fails, N_VERTS * 3u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Final kernel of the AVBD vertex-block-update pipeline (#42 PR-D). Reads per-vertex scratch \`g\` and packed sym 3x3 \`H\` (written by \`vbd_init\` and accumulated by the per-constraint gather kernels), inverts \`H\` via closed-form adjugate/det, and writes \`positions[v] += −H⁻¹·g\` in place.

\`\`\`
adjugate (sym 3x3):
  a00 = Hyy·Hzz − Hyz²        a01 = Hxz·Hyz − Hxy·Hzz
  a11 = Hxx·Hzz − Hxz²        a02 = Hxy·Hyz − Hxz·Hyy
  a22 = Hxx·Hyy − Hxy²        a12 = Hxy·Hxz − Hxx·Hyz

det = Hxx·a00 + Hxy·a01 + Hxz·a02
Δx  = −adj·g / det
\`\`\`

Caller guarantees H is PSD: the inertial term m/h²·I contributes a strict positive-definite diagonal, and the constraint Hessians from PR-A are all PSD by construction (Gauss-Newton with target held fixed). Indefinite contributions would need regularization on the host.

## Verification
\`\`\`
vbd_solve_apply: 3/3 verts OK (max_abs_diff=0, 0.0ms)
\`\`\`

Fixture covers three Hessian shapes:
- v0: \`H = 2·I\`, diagonal, with non-zero g
- v1: \`H = I\`, zero g (no displacement)
- v2: \`H\` sym with off-diagonal element, non-trivial inverse — exact rational coords match bit-exact

## Roadmap (#42) — PR-D progress

- ✅ PR-A four constraint-force kernels (#43-46)
- ✅ PR-B AdjacencySpring (#47), K-arity adjacency (#48 open)
- ✅ PR-C vertex graph coloring (#49 open)
- ✅ PR-D part 1 vbd_init (#50 open)
- **PR-D part 2 vbd_solve_apply** — this PR
- PR-D part 3 vbd_gather_spring (next)
- PR-D continued vbd_gather_attachment / triangle / bending

Once gather lands, the three kernels compose end-to-end:
  \`vbd_init → vbd_gather_* → vbd_solve_apply\`

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on 3-vert fixture covering diagonal + off-diagonal Hessian (max_abs_diff=0)
- [ ] CI lean-slang validate