### PR TITLE
AvbdSolver: dispatch vbd_solve_apply — full AVBD spring step on Metal (PR-E slice 5)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -70,14 +70,19 @@ public:
                        const float* restLen,
                        const float* stiffness);
 
-    // Dispatch one AVBD outer iteration. Currently runs:
+    // Dispatch one full AVBD outer iteration on the spring-only path:
     //   1. vbd_init           writes inertial term to (gScratch, hScratch)
-    //   2. spring_force       per-spring force + GN Hessian into output buffers
-    //   3. vbd_gather_spring  per-vertex accumulates spring contributions
-    //                         into (gScratch, hScratch) via CSR adjacency
-    // solve_apply lands in a follow-up PR. Returns 0 on success,
-    // -1 if not set up.
+    //   2. spring_force       per-spring force + GN Hessian
+    //   3. vbd_gather_spring  per-vertex accumulation via CSR adjacency
+    //   4. vbd_solve_apply    invert 3x3 H, update positions in place
+    //
+    // After step() returns, `readPositions(out)` returns the updated
+    // vertex positions. Returns 0 on success, -1 if not set up.
     int step();
+
+    // Read back current vertex positions to a host array. Used by tests.
+    // `positions_out` length = 3 * nVerts (xyz).
+    void readPositions(std::vector<float>& positions_out) const;
 
     // Read back current scratch state to host arrays. Used by tests.
     // `gScratch_out` length 3*nVerts (xyz); `hScratch_out` length 6*nVerts

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -301,6 +301,14 @@ int AvbdSolver::step() {
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
     }
 
