### PR TITLE
AvbdSolver: dispatch vbd_init on real Metal (PR-E slice 2)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -24,6 +24,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 
 namespace cloth {
 
@@ -46,11 +47,30 @@ public:
     // True if construction succeeded and all six kernels are loaded.
     bool ok() const;
 
-    // PR-E stub: one outer AVBD iteration (one pass over all color
-    // batches dispatching vbd_init → gathers → vbd_solve_apply).
-    // Currently a no-op that returns 0 without touching any buffer.
-    // Real implementation lands in PR-E continued.
+    // Upload mesh state. Allocates per-vertex GPU buffers (positions,
+    // predicted, mass, gScratch, hScratch) sized to `nVerts`, uploads
+    // initial state. Subsequent step() calls operate on this buffer
+    // set. Calling setupMesh again resizes/replaces the buffers.
+    //
+    // `positions`, `predicted` are flat float arrays of length 3*nVerts
+    // (xyz triplets); `mass` is length nVerts. `invHSquared = 1/h²`.
+    void setupMesh(uint32_t nVerts,
+                   const float* positions,
+                   const float* predicted,
+                   const float* mass,
+                   float invHSquared);
+
+    // Dispatch the vbd_init kernel: writes inertial term to (gScratch,
+    // hScratch) per vertex. Currently the only kernel dispatched per
+    // step — constraint gathers + solve_apply land in follow-up PRs.
+    // Returns 0 on success, -1 if not ok / not set up.
     int step();
+
+    // Read back current scratch state to host arrays. Used by tests.
+    // `gScratch_out` length 3*nVerts (xyz); `hScratch_out` length 6*nVerts
+    // (packed sym 3x3: [Hxx, Hxy, Hxz, Hyy, Hyz, Hzz] per vertex).
+    void readScratch(std::vector<float>& gScratch_out,
+                     std::vector<float>& hScratch_out) const;
 
 private:
     struct Impl;

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -8,9 +8,16 @@
 #import <Metal/Metal.h>
 
 #include <cstdio>
+#include <cstring>
 #include <string>
 
 namespace cloth {
+
+// Matches the VbdInitParams struct emitted by Cloth.SlangCodegen.VbdInit
+// (single float field `invHSquared`).
+struct VbdInitParams {
+    float invHSquared;
+};
 
 struct AvbdSolver::Impl {
     id<MTLDevice>               device   = nil;
@@ -25,7 +32,18 @@ struct AvbdSolver::Impl {
     id<MTLComputePipelineState> psoGatherBending    = nil;
     id<MTLComputePipelineState> psoSolveApply       = nil;
 
+    // Per-vertex state buffers (allocated by setupMesh).
+    id<MTLBuffer> bufPositions = nil;   // length = 3 * nVerts (float)
+    id<MTLBuffer> bufPredicted = nil;   // length = 3 * nVerts (float)
+    id<MTLBuffer> bufMass      = nil;   // length = nVerts (float)
+    id<MTLBuffer> bufGScratch  = nil;   // length = 3 * nVerts (float)
+    id<MTLBuffer> bufHScratch  = nil;   // length = 6 * nVerts (float)
+    id<MTLBuffer> bufInitParams = nil;  // sizeof(VbdInitParams)
+
+    uint32_t nVerts = 0;
+
     bool ok = false;
+    bool meshReady = false;
 
     static id<MTLLibrary> loadLib(id<MTLDevice> dev, const std::string& path,
                                    const char* name) {
@@ -98,10 +116,65 @@ AvbdSolver::~AvbdSolver() { delete impl_; }
 
 bool AvbdSolver::ok() const { return impl_ && impl_->ok; }
 
+void AvbdSolver::setupMesh(uint32_t nVerts,
+                           const float* positions,
+                           const float* predicted,
+                           const float* mass,
+                           float invHSquared) {
+    if (!ok()) return;
+    impl_->nVerts = nVerts;
+    const NSUInteger bytesVec3 = 3 * nVerts * sizeof(float);
+    const NSUInteger bytesScalar = nVerts * sizeof(float);
+    const NSUInteger bytesHess = 6 * nVerts * sizeof(float);
+    const MTLResourceOptions opts = MTLResourceStorageModeShared;
+
+    impl_->bufPositions = [impl_->device newBufferWithBytes:positions length:bytesVec3 options:opts];
+    impl_->bufPredicted = [impl_->device newBufferWithBytes:predicted length:bytesVec3 options:opts];
+    impl_->bufMass      = [impl_->device newBufferWithBytes:mass      length:bytesScalar options:opts];
+    impl_->bufGScratch  = [impl_->device newBufferWithLength:bytesVec3 options:opts];
+    impl_->bufHScratch  = [impl_->device newBufferWithLength:bytesHess options:opts];
+
+    impl_->bufInitParams = [impl_->device newBufferWithLength:sizeof(VbdInitParams) options:opts];
+    *static_cast<VbdInitParams*>(impl_->bufInitParams.contents) = {invHSquared};
+
+    impl_->meshReady = true;
+}
+
 int AvbdSolver::step() {
-    // PR-E stub. Real dispatch comes in follow-up PRs.
-    if (!ok()) return -1;
+    if (!ok() || !impl_->meshReady) return -1;
+
+    // PR-E slice 2: dispatch vbd_init only. Gather + solve_apply land
+    // in follow-up PRs once CSR adjacency upload is wired.
+    id<MTLCommandBuffer> cb = [impl_->queue commandBuffer];
+    id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+    [enc setComputePipelineState:impl_->psoInit];
+    [enc setBuffer:impl_->bufInitParams offset:0 atIndex:0];
+    [enc setBuffer:impl_->bufPositions  offset:0 atIndex:1];
+    [enc setBuffer:impl_->bufPredicted  offset:0 atIndex:2];
+    [enc setBuffer:impl_->bufMass       offset:0 atIndex:3];
+    [enc setBuffer:impl_->bufGScratch   offset:0 atIndex:4];
+    [enc setBuffer:impl_->bufHScratch   offset:0 atIndex:5];
+    [enc dispatchThreads:MTLSizeMake(impl_->nVerts, 1, 1)
+   threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+    [enc endEncoding];
+    [cb commit];
+    [cb waitUntilCompleted];
+
     return 0;
+}
+
+void AvbdSolver::readScratch(std::vector<float>& gScratch_out,
+                             std::vector<float>& hScratch_out) const {
+    if (!ok() || !impl_->meshReady) {
+        gScratch_out.clear();
+        hScratch_out.clear();
+        return;
+    }
+    const uint32_t n = impl_->nVerts;
+    gScratch_out.assign(3 * n, 0.0f);
+    hScratch_out.assign(6 * n, 0.0f);
+    std::memcpy(gScratch_out.data(), impl_->bufGScratch.contents, 3 * n * sizeof(float));
+    std::memcpy(hScratch_out.data(), impl_->bufHScratch.contents, 6 * n * sizeof(float));
 }
 
 }  // namespace cloth

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -1,23 +1,23 @@
-// Smoke test for AvbdSolver — verifies all six AVBD kernel metallibs
-// load and build PSOs successfully. This is the PR-E stub validation;
-// actual GPU dispatch isn't tested yet (that's follow-up PRs).
+// Smoke test for AvbdSolver — verifies the AVBD vbd_init kernel
+// dispatches correctly on real Metal hardware and produces the
+// expected inertial term in (gScratch, hScratch).
+//
+// Test fixture (2 verts, no constraints):
+//   v0:  x=(0,0,0), pred=(1,2,3), m=2, invH²=2 → w=4
+//        expected g=(-4,-8,-12), h=[4,0,0,4,0,4]
+//   v1:  x=(5,5,5), pred=(5,5,5), m=1, invH²=2 → w=2
+//        expected g=(0,0,0), h=[2,0,0,2,0,2]
 //
 // Usage:
 //   ./test_avbd_solver <metallib_dir>
-//
-// Expects <metallib_dir> to contain:
-//   vbd_init.metallib
-//   vbd_gather_spring.metallib
-//   vbd_gather_attachment.metallib
-//   vbd_gather_triangle.metallib
-//   vbd_gather_bending.metallib
-//   vbd_solve_apply.metallib
 
 #include "AvbdSolver.h"
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 int main(int argc, char** argv) {
     if (argc < 2) {
@@ -31,13 +31,66 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    // Stub: step() is a no-op that should return 0 when ok.
+    constexpr uint32_t N = 2;
+    const float positions[3 * N] = {
+        0.0f, 0.0f, 0.0f,
+        5.0f, 5.0f, 5.0f,
+    };
+    const float predicted[3 * N] = {
+        1.0f, 2.0f, 3.0f,
+        5.0f, 5.0f, 5.0f,
+    };
+    const float mass[N] = {2.0f, 1.0f};
+    constexpr float invHSquared = 2.0f;
+
+    solver.setupMesh(N, positions, predicted, mass, invHSquared);
+
     const int rc = solver.step();
     if (rc != 0) {
-        std::fprintf(stderr, "test_avbd_solver: step() returned %d, expected 0\n", rc);
+        std::fprintf(stderr, "test_avbd_solver: step() returned %d\n", rc);
         return 1;
     }
 
-    std::printf("test_avbd_solver: OK (all 6 PSOs built, step stub returned 0)\n");
-    return 0;
+    std::vector<float> gOut, hOut;
+    solver.readScratch(gOut, hOut);
+
+    const float expected_g[3 * N] = {
+        -4.0f, -8.0f, -12.0f,
+         0.0f,  0.0f,   0.0f,
+    };
+    const float expected_h[6 * N] = {
+        4.0f, 0.0f, 0.0f, 4.0f, 0.0f, 4.0f,
+        2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 2.0f,
+    };
+
+    int fails = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t i = 0; i < 3 * N; ++i) {
+        const float d = std::fabs(gOut[i] - expected_g[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            std::fprintf(stderr,
+                "g mismatch at i=%u: got %g, expected %g\n",
+                i, gOut[i], expected_g[i]);
+            ++fails;
+        }
+    }
+    for (uint32_t i = 0; i < 6 * N; ++i) {
+        const float d = std::fabs(hOut[i] - expected_h[i]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            std::fprintf(stderr,
+                "h mismatch at i=%u: got %g, expected %g\n",
+                i, hOut[i], expected_h[i]);
+            ++fails;
+        }
+    }
+
+    if (fails == 0) {
+        std::printf("test_avbd_solver: OK (vbd_init dispatched on %u verts, max_abs_diff=%g)\n",
+                    N, max_abs_diff);
+        return 0;
+    }
+    std::fprintf(stderr, "test_avbd_solver: %d FAIL\n", fails);
+    return 1;
 }


### PR DESCRIPTION
## Summary
Extends the PR #56 stub with the first real GPU dispatch.

Adds:
- \`setupMesh(nVerts, positions, predicted, mass, invHSquared)\` — uploads per-vertex state to GPU shared buffers
- \`step()\` dispatches \`vbd_init\` kernel via a Metal command buffer
- \`readScratch(g_out, h_out)\` reads scratch back to host for verification

\`vbd_init\` computes the per-vertex inertial term:
\`\`\`
w   = mass[v] · invHSquared          (= m/h²)
g   = w · (x − x̃)
H   = w · I₃ (packed sym 3x3)
\`\`\`

Other gather + solve kernels remain unwired — they need CSR adjacency upload paths that follow in subsequent PRs.

## Verification (real Apple Silicon Metal)
\`\`\`
test_avbd_solver: OK (vbd_init dispatched on 2 verts, max_abs_diff=0)
\`\`\`

2-vertex fixture, bit-exact match against hand-computed inertial term for both verts.

## Roadmap (#42) — PR-E progress

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver stub (#56)
- 🟡 **PR-E AvbdSolver vbd_init dispatch** — this PR
- PR-E AvbdSolver spring gather dispatch — next
- PR-E AvbdSolver attachment / triangle / bending gathers
- PR-E AvbdSolver solve_apply dispatch
- PR-E Simulation.cpp routing (\`USE_AVBD=1\`)
- PR-F augmented Lagrangian dual update
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`make -C src/code/slang_solver test-avbd\` passes — GPU dispatch matches hand-computed reference
- [ ] CI lean-slang validate (Lean side only; Metal dispatch is local-test only)