### PR TITLE
Add AvbdSolver stub: loads all 6 AVBD kernels (PR-E start)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -1,0 +1,62 @@
+// AvbdSolver — pure-C++ interface to the Slang/Metal AVBD
+// vertex-block-update pipeline (vbd_init + 4 gather kernels +
+// vbd_solve_apply). Wraps the Metal dispatcher so DiffCloth's
+// simulation code can call into the AVBD path without pulling
+// Foundation/Metal headers into Eigen-using TUs.
+//
+// This PR (PR-E stub) ships only the constructor — it loads the
+// six kernel metallibs and reports `ok()` if all PSOs built. The
+// per-step `step()` dispatch is intentionally a no-op stub that
+// returns immediately; the actual GPU loop wiring lands in follow-up
+// PRs (PR-E continued, then PR-F augmented Lagrangian).
+//
+// AVBD is one algorithm covering cloth, attachment, triangle membrane,
+// and dihedral bending in a single per-vertex block update. See
+// todo.md for the full roadmap.
+//
+// Lifecycle:
+//   - Construct once per simulation scene (loads metallibs, builds PSOs).
+//   - `step()` per timestep — currently a stub.
+//   - Destruct to free Metal resources.
+
+#ifndef CLOTH_AVBD_SOLVER_H
+#define CLOTH_AVBD_SOLVER_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cloth {
+
+class AvbdSolver {
+public:
+    // Construct from a metallib directory path. The directory must
+    // contain all six AVBD kernels:
+    //   vbd_init.metallib
+    //   vbd_gather_spring.metallib
+    //   vbd_gather_attachment.metallib
+    //   vbd_gather_triangle.metallib
+    //   vbd_gather_bending.metallib
+    //   vbd_solve_apply.metallib
+    //
+    // Builds compute pipeline state objects for each and reports
+    // `ok() == true` only if every PSO built successfully.
+    explicit AvbdSolver(const char* metallibPath);
+    ~AvbdSolver();
+
+    // True if construction succeeded and all six kernels are loaded.
+    bool ok() const;
+
+    // PR-E stub: one outer AVBD iteration (one pass over all color
+    // batches dispatching vbd_init → gathers → vbd_solve_apply).
+    // Currently a no-op that returns 0 without touching any buffer.
+    // Real implementation lands in PR-E continued.
+    int step();
+
+private:
+    struct Impl;
+    Impl* impl_;
+};
+
+}  // namespace cloth
+
+#endif  // CLOTH_AVBD_SOLVER_H

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -1,0 +1,107 @@
+// AvbdSolver implementation (PR-E stub). Loads the six AVBD kernel
+// metallibs and builds compute pipeline state objects. Per-step
+// dispatch is a stub — actual GPU loop wiring lands in follow-up PRs.
+
+#include "AvbdSolver.h"
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+#include <cstdio>
+#include <string>
+
+namespace cloth {
+
+struct AvbdSolver::Impl {
+    id<MTLDevice>               device   = nil;
+    id<MTLCommandQueue>         queue    = nil;
+
+    // Six AVBD pipeline kernels. Each loaded from a separate
+    // metallib at construction time.
+    id<MTLComputePipelineState> psoInit             = nil;
+    id<MTLComputePipelineState> psoGatherSpring     = nil;
+    id<MTLComputePipelineState> psoGatherAttachment = nil;
+    id<MTLComputePipelineState> psoGatherTriangle   = nil;
+    id<MTLComputePipelineState> psoGatherBending    = nil;
+    id<MTLComputePipelineState> psoSolveApply       = nil;
+
+    bool ok = false;
+
+    static id<MTLLibrary> loadLib(id<MTLDevice> dev, const std::string& path,
+                                   const char* name) {
+        NSError* err = nil;
+        NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path.c_str()]];
+        id<MTLLibrary> lib = [dev newLibraryWithURL:url error:&err];
+        if (!lib) {
+            std::fprintf(stderr, "AvbdSolver: failed to load %s from %s: %s\n",
+                         name, path.c_str(),
+                         err ? err.localizedDescription.UTF8String : "(null)");
+        }
+        return lib;
+    }
+
+    static id<MTLComputePipelineState> makePSO(id<MTLDevice> dev,
+                                                 id<MTLLibrary> lib,
+                                                 const char* fn,
+                                                 const char* tag) {
+        NSError* err = nil;
+        id<MTLFunction> f = [lib newFunctionWithName:[NSString stringWithUTF8String:fn]];
+        if (!f) {
+            std::fprintf(stderr, "AvbdSolver: no fn %s in %s\n", fn, tag);
+            return nil;
+        }
+        id<MTLComputePipelineState> pso =
+            [dev newComputePipelineStateWithFunction:f error:&err];
+        if (!pso) {
+            std::fprintf(stderr, "AvbdSolver: PSO %s failed: %s\n",
+                         tag, err ? err.localizedDescription.UTF8String : "(null)");
+        }
+        return pso;
+    }
+};
+
+AvbdSolver::AvbdSolver(const char* metallibPath)
+    : impl_(new Impl()) {
+    impl_->device = MTLCreateSystemDefaultDevice();
+    if (!impl_->device) {
+        std::fprintf(stderr, "AvbdSolver: no Metal device\n");
+        return;
+    }
+    impl_->queue = [impl_->device newCommandQueue];
+
+    std::string root = metallibPath;
+    if (!root.empty() && root.back() != '/') root.push_back('/');
+
+    id<MTLLibrary> libInit       = Impl::loadLib(impl_->device, root + "vbd_init.metallib",             "vbd_init");
+    id<MTLLibrary> libSpring     = Impl::loadLib(impl_->device, root + "vbd_gather_spring.metallib",    "vbd_gather_spring");
+    id<MTLLibrary> libAttachment = Impl::loadLib(impl_->device, root + "vbd_gather_attachment.metallib","vbd_gather_attachment");
+    id<MTLLibrary> libTriangle   = Impl::loadLib(impl_->device, root + "vbd_gather_triangle.metallib",  "vbd_gather_triangle");
+    id<MTLLibrary> libBending    = Impl::loadLib(impl_->device, root + "vbd_gather_bending.metallib",   "vbd_gather_bending");
+    id<MTLLibrary> libSolve      = Impl::loadLib(impl_->device, root + "vbd_solve_apply.metallib",      "vbd_solve_apply");
+    if (!libInit || !libSpring || !libAttachment || !libTriangle || !libBending || !libSolve) return;
+
+    impl_->psoInit             = Impl::makePSO(impl_->device, libInit,       "main_0", "vbd_init");
+    impl_->psoGatherSpring     = Impl::makePSO(impl_->device, libSpring,     "main_0", "vbd_gather_spring");
+    impl_->psoGatherAttachment = Impl::makePSO(impl_->device, libAttachment, "main_0", "vbd_gather_attachment");
+    impl_->psoGatherTriangle   = Impl::makePSO(impl_->device, libTriangle,   "main_0", "vbd_gather_triangle");
+    impl_->psoGatherBending    = Impl::makePSO(impl_->device, libBending,    "main_0", "vbd_gather_bending");
+    impl_->psoSolveApply       = Impl::makePSO(impl_->device, libSolve,      "main_0", "vbd_solve_apply");
+    if (!impl_->psoInit || !impl_->psoGatherSpring || !impl_->psoGatherAttachment ||
+        !impl_->psoGatherTriangle || !impl_->psoGatherBending || !impl_->psoSolveApply) return;
+
+    impl_->ok = true;
+    std::fprintf(stderr,
+        "AvbdSolver: all 6 AVBD kernels loaded (init, gather_{spring,attachment,triangle,bending}, solve_apply)\n");
+}
+
+AvbdSolver::~AvbdSolver() { delete impl_; }
+
+bool AvbdSolver::ok() const { return impl_ && impl_->ok; }
+
+int AvbdSolver::step() {
+    // PR-E stub. Real dispatch comes in follow-up PRs.
+    if (!ok()) return -1;
+    return 0;
+}
+
+}  // namespace cloth

