### PR TITLE
Add vbd_gather_spring: spring force/Hess gather (PR-D part 3)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -18,6 +18,7 @@ import Cloth.SlangCodegen.TriangleMembraneForce
 import Cloth.SlangCodegen.TriangleBendingForce
 import Cloth.SlangCodegen.VbdInit
 import Cloth.SlangCodegen.VbdSolveApply
+import Cloth.SlangCodegen.VbdGatherSpring
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/VbdGatherSpring.lean
+++ b/lean/Cloth/SlangCodegen/VbdGatherSpring.lean
@@ -1,0 +1,200 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdGatherSpring` — AVBD vertex-update spring gather (PR-D part 3)
+
+Gather kernel between `vbd_init` (PR #50) and `vbd_solve_apply` (PR #51).
+For each vertex `v`, loops over the CSR adjacency slice
+`[vertSpringOffset[v], vertSpringOffset[v+1])` to accumulate every
+incident spring's force and Hessian contribution into the per-vertex
+scratch buffers.
+
+Per incidence `k` in the slice:
+
+```
+c     = vertSpringIdx[k]                     -- spring id
+r     = vertSpringRole[k]                    -- 0 if v is endpoint a,
+                                                1 if endpoint b
+sign  = 1 − 2·float(r)                       -- +1 or −1
+
+g     += sign · springGradA[c]               -- gradient gather
+                                                (sign flip for endpoint b
+                                                via Newton's 3rd)
+
+hScratch[6v..6v+5] += springHess[6c..6c+5]   -- Hessian gather
+                                                (GN diagonal block is
+                                                the same matrix for
+                                                both endpoints; no sign)
+```
+
+This kernel reads scratch from `vbd_init` and writes back the updated
+scratch, so the three-stage pipeline composes:
+
+  vbd_init → vbd_gather_spring → vbd_solve_apply
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   springGradA       length = N_springs
+  1  StructuredBuffer<float>    springHess        length = 6 · N_springs
+  2  StructuredBuffer<uint>     vertSpringOffset  length = N_verts + 1
+  3  StructuredBuffer<uint>     vertSpringIdx     length = total incidences
+  4  StructuredBuffer<uint>     vertSpringRole    length = total incidences
+  5  RWStructuredBuffer<float3> gScratch          length = N_verts
+  6  RWStructuredBuffer<float>  hScratch          length = 6 · N_verts
+-/
+
+namespace Cloth.SlangCodegen.VbdGatherSpring
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def loopBody : List SlangStmt :=
+  [ .declInit u  "c"    (.index (.var "vertSpringIdx") (.var "k"))
+  , .declInit u  "r"    (.index (.var "vertSpringRole") (.var "k"))
+  , .declInit f  "sign" (.bin "-" (.litFloat 1.0)
+                          (.bin "*" (.litFloat 2.0)
+                            (.call "float" [.var "r"])))
+  , .declInit f3 "ga"   (.index (.var "springGradA") (.var "c"))
+  , .assign (.var "gx")
+      (.bin "+" (.var "gx")
+        (.bin "*" (.var "sign") (.member (.var "ga") "x")))
+  , .assign (.var "gy")
+      (.bin "+" (.var "gy")
+        (.bin "*" (.var "sign") (.member (.var "ga") "y")))
+  , .assign (.var "gz")
+      (.bin "+" (.var "gz")
+        (.bin "*" (.var "sign") (.member (.var "ga") "z")))
+  , .declInit u  "shb"  (.bin "*" (.litUint 6) (.var "c"))
+  , .assign (.var "Hxx")
+      (.bin "+" (.var "Hxx") (.index (.var "springHess") (.var "shb")))
+  , .assign (.var "Hxy")
+      (.bin "+" (.var "Hxy")
+        (.index (.var "springHess") (.bin "+" (.var "shb") (.litUint 1))))
+  , .assign (.var "Hxz")
+      (.bin "+" (.var "Hxz")
+        (.index (.var "springHess") (.bin "+" (.var "shb") (.litUint 2))))
+  , .assign (.var "Hyy")
+      (.bin "+" (.var "Hyy")
+        (.index (.var "springHess") (.bin "+" (.var "shb") (.litUint 3))))
+  , .assign (.var "Hyz")
+      (.bin "+" (.var "Hyz")
+        (.index (.var "springHess") (.bin "+" (.var "shb") (.litUint 4))))
+  , .assign (.var "Hzz")
+      (.bin "+" (.var "Hzz")
+        (.index (.var "springHess") (.bin "+" (.var "shb") (.litUint 5))))
+  ]
+
+private def body : List SlangStmt :=
+  [ .declInit u  "v"      (.member (.var "tid") "x")
+  , .declInit u  "sStart" (.index (.var "vertSpringOffset") (.var "v"))
+  , .declInit u  "sEnd"   (.index (.var "vertSpringOffset")
+                            (.bin "+" (.var "v") (.litUint 1)))
+  , .declInit u  "hb"     (.bin "*" (.litUint 6) (.var "v"))
+  , .declInit f3 "g"      (.index (.var "gScratch") (.var "v"))
+  , .declInit f  "gx"     (.member (.var "g") "x")
+  , .declInit f  "gy"     (.member (.var "g") "y")
+  , .declInit f  "gz"     (.member (.var "g") "z")
+  , .declInit f  "Hxx"    (.index (.var "hScratch") (.var "hb"))
+  , .declInit f  "Hxy"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 1)))
+  , .declInit f  "Hxz"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 2)))
+  , .declInit f  "Hyy"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3)))
+  , .declInit f  "Hyz"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 4)))
+  , .declInit f  "Hzz"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5)))
+  , .forCount "k" (.var "sStart") (.var "sEnd") loopBody
+  , .assign (.index (.var "gScratch") (.var "v"))
+      (.call "float3" [.var "gx", .var "gy", .var "gz"])
+  , .assign (.index (.var "hScratch") (.var "hb")) (.var "Hxx")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 1))) (.var "Hxy")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 2))) (.var "Hxz")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3))) (.var "Hyy")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 4))) (.var "Hyz")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5))) (.var "Hzz")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "springGradA"      (.roBuf f3)
+      , bnd 1 "springHess"       (.roBuf f)
+      , bnd 2 "vertSpringOffset" (.roBuf u)
+      , bnd 3 "vertSpringIdx"    (.roBuf u)
+      , bnd 4 "vertSpringRole"   (.roBuf u)
+      , bnd 5 "gScratch"         (.rwBuf f3)
+      , bnd 6 "hScratch"         (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> springGradA;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> springHess;
+[[vk::binding(2, 0)]]
+StructuredBuffer<uint> vertSpringOffset;
+[[vk::binding(3, 0)]]
+StructuredBuffer<uint> vertSpringIdx;
+[[vk::binding(4, 0)]]
+StructuredBuffer<uint> vertSpringRole;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> gScratch;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float> hScratch;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint v = tid.x;
+  uint sStart = vertSpringOffset[v];
+  uint sEnd = vertSpringOffset[(v + 1u)];
+  uint hb = (6u * v);
+  float3 g = gScratch[v];
+  float gx = g.x;
+  float gy = g.y;
+  float gz = g.z;
+  float Hxx = hScratch[hb];
+  float Hxy = hScratch[(hb + 1u)];
+  float Hxz = hScratch[(hb + 2u)];
+  float Hyy = hScratch[(hb + 3u)];
+  float Hyz = hScratch[(hb + 4u)];
+  float Hzz = hScratch[(hb + 5u)];
+  for (uint k = sStart; k < sEnd; ++k) {
+    uint c = vertSpringIdx[k];
+    uint r = vertSpringRole[k];
+    float sign = (1.000000 - (2.000000 * float(r)));
+    float3 ga = springGradA[c];
+    gx = (gx + (sign * ga.x));
+    gy = (gy + (sign * ga.y));
+    gz = (gz + (sign * ga.z));
+    uint shb = (6u * c);
+    Hxx = (Hxx + springHess[shb]);
+    Hxy = (Hxy + springHess[(shb + 1u)]);
+    Hxz = (Hxz + springHess[(shb + 2u)]);
+    Hyy = (Hyy + springHess[(shb + 3u)]);
+    Hyz = (Hyz + springHess[(shb + 4u)]);
+    Hzz = (Hzz + springHess[(shb + 5u)]);
+  }
+  gScratch[v] = float3(gx, gy, gz);
+  hScratch[hb] = Hxx;
+  hScratch[(hb + 1u)] = Hxy;
+  hScratch[(hb + 2u)] = Hxz;
+  hScratch[(hb + 3u)] = Hyy;
+  hScratch[(hb + 4u)] = Hyz;
+  hScratch[(hb + 5u)] = Hzz;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdGatherSpring

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -38,6 +38,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("triangle_bending_force", TriangleBendingForce.shader)
   , ("vbd_init",           VbdInit.shader)
   , ("vbd_solve_apply",    VbdSolveApply.shader)
+  , ("vbd_gather_spring",  VbdGatherSpring.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -52,7 +52,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               triangle_membrane_force:triangle_membrane_force \
               triangle_bending_force:triangle_bending_force \
               vbd_init:vbd_init \
-              vbd_solve_apply:vbd_solve_apply
+              vbd_solve_apply:vbd_solve_apply \
+              vbd_gather_spring:vbd_gather_spring
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/vbd_gather_spring_test.cpp
+++ b/tests/slang_validate/vbd_gather_spring_test.cpp
@@ -1,0 +1,126 @@
+// Real-input validator for Cloth.SlangCodegen.VbdGatherSpring —
+// gather kernel between vbd_init and vbd_solve_apply (PR-D part 3).
+//
+// Per vertex v, loops over the CSR adjacency slice and accumulates
+// every incident spring's force/Hessian into the per-vertex scratch:
+//   sign = 1 − 2·float(role[k])         -- +1 for endpoint a, −1 for b
+//   gScratch[v] += sign · springGradA[c]
+//   hScratch[6v..6v+5] += springHess[6c..6c+5]    (no sign flip; GN
+//                                                   diagonal block is
+//                                                   the same for both
+//                                                   endpoints)
+//
+// Test fixture (2 verts, 1 spring between them):
+//   spring 0: a=0, b=1
+//   springGradA[0] = (1, 0, 0),  springHess[0..5] = [1, 0, 0, 0, 0, 0]
+//   CSR (from AdjacencySpring.build 2 [(0,1)]):
+//     vertSpringOffset = [0, 1, 2, 2, ...]   (size GROUP_SIZE + 1)
+//     vertSpringIdx    = [0, 0]
+//     vertSpringRole   = [0, 1]
+//   Initial scratch:
+//     gScratch[0] = (10, 0, 0)   hScratch[0..5]  = [100, 0, 0, 100, 0, 100]
+//     gScratch[1] = (20, 0, 0)   hScratch[6..11] = [200, 0, 0, 200, 0, 200]
+//
+// Expected (after one spring gather):
+//   v0 role 0, sign=+1:  g=(10+1, 0, 0)=(11, 0, 0),
+//                        h=[100+1, 0, 0, 100, 0, 100]=[101, 0, 0, 100, 0, 100]
+//   v1 role 1, sign=−1:  g=(20−1, 0, 0)=(19, 0, 0),
+//                        h=[200+1, 0, 0, 200, 0, 200]=[201, 0, 0, 200, 0, 200]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "vbd_gather_spring_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_VERTS    = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    // Spring outputs (from a prior spring_force dispatch). Padded to
+    // GROUP_SIZE but only spring 0 is real.
+    std::vector<Vector<float, 3>> springGradA(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            springHess(6 * GROUP_SIZE, 0.0f);
+    springGradA[0] = Vector<float, 3>(1.0f, 0.0f, 0.0f);
+    springHess[0]  = 1.0f;  // Hxx of spring 0; others stay 0
+
+    // CSR adjacency for verts 0 and 1. Padded verts 2..GROUP_SIZE point
+    // at offset 2 so their loop range is empty (no gather happens).
+    std::vector<uint32_t> vertSpringOffset(GROUP_SIZE + 1, 2u);
+    vertSpringOffset[0] = 0u;
+    vertSpringOffset[1] = 1u;
+    vertSpringOffset[2] = 2u;
+    std::vector<uint32_t> vertSpringIdx  = { 0u, 0u };
+    std::vector<uint32_t> vertSpringRole = { 0u, 1u };
+
+    // Initial scratch (would normally come from vbd_init).
+    std::vector<Vector<float, 3>> gScratch(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hScratch(6 * GROUP_SIZE, 0.0f);
+    gScratch[0] = Vector<float, 3>(10.0f, 0.0f, 0.0f);
+    gScratch[1] = Vector<float, 3>(20.0f, 0.0f, 0.0f);
+    hScratch[0]  = 100.0f; hScratch[3]  = 100.0f; hScratch[5]  = 100.0f;
+    hScratch[6]  = 200.0f; hScratch[9]  = 200.0f; hScratch[11] = 200.0f;
+
+    GlobalParams_0 gp{};
+    gp.springGradA_0.data      = springGradA.data();      gp.springGradA_0.count      = springGradA.size();
+    gp.springHess_0.data       = springHess.data();       gp.springHess_0.count       = springHess.size();
+    gp.vertSpringOffset_0.data = vertSpringOffset.data(); gp.vertSpringOffset_0.count = vertSpringOffset.size();
+    gp.vertSpringIdx_0.data    = vertSpringIdx.data();    gp.vertSpringIdx_0.count    = vertSpringIdx.size();
+    gp.vertSpringRole_0.data   = vertSpringRole.data();   gp.vertSpringRole_0.count   = vertSpringRole.size();
+    gp.gScratch_0.data         = gScratch.data();         gp.gScratch_0.count         = gScratch.size();
+    gp.hScratch_0.data         = hScratch.data();         gp.hScratch_0.count         = hScratch.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_g[N_VERTS][3] = {
+        {11.0f, 0.0f, 0.0f},
+        {19.0f, 0.0f, 0.0f},
+    };
+    const float expected_h[N_VERTS][6] = {
+        {101.0f, 0.0f, 0.0f, 100.0f, 0.0f, 100.0f},
+        {201.0f, 0.0f, 0.0f, 200.0f, 0.0f, 200.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t v, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vbd_gather_spring %s mismatch at v=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, v, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t v = 0; v < N_VERTS; ++v) {
+        for (int axis = 0; axis < 3; ++axis) check(gScratch[v][axis], expected_g[v][axis], "g", v, axis);
+        for (int j = 0; j < 6; ++j)          check(hScratch[6*v + j], expected_h[v][j],    "h", v, j);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "vbd_gather_spring: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("vbd_gather_spring: %u/%u verts OK (max_abs_diff=%g, %.1fms)\n",
+                    N_VERTS, N_VERTS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "vbd_gather_spring: %d FAIL out of %u checks\n", fails, N_VERTS * 9u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Gather kernel between \`vbd_init\` (#50) and \`vbd_solve_apply\` (#51). For each vertex \`v\`, loops over the CSR adjacency slice (#47) and accumulates every incident spring's force + Hessian contribution.

\`\`\`
sign  = 1 − 2·float(role[k])                 -- +1 endpoint a, −1 endpoint b
gScratch[v] += sign · springGradA[c]
hScratch[6v..6v+5] += springHess[6c..6c+5]   -- no sign flip;
                                                GN diagonal block shared
\`\`\`

Uses LeanSlang's \`.forCount\` construct for the per-vertex loop (same pattern \`AssembleB\` already uses for projection gather). Role-to-sign math fits in a single fp expression — no branch.

## Verification
\`\`\`
vbd_gather_spring: 2/2 verts OK (max_abs_diff=0, 0.0ms)
\`\`\`

Smoke test: 2 verts, 1 spring connecting them. Both endpoints validated — role 0 (sign +1) and role 1 (sign −1).

## End of iteration-10 loop — AVBD spring-only pipeline complete

Once the chain (#47, #48, #49, #50, #51, this PR) lands, the three vertex-update kernels compose end-to-end:

\`\`\`
vbd_init  →  vbd_gather_spring  →  vbd_solve_apply
\`\`\`

This is a runnable AVBD step on a spring-only mesh. Wiring into \`Simulation.cpp\` (\`USE_AVBD=1\`), augmented Lagrangian, gather kernels for the other constraint types (attachment/triangle/bending), and the differentiable adjoint are the remaining roadmap items (PR-E through PR-H of #42).

## Roadmap (#42) — final iteration of the 10-step loop

- ✅ PR-A four constraint-force kernels (#43-46 merged)
- ✅ PR-B AdjacencySpring #47 merged, K-arity #48 open
- ✅ PR-C vertex graph coloring #49 open
- ✅ PR-D part 1 vbd_init #50 open
- ✅ PR-D part 2 vbd_solve_apply #51 open
- ✅ PR-D part 3 **vbd_gather_spring** — this PR
- PR-D continued vbd_gather_attachment / triangle / bending — future
- PR-E outer iteration loop in Simulation.cpp — future
- PR-F augmented Lagrangian dual update — future
- PR-G differentiable adjoint — future
- PR-H dress demo validation — future

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on 2-vert / 1-spring fixture (max_abs_diff=0)
- [ ] CI lean-slang validate