### PR TITLE
Add vbd_gather_triangle: K=3 membrane gather (PR-D continued)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -20,6 +20,7 @@ import Cloth.SlangCodegen.VbdInit
 import Cloth.SlangCodegen.VbdSolveApply
 import Cloth.SlangCodegen.VbdGatherSpring
 import Cloth.SlangCodegen.VbdGatherAttachment
+import Cloth.SlangCodegen.VbdGatherTriangle
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/VbdGatherTriangle.lean
+++ b/lean/Cloth/SlangCodegen/VbdGatherTriangle.lean
@@ -1,0 +1,158 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdGatherTriangle` — AVBD vertex-update triangle membrane gather
+
+Third gather kernel of the AVBD vertex-block-update pipeline. For each
+vertex v, loops over the CSR adjacency slice and accumulates every
+incident triangle membrane constraint's force + scalar Hessian into
+per-vertex scratch.
+
+`triangle_membrane_force` writes per-corner outputs indexed as
+`[3·c + r]` for triangle c, role r ∈ {0, 1, 2}. The gather reads the
+right slot via the role buffer:
+
+```
+for k in [vertTriOffset[v], vertTriOffset[v+1]):
+  c    = vertTriIdx[k]
+  r    = vertTriRole[k]                          -- 0, 1, or 2
+  gi   = 3·c + r
+  gScratch[v]    += triGrad[gi]
+  hScratch[6v+0] += triHessScalar[gi]            -- Hxx
+  hScratch[6v+3] += triHessScalar[gi]            -- Hyy
+  hScratch[6v+5] += triHessScalar[gi]            -- Hzz
+```
+
+Same scalar-on-diagonal Hessian as attachment_force — the GN
+approximation for the ARAP membrane energy reduces each per-vertex
+block to `scalar · I₃`. Off-diagonal entries are unchanged.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   triGrad         length = 3 · N_tri
+  1  StructuredBuffer<float>    triHessScalar   length = 3 · N_tri
+  2  StructuredBuffer<uint>     vertTriOffset   length = N_verts + 1
+  3  StructuredBuffer<uint>     vertTriIdx      length = total incidences
+  4  StructuredBuffer<uint>     vertTriRole     length = total incidences
+  5  RWStructuredBuffer<float3> gScratch        length = N_verts
+  6  RWStructuredBuffer<float>  hScratch        length = 6 · N_verts
+-/
+
+namespace Cloth.SlangCodegen.VbdGatherTriangle
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def loopBody : List SlangStmt :=
+  [ .declInit u  "c"  (.index (.var "vertTriIdx") (.var "k"))
+  , .declInit u  "r"  (.index (.var "vertTriRole") (.var "k"))
+  , .declInit u  "gi" (.bin "+" (.bin "*" (.litUint 3) (.var "c")) (.var "r"))
+  , .declInit f3 "ga" (.index (.var "triGrad") (.var "gi"))
+  , .declInit f  "hs" (.index (.var "triHessScalar") (.var "gi"))
+  , .assign (.var "gx") (.bin "+" (.var "gx") (.member (.var "ga") "x"))
+  , .assign (.var "gy") (.bin "+" (.var "gy") (.member (.var "ga") "y"))
+  , .assign (.var "gz") (.bin "+" (.var "gz") (.member (.var "ga") "z"))
+  , .assign (.var "Hxx") (.bin "+" (.var "Hxx") (.var "hs"))
+  , .assign (.var "Hyy") (.bin "+" (.var "Hyy") (.var "hs"))
+  , .assign (.var "Hzz") (.bin "+" (.var "Hzz") (.var "hs"))
+  ]
+
+private def body : List SlangStmt :=
+  [ .declInit u  "v"      (.member (.var "tid") "x")
+  , .declInit u  "sStart" (.index (.var "vertTriOffset") (.var "v"))
+  , .declInit u  "sEnd"   (.index (.var "vertTriOffset")
+                            (.bin "+" (.var "v") (.litUint 1)))
+  , .declInit u  "hb"     (.bin "*" (.litUint 6) (.var "v"))
+  , .declInit f3 "g"      (.index (.var "gScratch") (.var "v"))
+  , .declInit f  "gx"     (.member (.var "g") "x")
+  , .declInit f  "gy"     (.member (.var "g") "y")
+  , .declInit f  "gz"     (.member (.var "g") "z")
+  , .declInit f  "Hxx"    (.index (.var "hScratch") (.var "hb"))
+  , .declInit f  "Hyy"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3)))
+  , .declInit f  "Hzz"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5)))
+  , .forCount "k" (.var "sStart") (.var "sEnd") loopBody
+  , .assign (.index (.var "gScratch") (.var "v"))
+      (.call "float3" [.var "gx", .var "gy", .var "gz"])
+  , .assign (.index (.var "hScratch") (.var "hb")) (.var "Hxx")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3))) (.var "Hyy")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5))) (.var "Hzz")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "triGrad"        (.roBuf f3)
+      , bnd 1 "triHessScalar"  (.roBuf f)
+      , bnd 2 "vertTriOffset"  (.roBuf u)
+      , bnd 3 "vertTriIdx"     (.roBuf u)
+      , bnd 4 "vertTriRole"    (.roBuf u)
+      , bnd 5 "gScratch"       (.rwBuf f3)
+      , bnd 6 "hScratch"       (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> triGrad;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> triHessScalar;
+[[vk::binding(2, 0)]]
+StructuredBuffer<uint> vertTriOffset;
+[[vk::binding(3, 0)]]
+StructuredBuffer<uint> vertTriIdx;
+[[vk::binding(4, 0)]]
+StructuredBuffer<uint> vertTriRole;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> gScratch;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float> hScratch;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint v = tid.x;
+  uint sStart = vertTriOffset[v];
+  uint sEnd = vertTriOffset[(v + 1u)];
+  uint hb = (6u * v);
+  float3 g = gScratch[v];
+  float gx = g.x;
+  float gy = g.y;
+  float gz = g.z;
+  float Hxx = hScratch[hb];
+  float Hyy = hScratch[(hb + 3u)];
+  float Hzz = hScratch[(hb + 5u)];
+  for (uint k = sStart; k < sEnd; ++k) {
+    uint c = vertTriIdx[k];
+    uint r = vertTriRole[k];
+    uint gi = ((3u * c) + r);
+    float3 ga = triGrad[gi];
+    float hs = triHessScalar[gi];
+    gx = (gx + ga.x);
+    gy = (gy + ga.y);
+    gz = (gz + ga.z);
+    Hxx = (Hxx + hs);
+    Hyy = (Hyy + hs);
+    Hzz = (Hzz + hs);
+  }
+  gScratch[v] = float3(gx, gy, gz);
+  hScratch[hb] = Hxx;
+  hScratch[(hb + 3u)] = Hyy;
+  hScratch[(hb + 5u)] = Hzz;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdGatherTriangle

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -40,6 +40,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("vbd_solve_apply",    VbdSolveApply.shader)
   , ("vbd_gather_spring",  VbdGatherSpring.shader)
   , ("vbd_gather_attachment", VbdGatherAttachment.shader)
+  , ("vbd_gather_triangle", VbdGatherTriangle.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -54,7 +54,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               vbd_init:vbd_init \
               vbd_solve_apply:vbd_solve_apply \
               vbd_gather_spring:vbd_gather_spring \
-              vbd_gather_attachment:vbd_gather_attachment
+              vbd_gather_attachment:vbd_gather_attachment \
+              vbd_gather_triangle:vbd_gather_triangle
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/vbd_gather_triangle_test.cpp
+++ b/tests/slang_validate/vbd_gather_triangle_test.cpp
@@ -1,0 +1,118 @@
+// Real-input validator for Cloth.SlangCodegen.VbdGatherTriangle —
+// triangle-membrane gather (K=3) in the AVBD vertex-block-update pipeline.
+//
+// Per vertex v, loops over the CSR adjacency slice and accumulates each
+// incident triangle's per-corner force + scalar Hessian (at slot
+// 3·c + r) into per-vertex scratch.
+//
+// Test fixture (3 verts, 1 triangle T0=(0,1,2)):
+//   triGrad[3*0+0..2] = [(1,0,0), (0,1,0), (0,0,1)]
+//   triHessScalar[3*0+0..2] = [3, 4, 5]
+//
+//   CSR (from AdjacencyKwise.build 3 [[0,1,2]]):
+//     vertTriOffset = [0, 1, 2, 3]
+//     vertTriIdx    = [0, 0, 0]
+//     vertTriRole   = [0, 1, 2]
+//
+//   Initial scratch all zero.
+//
+// Expected:
+//   v0:  g=(1,0,0), h=[3, 0, 0, 3, 0, 3]   (role 0 picks slot 0)
+//   v1:  g=(0,1,0), h=[4, 0, 0, 4, 0, 4]   (role 1 picks slot 1)
+//   v2:  g=(0,0,1), h=[5, 0, 0, 5, 0, 5]   (role 2 picks slot 2)
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "vbd_gather_triangle_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_VERTS    = 3;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> triGrad(3 * GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            triHessScalar(3 * GROUP_SIZE, 0.0f);
+    triGrad[0] = Vector<float, 3>(1.0f, 0.0f, 0.0f);
+    triGrad[1] = Vector<float, 3>(0.0f, 1.0f, 0.0f);
+    triGrad[2] = Vector<float, 3>(0.0f, 0.0f, 1.0f);
+    triHessScalar[0] = 3.0f;
+    triHessScalar[1] = 4.0f;
+    triHessScalar[2] = 5.0f;
+
+    std::vector<uint32_t> vertTriOffset(GROUP_SIZE + 1, 3u);
+    vertTriOffset[0] = 0u;
+    vertTriOffset[1] = 1u;
+    vertTriOffset[2] = 2u;
+    vertTriOffset[3] = 3u;
+    std::vector<uint32_t> vertTriIdx  = { 0u, 0u, 0u };
+    std::vector<uint32_t> vertTriRole = { 0u, 1u, 2u };
+
+    std::vector<Vector<float, 3>> gScratch(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hScratch(6 * GROUP_SIZE, 0.0f);
+
+    GlobalParams_0 gp{};
+    gp.triGrad_0.data       = triGrad.data();       gp.triGrad_0.count       = triGrad.size();
+    gp.triHessScalar_0.data = triHessScalar.data(); gp.triHessScalar_0.count = triHessScalar.size();
+    gp.vertTriOffset_0.data = vertTriOffset.data(); gp.vertTriOffset_0.count = vertTriOffset.size();
+    gp.vertTriIdx_0.data    = vertTriIdx.data();    gp.vertTriIdx_0.count    = vertTriIdx.size();
+    gp.vertTriRole_0.data   = vertTriRole.data();   gp.vertTriRole_0.count   = vertTriRole.size();
+    gp.gScratch_0.data      = gScratch.data();      gp.gScratch_0.count      = gScratch.size();
+    gp.hScratch_0.data      = hScratch.data();      gp.hScratch_0.count      = hScratch.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_g[N_VERTS][3] = {
+        {1.0f, 0.0f, 0.0f},
+        {0.0f, 1.0f, 0.0f},
+        {0.0f, 0.0f, 1.0f},
+    };
+    const float expected_h[N_VERTS][6] = {
+        {3.0f, 0.0f, 0.0f, 3.0f, 0.0f, 3.0f},
+        {4.0f, 0.0f, 0.0f, 4.0f, 0.0f, 4.0f},
+        {5.0f, 0.0f, 0.0f, 5.0f, 0.0f, 5.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t v, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vbd_gather_triangle %s mismatch at v=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, v, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t v = 0; v < N_VERTS; ++v) {
+        for (int axis = 0; axis < 3; ++axis) check(gScratch[v][axis], expected_g[v][axis], "g", v, axis);
+        for (int j = 0; j < 6; ++j)          check(hScratch[6*v + j], expected_h[v][j],    "h", v, j);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "vbd_gather_triangle: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("vbd_gather_triangle: %u/%u verts OK (max_abs_diff=%g, %.1fms)\n",
+                    N_VERTS, N_VERTS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "vbd_gather_triangle: %d FAIL out of %u checks\n", fails, N_VERTS * 9u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Third gather kernel of the AVBD vertex-block-update pipeline. For each vertex \`v\`, loops over the CSR adjacency slice and accumulates each incident triangle's per-corner force + scalar Hessian into per-vertex scratch.

Same scalar·I₃ Hessian shape as attachment (membrane GN approximation gives scalar diagonal blocks); difference is the lookup index — \`3·c + r\` because \`triangle_membrane_force\` writes 3 outputs per triangle.

\`\`\`
for k in [vertTriOffset[v], vertTriOffset[v+1]):
  c    = vertTriIdx[k]
  r    = vertTriRole[k]
  gi   = 3·c + r
  gScratch[v]    += triGrad[gi]
  hScratch[6v+0] += triHessScalar[gi]    -- Hxx
  hScratch[6v+3] += triHessScalar[gi]    -- Hyy
  hScratch[6v+5] += triHessScalar[gi]    -- Hzz
\`\`\`

## Verification
\`\`\`
vbd_gather_triangle: 3/3 verts OK (max_abs_diff=0, 0.0ms)
\`\`\`

3-vert / 1-triangle fixture exercises all three roles (0, 1, 2). Bit-exact.

## Pipeline status
Pipeline now supports gathers for: **springs, attachments, triangle membrane**.
Remaining: bending (K=4) — same kernel shape with \`4·c + r\` indexing.

## Roadmap (#42) — PR-D progress

- ✅ PR-D part 1 vbd_init (#50)
- ✅ PR-D part 2 vbd_solve_apply (#51)
- ✅ PR-D part 3 vbd_gather_spring (#52)
- 🟡 PR-D continued vbd_gather_attachment (#53)
- ✅ PR-D continued **vbd_gather_triangle** — this PR
- PR-D continued vbd_gather_bending (K=4) — next
- PR-E outer iteration loop in Simulation.cpp

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on 3-vert / 1-triangle fixture
- [ ] CI lean-slang validate