--- a/src/code/slang_solver/Makefile
+++ b/src/code/slang_solver/Makefile
@@ -16,11 +16,15 @@ CXX        ?= clang++
 CXXFLAGS   ?= -std=c++17 -O2 -Wall -Wextra
 INCLUDES   := -I.
 
-.PHONY: test clean
+.PHONY: test test-avbd clean
 
 test: $(BUILD)/test_metal_cg_solver
 	@echo "=== Smoke test of the wrapper (no Eigen, no DiffCloth)."
 	$(BUILD)/test_metal_cg_solver $(METALLIB_DIR)
+
+test-avbd: $(BUILD)/test_avbd_solver
+	@echo "=== Smoke test of AvbdSolver — all 6 AVBD PSOs build."
+	$(BUILD)/test_avbd_solver $(METALLIB_DIR)
 
 $(BUILD)/test_metal_cg_solver: test_metal_cg_solver.cpp \
                                 $(BUILD)/MetalCGSolver.o
@@ -29,9 +33,19 @@ $(BUILD)/test_metal_cg_solver: test_metal_cg_solver.cpp \
 	  -framework Metal -framework Foundation \
 	  -o $@ $^
 
+$(BUILD)/test_avbd_solver: test_avbd_solver.cpp $(BUILD)/AvbdSolver.o
+	@mkdir -p $(BUILD)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) \
+	  -framework Metal -framework Foundation \
+	  -o $@ $^
+
 $(BUILD)/MetalCGSolver.o: MetalCGSolver.mm MetalCGSolver.h
 	@mkdir -p $(BUILD)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -fobjc-arc -c -o $@ MetalCGSolver.mm