+    // 4. vbd_solve_apply: invert 3x3 H, write positions += -H⁻¹ g.
+    [enc setComputePipelineState:impl_->psoSolveApply];
+    [enc setBuffer:impl_->bufGScratch  offset:0 atIndex:0];
+    [enc setBuffer:impl_->bufHScratch  offset:0 atIndex:1];
+    [enc setBuffer:impl_->bufPositions offset:0 atIndex:2];
+    [enc dispatchThreads:MTLSizeMake(impl_->nVerts, 1, 1)
+   threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+
     [enc endEncoding];
     [cb commit];
     [cb waitUntilCompleted];
@@ -319,6 +327,14 @@ void AvbdSolver::readScratch(std::vector<float>& gScratch_out,
     readVec3Padded(gScratch_out, impl_->bufGScratch, n);
     hScratch_out.assign(6 * n, 0.0f);
     std::memcpy(hScratch_out.data(), impl_->bufHScratch.contents, 6 * n * sizeof(float));
+}
+
+void AvbdSolver::readPositions(std::vector<float>& positions_out) const {
+    if (!ok() || !impl_->meshReady) {
+        positions_out.clear();
+        return;
+    }
+    readVec3Padded(positions_out, impl_->bufPositions, impl_->nVerts);
 }
 
 void AvbdSolver::readSpringForce(std::vector<float>& gradA_out,

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -68,16 +68,26 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    std::vector<float> gOut, hOut;
-    solver.readScratch(gOut, hOut);
+    // After step(), check positions were updated by vbd_solve_apply.
+    //
+    // Per-vertex math: Δx = −H⁻¹ g, where (g, H) is the inertial term
+    // plus the spring contribution from the gather kernel.
+    //
+    // v0:  g=(-5,-8,-12), H=diag(5,4,4)
+    //   adj=diag(16,20,20), det=80, invDet=1/80
+    //   Δx = -(1/80)·(16·-5, 20·-8, 20·-12) = (1, 2, 3)
+    //   new pos = (0,0,0) + (1,2,3) = (1, 2, 3)
+    //
+    // v1:  g=(1,0,0), H=diag(3,2,2)
+    //   adj=diag(4,6,6), det=12, invDet=1/12
+    //   Δx = -(1/12)·(4·1, 6·0, 6·0) = (-1/3, 0, 0)
+    //   new pos = (3,0,0) + (-1/3,0,0) = (8/3, 0, 0)
+    std::vector<float> posOut;
+    solver.readPositions(posOut);
 
-    const float expected_g[3 * N] = {
-        -5.0f, -8.0f, -12.0f,
-         1.0f,  0.0f,   0.0f,
-    };
-    const float expected_h[6 * N] = {
-        5.0f, 0.0f, 0.0f, 4.0f, 0.0f, 4.0f,
-        3.0f, 0.0f, 0.0f, 2.0f, 0.0f, 2.0f,
+    const float expected_pos[3 * N] = {
+        1.0f, 2.0f, 3.0f,
+        8.0f / 3.0f, 0.0f, 0.0f,
     };
 
     int fails = 0;
@@ -94,12 +104,13 @@ int main(int argc, char** argv) {
             ++fails;
         }
     };
-    for (uint32_t i = 0; i < 3 * N; ++i) check(gOut[i], expected_g[i], "g", i);
-    for (uint32_t i = 0; i < 6 * N; ++i) check(hOut[i], expected_h[i], "h", i);
+    for (uint32_t i = 0; i < 3 * N; ++i) check(posOut[i], expected_pos[i], "pos", i);
 
     if (fails == 0) {
-        std::printf("test_avbd_solver: OK (vbd_init+spring_force+gather_spring on %u verts/%u spring, max_abs_diff=%g)\n",
+        std::printf("test_avbd_solver: OK (full AVBD step on %u verts/%u spring, max_abs_diff=%g)\n",
                     N, N_S, max_abs_diff);
+        std::printf("  v0 pos: (%g, %g, %g) — expected (1, 2, 3)\n",     posOut[0], posOut[1], posOut[2]);
+        std::printf("  v1 pos: (%g, %g, %g) — expected (8/3, 0, 0)\n",   posOut[3], posOut[4], posOut[5]);
         return 0;
     }
     std::fprintf(stderr, "test_avbd_solver: %d FAIL\n", fails);


### PR DESCRIPTION
## Summary
**Closes the spring-only AVBD outer iteration on real Metal hardware.**

\`step()\` now dispatches the full four-kernel pipeline in a single command buffer:
\`\`\`
1. vbd_init           inertial term per vertex
2. spring_force       per-spring force + GN Hessian
3. vbd_gather_spring  per-vertex CSR-based accumulation
4. vbd_solve_apply    3x3 adjugate-inverse, update positions in place
\`\`\`

After \`step()\`, \`positions[v] += −H⁻¹ g\`. Also adds \`readPositions(out)\` for verification.

## Verification (real Apple Silicon Metal)

\`\`\`
test_avbd_solver: OK (full AVBD step on 2 verts/1 spring, max_abs_diff=2.38e-07)
  v0 pos: (1, 2, 3)       — expected (1, 2, 3)
  v1 pos: (2.66667, 0, 0) — expected (8/3, 0, 0)
\`\`\`

Fixture: v0 at origin predicted to (1,2,3) with mass 2; v1 at (3,0,0) with predicted = position; spring between them with rest length 2, current length 3. After one AVBD step:
- **v0 lands exactly at predicted** — inertial and spring force contributions cancel out for vertex 0
- **v1 pulled by spring** from (3,0,0) toward v0 by 1/3 of a unit, landing at (8/3, 0, 0)

Output bit-accurate at fp32 ULP level (2.38e-7 ≈ 2× float epsilon, accumulated from the chain of fp ops in the 4-kernel pipeline).

## What this means

**The AVBD step now works end-to-end on GPU**: predict + inertia + constraint force + Hessian gather + 3x3 solve + position write — all on Apple Silicon Metal, all bit-checkable against hand-computed reference. A spring-only mesh can now be simulated by repeatedly calling \`step()\` from C++ code.

## Roadmap (#42) — PR-E progress

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver stub + vbd_init + spring_force + gather_spring (#56–59)
- 🟡 **PR-E AvbdSolver vbd_solve_apply — full spring step closes** — this PR
- PR-E AvbdSolver other constraint types (attachment, triangle, bending)
- PR-E Simulation.cpp routing (\`USE_AVBD=1\`)
- PR-F augmented Lagrangian dual update
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`make -C src/code/slang_solver test-avbd\` — 4-kernel chain bit-accurate at fp32 ULP
- [ ] CI lean-slang validate