### PR TITLE
Add vbd_gather_attachment: K=1 gather (PR-D continued)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -19,6 +19,7 @@ import Cloth.SlangCodegen.TriangleBendingForce
 import Cloth.SlangCodegen.VbdInit
 import Cloth.SlangCodegen.VbdSolveApply
 import Cloth.SlangCodegen.VbdGatherSpring
+import Cloth.SlangCodegen.VbdGatherAttachment
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/VbdGatherAttachment.lean
+++ b/lean/Cloth/SlangCodegen/VbdGatherAttachment.lean
@@ -1,0 +1,149 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdGatherAttachment` — AVBD vertex-update attachment gather
+
+Second gather kernel in the AVBD vertex-block-update pipeline, after
+`vbd_gather_spring`. Accumulates each incident attachment's force +
+Hessian into per-vertex scratch.
+
+Attachments are the simplest constraint geometry — one vertex per
+constraint, no role question, Hessian is a scalar multiple of the
+identity. The gather therefore omits the role buffer and only adds the
+scalar to the three diagonal entries of `hScratch[6v..6v+5]`:
+
+```
+for k in [vertAttachOffset[v], vertAttachOffset[v+1]):
+  c = vertAttachIdx[k]
+  gScratch[v]      += attachGradV[c]                -- ∇_v E_c
+  hScratch[6v]     += attachHessScalar[c]           -- Hxx += k
+  hScratch[6v+3]   += attachHessScalar[c]           -- Hyy += k
+  hScratch[6v+5]   += attachHessScalar[c]           -- Hzz += k
+  -- off-diagonal entries Hxy, Hxz, Hyz are unchanged because
+  -- attachment Hessian is k · I₃
+```
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   attachGradV       length = N_attach
+  1  StructuredBuffer<float>    attachHessScalar  length = N_attach
+  2  StructuredBuffer<uint>     vertAttachOffset  length = N_verts + 1
+  3  StructuredBuffer<uint>     vertAttachIdx     length = total incidences
+  4  RWStructuredBuffer<float3> gScratch          length = N_verts
+  5  RWStructuredBuffer<float>  hScratch          length = 6 · N_verts
+
+Note the absence of a `vertAttachRole` buffer — attachment always
+has K=1, so role is implicitly 0 and contributes no sign flip.
+-/
+
+namespace Cloth.SlangCodegen.VbdGatherAttachment
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def loopBody : List SlangStmt :=
+  [ .declInit u  "c"  (.index (.var "vertAttachIdx") (.var "k"))
+  , .declInit f3 "ga" (.index (.var "attachGradV") (.var "c"))
+  , .declInit f  "hs" (.index (.var "attachHessScalar") (.var "c"))
+  , .assign (.var "gx") (.bin "+" (.var "gx") (.member (.var "ga") "x"))
+  , .assign (.var "gy") (.bin "+" (.var "gy") (.member (.var "ga") "y"))
+  , .assign (.var "gz") (.bin "+" (.var "gz") (.member (.var "ga") "z"))
+  , .assign (.var "Hxx") (.bin "+" (.var "Hxx") (.var "hs"))
+  , .assign (.var "Hyy") (.bin "+" (.var "Hyy") (.var "hs"))
+  , .assign (.var "Hzz") (.bin "+" (.var "Hzz") (.var "hs"))
+  ]
+
+private def body : List SlangStmt :=
+  [ .declInit u  "v"      (.member (.var "tid") "x")
+  , .declInit u  "sStart" (.index (.var "vertAttachOffset") (.var "v"))
+  , .declInit u  "sEnd"   (.index (.var "vertAttachOffset")
+                            (.bin "+" (.var "v") (.litUint 1)))
+  , .declInit u  "hb"     (.bin "*" (.litUint 6) (.var "v"))
+  , .declInit f3 "g"      (.index (.var "gScratch") (.var "v"))
+  , .declInit f  "gx"     (.member (.var "g") "x")
+  , .declInit f  "gy"     (.member (.var "g") "y")
+  , .declInit f  "gz"     (.member (.var "g") "z")
+  , .declInit f  "Hxx"    (.index (.var "hScratch") (.var "hb"))
+  , .declInit f  "Hyy"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3)))
+  , .declInit f  "Hzz"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5)))
+  , .forCount "k" (.var "sStart") (.var "sEnd") loopBody
+  , .assign (.index (.var "gScratch") (.var "v"))
+      (.call "float3" [.var "gx", .var "gy", .var "gz"])
+  , .assign (.index (.var "hScratch") (.var "hb")) (.var "Hxx")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3))) (.var "Hyy")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5))) (.var "Hzz")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "attachGradV"      (.roBuf f3)
+      , bnd 1 "attachHessScalar" (.roBuf f)
+      , bnd 2 "vertAttachOffset" (.roBuf u)
+      , bnd 3 "vertAttachIdx"    (.roBuf u)
+      , bnd 4 "gScratch"         (.rwBuf f3)
+      , bnd 5 "hScratch"         (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> attachGradV;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> attachHessScalar;
+[[vk::binding(2, 0)]]
+StructuredBuffer<uint> vertAttachOffset;
+[[vk::binding(3, 0)]]
+StructuredBuffer<uint> vertAttachIdx;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float3> gScratch;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> hScratch;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint v = tid.x;
+  uint sStart = vertAttachOffset[v];
+  uint sEnd = vertAttachOffset[(v + 1u)];
+  uint hb = (6u * v);
+  float3 g = gScratch[v];
+  float gx = g.x;
+  float gy = g.y;
+  float gz = g.z;
+  float Hxx = hScratch[hb];
+  float Hyy = hScratch[(hb + 3u)];
+  float Hzz = hScratch[(hb + 5u)];
+  for (uint k = sStart; k < sEnd; ++k) {
+    uint c = vertAttachIdx[k];
+    float3 ga = attachGradV[c];
+    float hs = attachHessScalar[c];
+    gx = (gx + ga.x);
+    gy = (gy + ga.y);
+    gz = (gz + ga.z);
+    Hxx = (Hxx + hs);
+    Hyy = (Hyy + hs);
+    Hzz = (Hzz + hs);
+  }
+  gScratch[v] = float3(gx, gy, gz);
+  hScratch[hb] = Hxx;
+  hScratch[(hb + 3u)] = Hyy;
+  hScratch[(hb + 5u)] = Hzz;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdGatherAttachment

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -39,6 +39,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("vbd_init",           VbdInit.shader)
   , ("vbd_solve_apply",    VbdSolveApply.shader)
   , ("vbd_gather_spring",  VbdGatherSpring.shader)
+  , ("vbd_gather_attachment", VbdGatherAttachment.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -53,7 +53,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               triangle_bending_force:triangle_bending_force \
               vbd_init:vbd_init \
               vbd_solve_apply:vbd_solve_apply \
-              vbd_gather_spring:vbd_gather_spring
+              vbd_gather_spring:vbd_gather_spring \
+              vbd_gather_attachment:vbd_gather_attachment
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/vbd_gather_attachment_test.cpp
+++ b/tests/slang_validate/vbd_gather_attachment_test.cpp
@@ -1,0 +1,122 @@
+// Real-input validator for Cloth.SlangCodegen.VbdGatherAttachment —
+// attachment gather in the AVBD vertex-block-update pipeline.
+//
+// Per vertex v, loops over the CSR adjacency slice and accumulates
+// every incident attachment's force into gScratch[v] and scalar
+// Hessian (k·I) into the three diagonal entries of hScratch.
+//
+// Test fixture (3 verts, 2 attachments):
+//   attach 0 pins v0:  gradV=(1, 2, 3),   hessScalar=5
+//   attach 1 pins v2:  gradV=(-1, 0, 0),  hessScalar=2
+//   v1 has no attachment.
+//
+//   CSR (from AdjacencyKwise.build 3 [[0], [2]]):
+//     vertAttachOffset = [0, 1, 1, 2]
+//     vertAttachIdx    = [0, 1]
+//
+//   Initial scratch (would normally come from vbd_init / earlier gathers):
+//     g[0] = (0, 0, 0)   h[0..5]  = [10, 0, 0, 10, 0, 10]
+//     g[1] = (0, 0, 0)   h[6..11] = [10, 0, 0, 10, 0, 10]
+//     g[2] = (0, 0, 0)   h[12..17]= [10, 0, 0, 10, 0, 10]
+//
+// Expected:
+//   v0:  g=(1, 2, 3),    h=[15, 0, 0, 15, 0, 15]   (+5 on Hxx/Hyy/Hzz)
+//   v1:  unchanged       h unchanged
+//   v2:  g=(-1, 0, 0),   h=[12, 0, 0, 12, 0, 12]   (+2 on Hxx/Hyy/Hzz)
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "vbd_gather_attachment_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_VERTS    = 3;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> attachGradV(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            attachHessScalar(GROUP_SIZE, 0.0f);
+    attachGradV[0]      = Vector<float, 3>(1.0f, 2.0f, 3.0f);
+    attachHessScalar[0] = 5.0f;
+    attachGradV[1]      = Vector<float, 3>(-1.0f, 0.0f, 0.0f);
+    attachHessScalar[1] = 2.0f;
+
+    std::vector<uint32_t> vertAttachOffset(GROUP_SIZE + 1, 2u);
+    vertAttachOffset[0] = 0u;
+    vertAttachOffset[1] = 1u;
+    vertAttachOffset[2] = 1u;
+    vertAttachOffset[3] = 2u;
+    std::vector<uint32_t> vertAttachIdx = { 0u, 1u };
+
+    std::vector<Vector<float, 3>> gScratch(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hScratch(6 * GROUP_SIZE, 0.0f);
+    for (uint32_t v = 0; v < N_VERTS; ++v) {
+        hScratch[6*v + 0] = 10.0f;  // Hxx
+        hScratch[6*v + 3] = 10.0f;  // Hyy
+        hScratch[6*v + 5] = 10.0f;  // Hzz
+    }
+
+    GlobalParams_0 gp{};
+    gp.attachGradV_0.data      = attachGradV.data();      gp.attachGradV_0.count      = attachGradV.size();
+    gp.attachHessScalar_0.data = attachHessScalar.data(); gp.attachHessScalar_0.count = attachHessScalar.size();
+    gp.vertAttachOffset_0.data = vertAttachOffset.data(); gp.vertAttachOffset_0.count = vertAttachOffset.size();
+    gp.vertAttachIdx_0.data    = vertAttachIdx.data();    gp.vertAttachIdx_0.count    = vertAttachIdx.size();
+    gp.gScratch_0.data         = gScratch.data();         gp.gScratch_0.count         = gScratch.size();
+    gp.hScratch_0.data         = hScratch.data();         gp.hScratch_0.count         = hScratch.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_g[N_VERTS][3] = {
+        { 1.0f,  2.0f, 3.0f},
+        { 0.0f,  0.0f, 0.0f},
+        {-1.0f,  0.0f, 0.0f},
+    };
+    const float expected_h[N_VERTS][6] = {
+        {15.0f, 0.0f, 0.0f, 15.0f, 0.0f, 15.0f},
+        {10.0f, 0.0f, 0.0f, 10.0f, 0.0f, 10.0f},
+        {12.0f, 0.0f, 0.0f, 12.0f, 0.0f, 12.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t v, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vbd_gather_attachment %s mismatch at v=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, v, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t v = 0; v < N_VERTS; ++v) {
+        for (int axis = 0; axis < 3; ++axis) check(gScratch[v][axis], expected_g[v][axis], "g", v, axis);
+        for (int j = 0; j < 6; ++j)          check(hScratch[6*v + j], expected_h[v][j],    "h", v, j);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "vbd_gather_attachment: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("vbd_gather_attachment: %u/%u verts OK (max_abs_diff=%g, %.1fms)\n",
+                    N_VERTS, N_VERTS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "vbd_gather_attachment: %d FAIL out of %u checks\n", fails, N_VERTS * 9u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Second gather kernel of the AVBD vertex-block-update pipeline, after \`vbd_gather_spring\` (#52). Accumulates each incident attachment's force + scalar Hessian into per-vertex scratch.

Attachments are K=1 (no role flip) and Hessian is k·I₃ (one scalar). The gather omits the role buffer and only touches the three diagonal entries of hScratch:

\`\`\`
gScratch[v]    += attachGradV[c]
hScratch[6v+0] += attachHessScalar[c]   -- Hxx += k
hScratch[6v+3] += attachHessScalar[c]   -- Hyy += k
hScratch[6v+5] += attachHessScalar[c]   -- Hzz += k
\`\`\`

Off-diagonal entries Hxy/Hxz/Hyz unchanged.

## Verification
\`\`\`
vbd_gather_attachment: 3/3 verts OK (max_abs_diff=0, 0.0ms)
\`\`\`

3-vert fixture covers attached (v0, v2) and unattached (v1) cases. Bit-exact.

## Pipeline status
Pipeline now supports gathers for: **springs + attachments**.
Remaining gathers: triangle membrane (K=3), bending (K=4).

## Roadmap (#42) — PR-D progress

- ✅ PR-D part 1 vbd_init (#50 merged)
- ✅ PR-D part 2 vbd_solve_apply (#51 merged)
- ✅ PR-D part 3 vbd_gather_spring (#52 merged)
- ✅ PR-D continued **vbd_gather_attachment** — this PR
- PR-D continued vbd_gather_triangle (K=3) — next
- PR-D continued vbd_gather_bending (K=4)
- PR-E outer iteration loop in Simulation.cpp

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on 3-vert / 2-attachment fixture
- [ ] CI lean-slang validate