### PR TITLE
Add vbd_gather_bending: K=4 gather (PR-D vertex-block-update COMPLETE)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -21,6 +21,7 @@ import Cloth.SlangCodegen.VbdSolveApply
 import Cloth.SlangCodegen.VbdGatherSpring
 import Cloth.SlangCodegen.VbdGatherAttachment
 import Cloth.SlangCodegen.VbdGatherTriangle
+import Cloth.SlangCodegen.VbdGatherBending
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/VbdGatherBending.lean
+++ b/lean/Cloth/SlangCodegen/VbdGatherBending.lean
@@ -1,0 +1,161 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdGatherBending` — AVBD vertex-update dihedral bending gather
+
+Fourth and final gather kernel of the AVBD vertex-block-update
+pipeline. Same shape as `vbd_gather_triangle` (#54) but K=4 — the
+dihedral bending constraint has a 4-vertex stencil and
+`triangle_bending_force` writes its per-vertex outputs indexed as
+`[4·c + r]` for r ∈ {0, 1, 2, 3}.
+
+```
+for k in [vertBendOffset[v], vertBendOffset[v+1]):
+  c    = vertBendIdx[k]
+  r    = vertBendRole[k]                         -- 0, 1, 2, or 3
+  gi   = 4·c + r
+  gScratch[v]    += bendGrad[gi]
+  hScratch[6v+0] += bendHessScalar[gi]           -- Hxx
+  hScratch[6v+3] += bendHessScalar[gi]           -- Hyy
+  hScratch[6v+5] += bendHessScalar[gi]           -- Hzz
+```
+
+Diagonal-scalar Hessian, same as attachment/triangle. With this gather
+landed, the AVBD vertex-block-update pipeline covers every constraint
+type DiffCloth uses: spring, attachment, triangle membrane, and dihedral
+bending. Full composition:
+
+  vbd_init →
+    vbd_gather_spring → vbd_gather_attachment →
+    vbd_gather_triangle → vbd_gather_bending →
+    vbd_solve_apply
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   bendGrad        length = 4 · N_bend
+  1  StructuredBuffer<float>    bendHessScalar  length = 4 · N_bend
+  2  StructuredBuffer<uint>     vertBendOffset  length = N_verts + 1
+  3  StructuredBuffer<uint>     vertBendIdx     length = total incidences
+  4  StructuredBuffer<uint>     vertBendRole    length = total incidences
+  5  RWStructuredBuffer<float3> gScratch        length = N_verts
+  6  RWStructuredBuffer<float>  hScratch        length = 6 · N_verts
+-/
+
+namespace Cloth.SlangCodegen.VbdGatherBending
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def loopBody : List SlangStmt :=
+  [ .declInit u  "c"  (.index (.var "vertBendIdx") (.var "k"))
+  , .declInit u  "r"  (.index (.var "vertBendRole") (.var "k"))
+  , .declInit u  "gi" (.bin "+" (.bin "*" (.litUint 4) (.var "c")) (.var "r"))
+  , .declInit f3 "ga" (.index (.var "bendGrad") (.var "gi"))
+  , .declInit f  "hs" (.index (.var "bendHessScalar") (.var "gi"))
+  , .assign (.var "gx") (.bin "+" (.var "gx") (.member (.var "ga") "x"))
+  , .assign (.var "gy") (.bin "+" (.var "gy") (.member (.var "ga") "y"))
+  , .assign (.var "gz") (.bin "+" (.var "gz") (.member (.var "ga") "z"))
+  , .assign (.var "Hxx") (.bin "+" (.var "Hxx") (.var "hs"))
+  , .assign (.var "Hyy") (.bin "+" (.var "Hyy") (.var "hs"))
+  , .assign (.var "Hzz") (.bin "+" (.var "Hzz") (.var "hs"))
+  ]
+
+private def body : List SlangStmt :=
+  [ .declInit u  "v"      (.member (.var "tid") "x")
+  , .declInit u  "sStart" (.index (.var "vertBendOffset") (.var "v"))
+  , .declInit u  "sEnd"   (.index (.var "vertBendOffset")
+                            (.bin "+" (.var "v") (.litUint 1)))
+  , .declInit u  "hb"     (.bin "*" (.litUint 6) (.var "v"))
+  , .declInit f3 "g"      (.index (.var "gScratch") (.var "v"))
+  , .declInit f  "gx"     (.member (.var "g") "x")
+  , .declInit f  "gy"     (.member (.var "g") "y")
+  , .declInit f  "gz"     (.member (.var "g") "z")
+  , .declInit f  "Hxx"    (.index (.var "hScratch") (.var "hb"))
+  , .declInit f  "Hyy"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3)))
+  , .declInit f  "Hzz"    (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5)))
+  , .forCount "k" (.var "sStart") (.var "sEnd") loopBody
+  , .assign (.index (.var "gScratch") (.var "v"))
+      (.call "float3" [.var "gx", .var "gy", .var "gz"])
+  , .assign (.index (.var "hScratch") (.var "hb")) (.var "Hxx")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 3))) (.var "Hyy")
+  , .assign (.index (.var "hScratch") (.bin "+" (.var "hb") (.litUint 5))) (.var "Hzz")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "bendGrad"        (.roBuf f3)
+      , bnd 1 "bendHessScalar"  (.roBuf f)
+      , bnd 2 "vertBendOffset"  (.roBuf u)
+      , bnd 3 "vertBendIdx"     (.roBuf u)
+      , bnd 4 "vertBendRole"    (.roBuf u)
+      , bnd 5 "gScratch"        (.rwBuf f3)
+      , bnd 6 "hScratch"        (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> bendGrad;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> bendHessScalar;
+[[vk::binding(2, 0)]]
+StructuredBuffer<uint> vertBendOffset;
+[[vk::binding(3, 0)]]
+StructuredBuffer<uint> vertBendIdx;
+[[vk::binding(4, 0)]]
+StructuredBuffer<uint> vertBendRole;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> gScratch;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float> hScratch;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint v = tid.x;
+  uint sStart = vertBendOffset[v];
+  uint sEnd = vertBendOffset[(v + 1u)];
+  uint hb = (6u * v);
+  float3 g = gScratch[v];
+  float gx = g.x;
+  float gy = g.y;
+  float gz = g.z;
+  float Hxx = hScratch[hb];
+  float Hyy = hScratch[(hb + 3u)];
+  float Hzz = hScratch[(hb + 5u)];
+  for (uint k = sStart; k < sEnd; ++k) {
+    uint c = vertBendIdx[k];
+    uint r = vertBendRole[k];
+    uint gi = ((4u * c) + r);
+    float3 ga = bendGrad[gi];
+    float hs = bendHessScalar[gi];
+    gx = (gx + ga.x);
+    gy = (gy + ga.y);
+    gz = (gz + ga.z);
+    Hxx = (Hxx + hs);
+    Hyy = (Hyy + hs);
+    Hzz = (Hzz + hs);
+  }
+  gScratch[v] = float3(gx, gy, gz);
+  hScratch[hb] = Hxx;
+  hScratch[(hb + 3u)] = Hyy;
+  hScratch[(hb + 5u)] = Hzz;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdGatherBending

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -41,6 +41,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("vbd_gather_spring",  VbdGatherSpring.shader)
   , ("vbd_gather_attachment", VbdGatherAttachment.shader)
   , ("vbd_gather_triangle", VbdGatherTriangle.shader)
+  , ("vbd_gather_bending", VbdGatherBending.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -55,7 +55,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               vbd_solve_apply:vbd_solve_apply \
               vbd_gather_spring:vbd_gather_spring \
               vbd_gather_attachment:vbd_gather_attachment \
-              vbd_gather_triangle:vbd_gather_triangle
+              vbd_gather_triangle:vbd_gather_triangle \
+              vbd_gather_bending:vbd_gather_bending
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/vbd_gather_bending_test.cpp
+++ b/tests/slang_validate/vbd_gather_bending_test.cpp
@@ -1,0 +1,122 @@
+// Real-input validator for Cloth.SlangCodegen.VbdGatherBending —
+// dihedral-bending gather (K=4) in the AVBD vertex-block-update pipeline.
+//
+// Same shape as vbd_gather_triangle (#54) but K=4: the bending stencil
+// touches 4 vertices and triangle_bending_force writes per-vertex outputs
+// at slot 4·c + r.
+//
+// Test fixture (4 verts, 1 bending constraint B0=(0,1,2,3)):
+//   bendGrad[4*0+0..3] = [(1,0,0), (0,1,0), (0,0,1), (1,1,1)]
+//   bendHessScalar     = [2, 3, 5, 7]
+//
+//   CSR (from AdjacencyKwise.build 4 [[0,1,2,3]]):
+//     vertBendOffset = [0, 1, 2, 3, 4]
+//     vertBendIdx    = [0, 0, 0, 0]
+//     vertBendRole   = [0, 1, 2, 3]
+//
+// Expected (initial scratch zero):
+//   v0: g=(1,0,0), h_diag=2    (role 0 → slot 0)
+//   v1: g=(0,1,0), h_diag=3    (role 1 → slot 1)
+//   v2: g=(0,0,1), h_diag=5    (role 2 → slot 2)
+//   v3: g=(1,1,1), h_diag=7    (role 3 → slot 3)
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "vbd_gather_bending_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_VERTS    = 4;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> bendGrad(4 * GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            bendHessScalar(4 * GROUP_SIZE, 0.0f);
+    bendGrad[0] = Vector<float, 3>(1.0f, 0.0f, 0.0f);
+    bendGrad[1] = Vector<float, 3>(0.0f, 1.0f, 0.0f);
+    bendGrad[2] = Vector<float, 3>(0.0f, 0.0f, 1.0f);
+    bendGrad[3] = Vector<float, 3>(1.0f, 1.0f, 1.0f);
+    bendHessScalar[0] = 2.0f;
+    bendHessScalar[1] = 3.0f;
+    bendHessScalar[2] = 5.0f;
+    bendHessScalar[3] = 7.0f;
+
+    std::vector<uint32_t> vertBendOffset(GROUP_SIZE + 1, 4u);
+    vertBendOffset[0] = 0u;
+    vertBendOffset[1] = 1u;
+    vertBendOffset[2] = 2u;
+    vertBendOffset[3] = 3u;
+    vertBendOffset[4] = 4u;
+    std::vector<uint32_t> vertBendIdx  = { 0u, 0u, 0u, 0u };
+    std::vector<uint32_t> vertBendRole = { 0u, 1u, 2u, 3u };
+
+    std::vector<Vector<float, 3>> gScratch(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hScratch(6 * GROUP_SIZE, 0.0f);
+
+    GlobalParams_0 gp{};
+    gp.bendGrad_0.data       = bendGrad.data();       gp.bendGrad_0.count       = bendGrad.size();
+    gp.bendHessScalar_0.data = bendHessScalar.data(); gp.bendHessScalar_0.count = bendHessScalar.size();
+    gp.vertBendOffset_0.data = vertBendOffset.data(); gp.vertBendOffset_0.count = vertBendOffset.size();
+    gp.vertBendIdx_0.data    = vertBendIdx.data();    gp.vertBendIdx_0.count    = vertBendIdx.size();
+    gp.vertBendRole_0.data   = vertBendRole.data();   gp.vertBendRole_0.count   = vertBendRole.size();
+    gp.gScratch_0.data       = gScratch.data();       gp.gScratch_0.count       = gScratch.size();
+    gp.hScratch_0.data       = hScratch.data();       gp.hScratch_0.count       = hScratch.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_g[N_VERTS][3] = {
+        {1.0f, 0.0f, 0.0f},
+        {0.0f, 1.0f, 0.0f},
+        {0.0f, 0.0f, 1.0f},
+        {1.0f, 1.0f, 1.0f},
+    };
+    const float expected_h[N_VERTS][6] = {
+        {2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 2.0f},
+        {3.0f, 0.0f, 0.0f, 3.0f, 0.0f, 3.0f},
+        {5.0f, 0.0f, 0.0f, 5.0f, 0.0f, 5.0f},
+        {7.0f, 0.0f, 0.0f, 7.0f, 0.0f, 7.0f},
+    };
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t v, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vbd_gather_bending %s mismatch at v=%u, axis=%d: got %g, expected %g (diff %g)\n",
+                    label, v, axis, got, ref, d);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t v = 0; v < N_VERTS; ++v) {
+        for (int axis = 0; axis < 3; ++axis) check(gScratch[v][axis], expected_g[v][axis], "g", v, axis);
+        for (int j = 0; j < 6; ++j)          check(hScratch[6*v + j], expected_h[v][j],    "h", v, j);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "vbd_gather_bending: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("vbd_gather_bending: %u/%u verts OK (max_abs_diff=%g, %.1fms)\n",
+                    N_VERTS, N_VERTS, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "vbd_gather_bending: %d FAIL out of %u checks\n", fails, N_VERTS * 9u);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Fourth and final gather kernel of the AVBD vertex-block-update pipeline. Same shape as \`vbd_gather_triangle\` (#54) but K=4 — the dihedral bending stencil touches 4 vertices and \`triangle_bending_force\` writes per-vertex outputs at slot \`4·c + r\`.

\`\`\`
for k in [vertBendOffset[v], vertBendOffset[v+1]):
  c    = vertBendIdx[k]
  r    = vertBendRole[k]                         -- 0, 1, 2, or 3
  gi   = 4·c + r
  gScratch[v]    += bendGrad[gi]
  hScratch[6v+0] += bendHessScalar[gi]    -- Hxx
  hScratch[6v+3] += bendHessScalar[gi]    -- Hyy
  hScratch[6v+5] += bendHessScalar[gi]    -- Hzz
\`\`\`

## Verification
\`\`\`
vbd_gather_bending: 4/4 verts OK (max_abs_diff=0, 0.0ms)
\`\`\`

4-vert / 1-bending fixture exercises all four roles (0, 1, 2, 3). Bit-exact.

## Pipeline complete

With this kernel landed, **the AVBD vertex-block-update pipeline now covers every constraint type DiffCloth uses**. Full composition:

\`\`\`
vbd_init
  → vbd_gather_spring     (springs)
  → vbd_gather_attachment (single-vertex pins)
  → vbd_gather_triangle   (membrane, 3-corner stencils)
  → vbd_gather_bending    (dihedral, 4-vertex stencils)
  → vbd_solve_apply       (3x3 inverse + position update)
\`\`\`

Each kernel runs one thread per vertex within a color batch (PR-C coloring); the host dispatches one color at a time, so all writes to scratch are race-free.

## Roadmap (#42) — PR-D COMPLETE

- ✅ PR-A four constraint-force kernels (#43–46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D vbd_init (#50), vbd_solve_apply (#51), vbd_gather_spring (#52)
- 🟡 PR-D vbd_gather_attachment (#53), vbd_gather_triangle (#54)
- ✅ **PR-D vbd_gather_bending** — this PR  ← **PR-D complete**

Remaining roadmap items:
- PR-E outer iteration loop in Simulation.cpp (\`USE_AVBD=1\` wiring)
- PR-F augmented Lagrangian dual update (the "A" in AVBD)
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on 4-vert / 1-bending fixture
- [ ] CI lean-slang validate