+
+$(BUILD)/AvbdSolver.o: AvbdSolver.mm AvbdSolver.h
+	@mkdir -p $(BUILD)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -fobjc-arc -c -o $@ AvbdSolver.mm
 
 clean:
 	rm -rf $(BUILD)

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -1,0 +1,43 @@
+// Smoke test for AvbdSolver — verifies all six AVBD kernel metallibs
+// load and build PSOs successfully. This is the PR-E stub validation;
+// actual GPU dispatch isn't tested yet (that's follow-up PRs).
+//
+// Usage:
+//   ./test_avbd_solver <metallib_dir>
+//
+// Expects <metallib_dir> to contain:
+//   vbd_init.metallib
+//   vbd_gather_spring.metallib
+//   vbd_gather_attachment.metallib
+//   vbd_gather_triangle.metallib
+//   vbd_gather_bending.metallib
+//   vbd_solve_apply.metallib
+
+#include "AvbdSolver.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <metallib_dir>\n", argv[0]);
+        return 2;
+    }
+
+    cloth::AvbdSolver solver(argv[1]);
+    if (!solver.ok()) {
+        std::fprintf(stderr, "test_avbd_solver: construction failed\n");
+        return 1;
+    }
+
+    // Stub: step() is a no-op that should return 0 when ok.
+    const int rc = solver.step();
+    if (rc != 0) {
+        std::fprintf(stderr, "test_avbd_solver: step() returned %d, expected 0\n", rc);
+        return 1;
+    }
+
+    std::printf("test_avbd_solver: OK (all 6 PSOs built, step stub returned 0)\n");
+    return 0;
+}

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force vbd_init
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force vbd_init vbd_solve_apply vbd_gather_spring vbd_gather_attachment vbd_gather_triangle vbd_gather_bending
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++


### PR DESCRIPTION
## Summary
First step toward **PR-E** (Simulation.cpp wiring). Adds \`AvbdSolver\` — the pure-C++ interface that mirrors \`MetalCGSolver\`'s PIMPL pattern but wraps the AVBD vertex-block-update pipeline instead of the PD CG path.

This PR ships only the constructor: load 6 metallibs, build 6 PSOs, report \`ok()\`. The per-step \`step()\` entry point is a no-op stub that returns 0 when ok. Actual GPU dispatch lands in follow-up PRs.

## Why a stub
Keeps PR-E integration work incremental. Future PRs add per-step buffer uploads, dispatch loops over color batches, and Simulation.cpp env-gated routing (\`USE_AVBD=1\`) on top of this foundation.

## Verification (real Metal hardware)
\`\`\`
$ make -C src/code/slang_solver test-avbd
AvbdSolver: all 6 AVBD kernels loaded (init, gather_{spring,attachment,triangle,bending}, solve_apply)
test_avbd_solver: OK (all 6 PSOs built, step stub returned 0)
\`\`\`

All 6 PSOs build on the AVBD \`.metallib\` outputs produced by the existing slang → air → metallib pipeline. The wrapper is isolated from Eigen via PIMPL so it can link into Simulation.cpp without dragging Foundation/Metal headers into TUs that include Eigen.

## What's also in this PR
- New AVBD kernels (\`vbd_init\`, \`vbd_solve_apply\`, \`vbd_gather_*\`) added to \`METAL_KERNELS\` in \`tests/slang_validate/Makefile\` so the standard build pipeline produces all 6 metallibs.

## Roadmap (#42)
- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- 🟡 **PR-E AvbdSolver stub** — this PR
- PR-E continued — per-step buffer uploads + dispatch loop
- PR-E continued — Simulation.cpp routing (\`USE_AVBD=1\`)
- PR-F augmented Lagrangian dual update
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] All 6 metallibs build via existing slang→air→metallib pipeline
- [x] \`make -C src/code/slang_solver test-avbd\` passes — all 6 PSOs build on real Metal
- [ ] CI lean-slang validate (covers Lean side only; cpp wrapper test is local-only since CI doesn't have Metal toolchain)