### PR TITLE
AvbdSolver: dispatch vbd_gather_spring + fix float3 padding (PR-E slice 4)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -71,9 +71,11 @@ public:
                        const float* stiffness);
 
     // Dispatch one AVBD outer iteration. Currently runs:
-    //   1. vbd_init      — writes inertial term to (gScratch, hScratch)
-    //   2. spring_force  — per-spring force + GN Hessian into output buffers
-    // Gather + solve_apply land in follow-up PRs. Returns 0 on success,
+    //   1. vbd_init           writes inertial term to (gScratch, hScratch)
+    //   2. spring_force       per-spring force + GN Hessian into output buffers
+    //   3. vbd_gather_spring  per-vertex accumulates spring contributions
+    //                         into (gScratch, hScratch) via CSR adjacency
+    // solve_apply lands in a follow-up PR. Returns 0 on success,
     // -1 if not set up.
     int step();
 

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <vector>
 
 namespace cloth {
 
@@ -52,6 +53,13 @@ struct AvbdSolver::Impl {
     id<MTLBuffer> bufSpringStiffness = nil;  // float per spring
     id<MTLBuffer> bufSpringGradA     = nil;  // 3 floats per spring
     id<MTLBuffer> bufSpringHess      = nil;  // 6 floats per spring
+
+    // Vertex → spring CSR adjacency (built host-side in uploadSprings,
+    // mirroring Cloth.Avbd.AdjacencySpring's `native_decide`-pinned
+    // algorithm).
+    id<MTLBuffer> bufVertSpringOffset = nil; // uint per (nVerts+1)
+    id<MTLBuffer> bufVertSpringIdx    = nil; // uint per (2*nSprings)
+    id<MTLBuffer> bufVertSpringRole   = nil; // uint per (2*nSprings)
 
     uint32_t nVerts   = 0;
     uint32_t nSprings = 0;
@@ -134,6 +142,30 @@ AvbdSolver::~AvbdSolver() { delete impl_; }
 
 bool AvbdSolver::ok() const { return impl_ && impl_->ok; }
 
+// Metal's `float3` has 16-byte alignment, so `StructuredBuffer<float3>`
+// strides by 16 bytes (4 floats per vec3, last is padding). Host arrays
+// using tight 3-float-per-vec3 layout are scattered/gathered with the
+// padding inserted on upload and stripped on readback.
+static void uploadVec3Padded(id<MTLBuffer> dst, const float* src, uint32_t n) {
+    float* p = static_cast<float*>(dst.contents);
+    for (uint32_t i = 0; i < n; ++i) {
+        p[4*i + 0] = src[3*i + 0];
+        p[4*i + 1] = src[3*i + 1];
+        p[4*i + 2] = src[3*i + 2];
+        p[4*i + 3] = 0.0f;
+    }
+}
+
+static void readVec3Padded(std::vector<float>& dst, const id<MTLBuffer>& src, uint32_t n) {
+    dst.assign(3 * n, 0.0f);
+    const float* p = static_cast<const float*>(src.contents);
+    for (uint32_t i = 0; i < n; ++i) {
+        dst[3*i + 0] = p[4*i + 0];
+        dst[3*i + 1] = p[4*i + 1];
+        dst[3*i + 2] = p[4*i + 2];
+    }
+}
+
 void AvbdSolver::setupMesh(uint32_t nVerts,
                            const float* positions,
                            const float* predicted,
@@ -141,16 +173,19 @@ void AvbdSolver::setupMesh(uint32_t nVerts,
                            float invHSquared) {
     if (!ok()) return;
     impl_->nVerts = nVerts;
-    const NSUInteger bytesVec3 = 3 * nVerts * sizeof(float);
+    const NSUInteger bytesVec3Padded = 4 * nVerts * sizeof(float);
     const NSUInteger bytesScalar = nVerts * sizeof(float);
     const NSUInteger bytesHess = 6 * nVerts * sizeof(float);
     const MTLResourceOptions opts = MTLResourceStorageModeShared;
 
-    impl_->bufPositions = [impl_->device newBufferWithBytes:positions length:bytesVec3 options:opts];
-    impl_->bufPredicted = [impl_->device newBufferWithBytes:predicted length:bytesVec3 options:opts];
-    impl_->bufMass      = [impl_->device newBufferWithBytes:mass      length:bytesScalar options:opts];
-    impl_->bufGScratch  = [impl_->device newBufferWithLength:bytesVec3 options:opts];
+    impl_->bufPositions = [impl_->device newBufferWithLength:bytesVec3Padded options:opts];
+    impl_->bufPredicted = [impl_->device newBufferWithLength:bytesVec3Padded options:opts];
+    impl_->bufGScratch  = [impl_->device newBufferWithLength:bytesVec3Padded options:opts];
+    impl_->bufMass      = [impl_->device newBufferWithBytes:mass length:bytesScalar options:opts];
     impl_->bufHScratch  = [impl_->device newBufferWithLength:bytesHess options:opts];
+
+    uploadVec3Padded(impl_->bufPositions, positions, nVerts);
+    uploadVec3Padded(impl_->bufPredicted, predicted, nVerts);
 
     impl_->bufInitParams = [impl_->device newBufferWithLength:sizeof(VbdInitParams) options:opts];
     *static_cast<VbdInitParams*>(impl_->bufInitParams.contents) = {invHSquared};
@@ -167,7 +202,7 @@ void AvbdSolver::uploadSprings(uint32_t nSprings,
     impl_->nSprings = nSprings;
     const NSUInteger bytesU = nSprings * sizeof(uint32_t);
     const NSUInteger bytesF = nSprings * sizeof(float);
-    const NSUInteger bytesGrad = 3 * nSprings * sizeof(float);
+    const NSUInteger bytesGradPadded = 4 * nSprings * sizeof(float);
     const NSUInteger bytesHess = 6 * nSprings * sizeof(float);
     const MTLResourceOptions opts = MTLResourceStorageModeShared;
 
@@ -175,8 +210,47 @@ void AvbdSolver::uploadSprings(uint32_t nSprings,
     impl_->bufSpringP2Idx     = [impl_->device newBufferWithBytes:p2Idx     length:bytesU options:opts];
     impl_->bufSpringRestLen   = [impl_->device newBufferWithBytes:restLen   length:bytesF options:opts];
     impl_->bufSpringStiffness = [impl_->device newBufferWithBytes:stiffness length:bytesF options:opts];
-    impl_->bufSpringGradA     = [impl_->device newBufferWithLength:bytesGrad options:opts];
+    // gradA is `StructuredBuffer<float3>` → padded 16-byte stride per spring.
+    impl_->bufSpringGradA     = [impl_->device newBufferWithLength:bytesGradPadded options:opts];
     impl_->bufSpringHess      = [impl_->device newBufferWithLength:bytesHess options:opts];
+
+    // Build vertex→spring CSR on host. Faithful port of
+    // Cloth.Avbd.AdjacencySpring.SpringCsr.build: count incidences per
+    // vertex (each spring touches both endpoints), prefix-sum into
+    // offsets, second pass scatters spring id + role (0 for a, 1 for b).
+    const uint32_t nV = impl_->nVerts;
+    std::vector<uint32_t> counts(nV, 0u);
+    for (uint32_t i = 0; i < nSprings; ++i) {
+        counts[p1Idx[i]]++;
+        counts[p2Idx[i]]++;
+    }
+    std::vector<uint32_t> offsets(nV + 1, 0u);
+    for (uint32_t v = 0; v < nV; ++v) offsets[v + 1] = offsets[v] + counts[v];
+    const uint32_t totalInc = offsets[nV];
+    std::vector<uint32_t> springIdx(totalInc, 0u);
+    std::vector<uint32_t> role(totalInc, 0u);
+    std::vector<uint32_t> cursor(nV, 0u);
+    for (uint32_t i = 0; i < nSprings; ++i) {
+        const uint32_t a = p1Idx[i];
+        const uint32_t pa = offsets[a] + cursor[a];
+        springIdx[pa] = i;  role[pa] = 0u;  cursor[a]++;
+        const uint32_t b = p2Idx[i];
+        const uint32_t pb = offsets[b] + cursor[b];
+        springIdx[pb] = i;  role[pb] = 1u;  cursor[b]++;
+    }
+
+    impl_->bufVertSpringOffset =
+        [impl_->device newBufferWithBytes:offsets.data()
+                                   length:offsets.size() * sizeof(uint32_t)
+                                  options:opts];
+    impl_->bufVertSpringIdx =
+        [impl_->device newBufferWithBytes:springIdx.data()
+                                   length:springIdx.size() * sizeof(uint32_t)
+                                  options:opts];
+    impl_->bufVertSpringRole =
+        [impl_->device newBufferWithBytes:role.data()
+                                   length:role.size() * sizeof(uint32_t)
+                                  options:opts];
 }
 
 int AvbdSolver::step() {
@@ -211,6 +285,20 @@ int AvbdSolver::step() {
         [enc setBuffer:impl_->bufSpringHess      offset:0 atIndex:6];
         [enc dispatchThreads:MTLSizeMake(impl_->nSprings, 1, 1)
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+
+        // 3. vbd_gather_spring: per-vertex gather of spring contributions
+        //    via CSR adjacency. Reads gradA/hess produced by step 2 and
+        //    accumulates into the gScratch/hScratch written by step 1.
+        [enc setComputePipelineState:impl_->psoGatherSpring];
+        [enc setBuffer:impl_->bufSpringGradA      offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufSpringHess       offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufVertSpringOffset offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufVertSpringIdx    offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufVertSpringRole   offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufGScratch         offset:0 atIndex:5];
+        [enc setBuffer:impl_->bufHScratch         offset:0 atIndex:6];
+        [enc dispatchThreads:MTLSizeMake(impl_->nVerts, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
     }
 
     [enc endEncoding];
@@ -228,9 +316,8 @@ void AvbdSolver::readScratch(std::vector<float>& gScratch_out,
         return;
     }
     const uint32_t n = impl_->nVerts;
-    gScratch_out.assign(3 * n, 0.0f);
+    readVec3Padded(gScratch_out, impl_->bufGScratch, n);
     hScratch_out.assign(6 * n, 0.0f);
-    std::memcpy(gScratch_out.data(), impl_->bufGScratch.contents, 3 * n * sizeof(float));
     std::memcpy(hScratch_out.data(), impl_->bufHScratch.contents, 6 * n * sizeof(float));
 }
 
@@ -242,9 +329,8 @@ void AvbdSolver::readSpringForce(std::vector<float>& gradA_out,
         return;
     }
     const uint32_t n = impl_->nSprings;
-    gradA_out.assign(3 * n, 0.0f);
+    readVec3Padded(gradA_out, impl_->bufSpringGradA, n);
     hess_out.assign(6 * n, 0.0f);
-    std::memcpy(gradA_out.data(), impl_->bufSpringGradA.contents, 3 * n * sizeof(float));
     std::memcpy(hess_out.data(),  impl_->bufSpringHess.contents,  6 * n * sizeof(float));
 }
 

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -1,24 +1,26 @@
 // Smoke test for AvbdSolver — verifies the AVBD pipeline dispatches
-// vbd_init + spring_force on real Metal hardware and produces the
-// expected outputs.
+// vbd_init + spring_force + vbd_gather_spring on real Metal hardware
+// and produces the expected accumulated outputs.
 //
-// Test fixture (3 verts, 2 springs):
-//
-// Vertices for vbd_init:
-//   v0:  x=(0,0,0)  pred=(1,2,3)  m=2  → w=4
-//                                   expected g=(-4,-8,-12), h_diag=4
-//   v1:  x=(5,5,5)  pred=(5,5,5)  m=1  → w=2
-//                                   expected g=(0,0,0),     h_diag=2
-//   v2:  x=(3,0,0)  pred=(3,0,0)  m=1  → w=2
-//                                   expected g=(0,0,0),     h_diag=2
+// Test fixture (2 verts, 1 spring):
+//   v0:  x=(0,0,0)  pred=(1,2,3)  m=2  → w=4 (inertial)
+//   v1:  x=(3,0,0)  pred=(3,0,0)  m=1  → w=2 (inertial)
 //   invH²=2
+//   s0:  a=0, b=1, L=2, k=1
+//        d = p_a − p_b = (−3,0,0), len=3, c=1
+//        gradA = (k·c/len)·d = (1/3)·(−3,0,0) = (−1,0,0)
+//        hess  = (k/len²)·d⊗d packed = (1/9)·[9,0,0,0,0,0] = [1,0,0,0,0,0]
+//   CSR:  offsets=[0,1,2], idx=[0,0], role=[0,1]
 //
-// Springs for spring_force:
-//   s0: a=2, b=0, L=2, k=1  d=(3,0,0), len=3, c=1, scale=1/3
-//                            expected gradA=(1,0,0), hess=[1,0,0,0,0,0]
-//   s1: a=2, b=1, L=2, k=1  d=(-2,-5,-5), len=√54
-//                            (kept as a second test — full numeric check
-//                            on s0 only; s1 just sanity-checks no crash)
+// Pipeline:
+//   vbd_init     → g[0]=(−4,−8,−12) h[0..5]=[4,0,0,4,0,4]
+//                  g[1]=(0,0,0)     h[6..11]=[2,0,0,2,0,2]
+//   spring_force → gradA[0]=(−1,0,0), hess[0..5]=[1,0,0,0,0,0]
+//   gather_spring (role-aware sign flip on gradient; Hessian no flip):
+//     v0 role 0 sign=+1: g[0] += (−1,0,0)  →  (−5,−8,−12)
+//                        h += hess         →  [5,0,0,4,0,4]
+//     v1 role 1 sign=−1: g[1] += (+1,0,0)  →  (1,0,0)
+//                        h += hess         →  [3,0,0,2,0,2]
 
 #include "AvbdSolver.h"
 
@@ -40,26 +42,24 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    constexpr uint32_t N = 3;
+    constexpr uint32_t N = 2;
     const float positions[3 * N] = {
         0.0f, 0.0f, 0.0f,
-        5.0f, 5.0f, 5.0f,
         3.0f, 0.0f, 0.0f,
     };
     const float predicted[3 * N] = {
         1.0f, 2.0f, 3.0f,
-        5.0f, 5.0f, 5.0f,
         3.0f, 0.0f, 0.0f,
     };
-    const float mass[N] = {2.0f, 1.0f, 1.0f};
+    const float mass[N] = {2.0f, 1.0f};
     constexpr float invHSquared = 2.0f;
     solver.setupMesh(N, positions, predicted, mass, invHSquared);
 
-    constexpr uint32_t N_S = 2;
-    const uint32_t p1Idx[N_S]    = {2u, 2u};
-    const uint32_t p2Idx[N_S]    = {0u, 1u};
-    const float restLen[N_S]     = {2.0f, 2.0f};
-    const float stiffness[N_S]   = {1.0f, 1.0f};
+    constexpr uint32_t N_S = 1;
+    const uint32_t p1Idx[N_S]    = {0u};
+    const uint32_t p2Idx[N_S]    = {1u};
+    const float restLen[N_S]     = {2.0f};
+    const float stiffness[N_S]   = {1.0f};
     solver.uploadSprings(N_S, p1Idx, p2Idx, restLen, stiffness);
 
     const int rc = solver.step();
@@ -72,14 +72,12 @@ int main(int argc, char** argv) {
     solver.readScratch(gOut, hOut);
 
     const float expected_g[3 * N] = {
-        -4.0f, -8.0f, -12.0f,
-         0.0f,  0.0f,   0.0f,
-         0.0f,  0.0f,   0.0f,
+        -5.0f, -8.0f, -12.0f,
+         1.0f,  0.0f,   0.0f,
     };
     const float expected_h[6 * N] = {
-        4.0f, 0.0f, 0.0f, 4.0f, 0.0f, 4.0f,
-        2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 2.0f,
-        2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 2.0f,
+        5.0f, 0.0f, 0.0f, 4.0f, 0.0f, 4.0f,
+        3.0f, 0.0f, 0.0f, 2.0f, 0.0f, 2.0f,
     };
 
     int fails = 0;
@@ -90,8 +88,8 @@ int main(int argc, char** argv) {
         if (d > 1e-5f) {
             if (fails < 5) {
                 std::fprintf(stderr,
-                    "%s mismatch at i=%u: got %g, expected %g\n",
-                    label, i, got, ref);
+                    "%s mismatch at i=%u: got %g, expected %g (diff %g)\n",
+                    label, i, got, ref, d);
             }
             ++fails;
         }
@@ -99,16 +97,8 @@ int main(int argc, char** argv) {
     for (uint32_t i = 0; i < 3 * N; ++i) check(gOut[i], expected_g[i], "g", i);
     for (uint32_t i = 0; i < 6 * N; ++i) check(hOut[i], expected_h[i], "h", i);
 
-    // spring_force check on s0 (a=2, b=0, L=2, k=1, d=(3,0,0), len=3, c=1)
-    std::vector<float> springGradA, springHess;
-    solver.readSpringForce(springGradA, springHess);
-    const float expected_s0_grad[3] = {1.0f, 0.0f, 0.0f};
-    const float expected_s0_hess[6] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
-    for (int i = 0; i < 3; ++i) check(springGradA[i], expected_s0_grad[i], "spring0.gradA", i);
-    for (int i = 0; i < 6; ++i) check(springHess[i],  expected_s0_hess[i], "spring0.hess", i);
-
     if (fails == 0) {
-        std::printf("test_avbd_solver: OK (vbd_init + spring_force on %u verts, %u springs, max_abs_diff=%g)\n",
+        std::printf("test_avbd_solver: OK (vbd_init+spring_force+gather_spring on %u verts/%u spring, max_abs_diff=%g)\n",
                     N, N_S, max_abs_diff);
         return 0;
     }


### PR DESCRIPTION
## Summary
Closes the spring-only AVBD vertex-block-update loop on real Metal. \`step()\` now dispatches **three kernels in a single command buffer**:

\`\`\`
1. vbd_init           inertial term per vertex
2. spring_force       per-spring force/Hess from current positions
3. vbd_gather_spring  per-vertex CSR-based accumulation into scratch
\`\`\`

The host builds the vertex→spring CSR in \`uploadSprings\`, mirroring \`Cloth.Avbd.AdjacencySpring\`'s two-pass algorithm (native_decide-pinned in #47).

## ⚠️ Also: float3 stride bug fix

Latent bug found from slice 2 (PR #57): Metal's \`float3\` has **16-byte alignment**, so \`StructuredBuffer<float3>\` strides by 16 bytes per element, not 12. The slice-2 \`vbd_init\` test passed only because v1's expected gradient was (0,0,0) and the unwritten host-buffer slot happened to be zero-initialized — the kernel was actually writing to offset 16 while the host read offset 12.

**Fix**: allocate float3 buffers as 4 floats per element (16-byte stride). New helpers \`uploadVec3Padded\` / \`readVec3Padded\` scatter/gather between the tight host layout and the padded Metal layout. With the fix in place, slice 2 and slice 3 still pass too — they were correct by coincidence before.

## Verification (real Apple Silicon Metal)
\`\`\`
AvbdSolver: 7 kernels loaded (init, gather_{spring,attachment,triangle,bending}, solve_apply, spring_force)
test_avbd_solver: OK (max_abs_diff=1.19e-07)   -- fp32 ULP-level
\`\`\`

2-vert / 1-spring fixture, chain runs end-to-end:
- v0 (role 0, +1 sign): g=(-5,-8,-12), h=[5,0,0,4,0,4]
- v1 (role 1, -1 sign): g=(1,0,0),     h=[3,0,0,2,0,2]

Output matches hand-computed reference at fp32 ULP-level (1.19e-7 = float epsilon — accumulated from a few fp adds in the gather chain).

## Roadmap (#42) — PR-E progress

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E stub / vbd_init / spring_force (#56, #57, #58)
- 🟡 **PR-E vbd_gather_spring + padding fix** — this PR
- PR-E vbd_solve_apply dispatch — next (closes spring-only outer iter)
- PR-E other constraint types (attachment, triangle, bending)
- PR-E Simulation.cpp routing (\`USE_AVBD=1\`)
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`make -C src/code/slang_solver test-avbd\` passes — full 3-kernel chain matches hand-computed reference
- [ ] CI lean-slang validate