### PR TITLE
AvbdSolver: dispatch attachment_force + gather_attachment (PR-E slice 6)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -70,11 +70,23 @@ public:
                        const float* restLen,
                        const float* stiffness);
 
-    // Dispatch one full AVBD outer iteration on the spring-only path:
-    //   1. vbd_init           writes inertial term to (gScratch, hScratch)
-    //   2. spring_force       per-spring force + GN Hessian
-    //   3. vbd_gather_spring  per-vertex accumulation via CSR adjacency
-    //   4. vbd_solve_apply    invert 3x3 H, update positions in place
+    // Upload attachment (point-pin) constraints. `nAttach` constraints
+    // pinning vertex `vertIdx[c]` to world anchor `fixedPos[c]` with
+    // stiffness `stiffness[c]`. `fixedPos` is flat float array of length
+    // 3 * nAttach (xyz). Allocates output buffers for attachment_force
+    // (gradV, hessScalar).
+    void uploadAttachments(uint32_t nAttach,
+                           const uint32_t* vertIdx,
+                           const float* fixedPos,
+                           const float* stiffness);
+
+    // Dispatch one full AVBD outer iteration:
+    //   1. vbd_init               inertial term per vertex
+    //   2. spring_force           per-spring force + Hess (if nSprings > 0)
+    //   3. vbd_gather_spring      per-vertex spring CSR gather
+    //   4. attachment_force       per-attachment force + Hess (if nAttach > 0)
+    //   5. vbd_gather_attachment  per-vertex attachment CSR gather
+    //   6. vbd_solve_apply        invert 3x3 H, update positions in place
     //
     // After step() returns, `readPositions(out)` returns the updated
     // vertex positions. Returns 0 on success, -1 if not set up.

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -35,8 +35,9 @@ struct AvbdSolver::Impl {
 
     // Per-constraint-type force kernels (compute force/Hess from
     // current positions before the gather kernel scatters them
-    // per-vertex). PR-E loads spring_force first; others follow.
+    // per-vertex).
     id<MTLComputePipelineState> psoSpringForce      = nil;
+    id<MTLComputePipelineState> psoAttachmentForce  = nil;
 
     // Per-vertex state buffers (allocated by setupMesh).
     id<MTLBuffer> bufPositions = nil;   // length = 3 * nVerts (float)
@@ -61,8 +62,21 @@ struct AvbdSolver::Impl {
     id<MTLBuffer> bufVertSpringIdx    = nil; // uint per (2*nSprings)
     id<MTLBuffer> bufVertSpringRole   = nil; // uint per (2*nSprings)
 
+    // Attachment constraint buffers (allocated by uploadAttachments).
+    // Each attachment pins one vertex to a fixed world anchor.
+    id<MTLBuffer> bufAttachVertIdx     = nil; // uint per attachment
+    id<MTLBuffer> bufAttachFixedPos    = nil; // padded float3 per attachment
+    id<MTLBuffer> bufAttachStiffness   = nil; // float per attachment
+    id<MTLBuffer> bufAttachGradV       = nil; // padded float3 per attachment
+    id<MTLBuffer> bufAttachHessScalar  = nil; // float per attachment
+
+    // Vertex → attachment CSR. Role is implicit (always 0 for K=1).
+    id<MTLBuffer> bufVertAttachOffset  = nil; // uint per (nVerts+1)
+    id<MTLBuffer> bufVertAttachIdx     = nil; // uint per nAttach
+
     uint32_t nVerts   = 0;
     uint32_t nSprings = 0;
+    uint32_t nAttach  = 0;
 
     bool ok = false;
     bool meshReady = false;
@@ -118,9 +132,10 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     id<MTLLibrary> libTriangle   = Impl::loadLib(impl_->device, root + "vbd_gather_triangle.metallib",  "vbd_gather_triangle");
     id<MTLLibrary> libBending    = Impl::loadLib(impl_->device, root + "vbd_gather_bending.metallib",   "vbd_gather_bending");
     id<MTLLibrary> libSolve      = Impl::loadLib(impl_->device, root + "vbd_solve_apply.metallib",      "vbd_solve_apply");
-    id<MTLLibrary> libSpringForce = Impl::loadLib(impl_->device, root + "spring_force.metallib",        "spring_force");
+    id<MTLLibrary> libSpringForce     = Impl::loadLib(impl_->device, root + "spring_force.metallib",     "spring_force");
+    id<MTLLibrary> libAttachmentForce = Impl::loadLib(impl_->device, root + "attachment_force.metallib", "attachment_force");
     if (!libInit || !libSpring || !libAttachment || !libTriangle || !libBending || !libSolve ||
-        !libSpringForce) return;
+        !libSpringForce || !libAttachmentForce) return;
 
     impl_->psoInit             = Impl::makePSO(impl_->device, libInit,       "main_0", "vbd_init");
     impl_->psoGatherSpring     = Impl::makePSO(impl_->device, libSpring,     "main_0", "vbd_gather_spring");
@@ -128,14 +143,15 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     impl_->psoGatherTriangle   = Impl::makePSO(impl_->device, libTriangle,   "main_0", "vbd_gather_triangle");
     impl_->psoGatherBending    = Impl::makePSO(impl_->device, libBending,    "main_0", "vbd_gather_bending");
     impl_->psoSolveApply       = Impl::makePSO(impl_->device, libSolve,      "main_0", "vbd_solve_apply");
-    impl_->psoSpringForce      = Impl::makePSO(impl_->device, libSpringForce, "main_0", "spring_force");
+    impl_->psoSpringForce      = Impl::makePSO(impl_->device, libSpringForce,     "main_0", "spring_force");
+    impl_->psoAttachmentForce  = Impl::makePSO(impl_->device, libAttachmentForce, "main_0", "attachment_force");
     if (!impl_->psoInit || !impl_->psoGatherSpring || !impl_->psoGatherAttachment ||
         !impl_->psoGatherTriangle || !impl_->psoGatherBending || !impl_->psoSolveApply ||
-        !impl_->psoSpringForce) return;
+        !impl_->psoSpringForce || !impl_->psoAttachmentForce) return;
 
     impl_->ok = true;
     std::fprintf(stderr,
-        "AvbdSolver: 7 kernels loaded (init, gather_{spring,attachment,triangle,bending}, solve_apply, spring_force)\n");
+        "AvbdSolver: 8 kernels loaded (init, gather_*, solve_apply, spring_force, attachment_force)\n");
 }
 
 AvbdSolver::~AvbdSolver() { delete impl_; }
@@ -253,6 +269,51 @@ void AvbdSolver::uploadSprings(uint32_t nSprings,
                                   options:opts];
 }
 
+void AvbdSolver::uploadAttachments(uint32_t nAttach,
+                                    const uint32_t* vertIdx,
+                                    const float* fixedPos,
+                                    const float* stiffness) {
+    if (!ok()) return;
+    impl_->nAttach = nAttach;
+    const NSUInteger bytesU = nAttach * sizeof(uint32_t);
+    const NSUInteger bytesF = nAttach * sizeof(float);
+    const NSUInteger bytesVec3Padded = 4 * nAttach * sizeof(float);
+    const MTLResourceOptions opts = MTLResourceStorageModeShared;
+
+    impl_->bufAttachVertIdx    = [impl_->device newBufferWithBytes:vertIdx   length:bytesU options:opts];
+    impl_->bufAttachFixedPos   = [impl_->device newBufferWithLength:bytesVec3Padded options:opts];
+    impl_->bufAttachStiffness  = [impl_->device newBufferWithBytes:stiffness length:bytesF options:opts];
+    impl_->bufAttachGradV      = [impl_->device newBufferWithLength:bytesVec3Padded options:opts];
+    impl_->bufAttachHessScalar = [impl_->device newBufferWithLength:bytesF options:opts];
+    uploadVec3Padded(impl_->bufAttachFixedPos, fixedPos, nAttach);
+
+    // Build vertex→attachment CSR. K=1, so each attachment contributes
+    // exactly one entry to vertIdx[c]. No role buffer — implicit 0.
+    const uint32_t nV = impl_->nVerts;
+    std::vector<uint32_t> counts(nV, 0u);
+    for (uint32_t i = 0; i < nAttach; ++i) counts[vertIdx[i]]++;
+    std::vector<uint32_t> offsets(nV + 1, 0u);
+    for (uint32_t v = 0; v < nV; ++v) offsets[v + 1] = offsets[v] + counts[v];
+    const uint32_t totalInc = offsets[nV];
+    std::vector<uint32_t> attachIdx(totalInc, 0u);
+    std::vector<uint32_t> cursor(nV, 0u);
+    for (uint32_t i = 0; i < nAttach; ++i) {
+        const uint32_t v = vertIdx[i];
+        const uint32_t p = offsets[v] + cursor[v];
+        attachIdx[p] = i;
+        cursor[v]++;
+    }
+
+    impl_->bufVertAttachOffset =
+        [impl_->device newBufferWithBytes:offsets.data()
+                                   length:offsets.size() * sizeof(uint32_t)
+                                  options:opts];
+    impl_->bufVertAttachIdx =
+        [impl_->device newBufferWithBytes:attachIdx.data()
+                                   length:attachIdx.size() * sizeof(uint32_t)
+                                  options:opts];
+}
+
 int AvbdSolver::step() {
     if (!ok() || !impl_->meshReady) return -1;
 
@@ -301,7 +362,30 @@ int AvbdSolver::step() {
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
     }
 
-    // 4. vbd_solve_apply: invert 3x3 H, write positions += -H⁻¹ g.
+    // 4. attachment_force + vbd_gather_attachment (if nAttach > 0).
+    if (impl_->nAttach > 0) {
+        [enc setComputePipelineState:impl_->psoAttachmentForce];
+        [enc setBuffer:impl_->bufPositions          offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufAttachVertIdx      offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufAttachFixedPos     offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufAttachStiffness    offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufAttachGradV        offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufAttachHessScalar   offset:0 atIndex:5];
+        [enc dispatchThreads:MTLSizeMake(impl_->nAttach, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+
+        [enc setComputePipelineState:impl_->psoGatherAttachment];
+        [enc setBuffer:impl_->bufAttachGradV        offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufAttachHessScalar   offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufVertAttachOffset   offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufVertAttachIdx      offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufGScratch           offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufHScratch           offset:0 atIndex:5];
+        [enc dispatchThreads:MTLSizeMake(impl_->nVerts, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+    }
+
+    // 5. vbd_solve_apply: invert 3x3 H, write positions += -H⁻¹ g.
     [enc setComputePipelineState:impl_->psoSolveApply];
     [enc setBuffer:impl_->bufGScratch  offset:0 atIndex:0];
     [enc setBuffer:impl_->bufHScratch  offset:0 atIndex:1];

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -1,26 +1,44 @@
 // Smoke test for AvbdSolver — verifies the AVBD pipeline dispatches
-// vbd_init + spring_force + vbd_gather_spring on real Metal hardware
-// and produces the expected accumulated outputs.
+// all wired kernels (vbd_init + spring_force + vbd_gather_spring +
+// attachment_force + vbd_gather_attachment + vbd_solve_apply) on real
+// Metal hardware and produces the expected updated positions.
 //
-// Test fixture (2 verts, 1 spring):
-//   v0:  x=(0,0,0)  pred=(1,2,3)  m=2  → w=4 (inertial)
-//   v1:  x=(3,0,0)  pred=(3,0,0)  m=1  → w=2 (inertial)
+// Test fixture (3 verts, 1 spring, 1 attachment):
+//   v0:  x=(0,0,0)  pred=(1,2,3)  m=2
+//   v1:  x=(3,0,0)  pred=(3,0,0)  m=1
+//   v2:  x=(0,0,0)  pred=(0,0,0)  m=1
 //   invH²=2
-//   s0:  a=0, b=1, L=2, k=1
-//        d = p_a − p_b = (−3,0,0), len=3, c=1
-//        gradA = (k·c/len)·d = (1/3)·(−3,0,0) = (−1,0,0)
-//        hess  = (k/len²)·d⊗d packed = (1/9)·[9,0,0,0,0,0] = [1,0,0,0,0,0]
-//   CSR:  offsets=[0,1,2], idx=[0,0], role=[0,1]
 //
-// Pipeline:
-//   vbd_init     → g[0]=(−4,−8,−12) h[0..5]=[4,0,0,4,0,4]
-//                  g[1]=(0,0,0)     h[6..11]=[2,0,0,2,0,2]
-//   spring_force → gradA[0]=(−1,0,0), hess[0..5]=[1,0,0,0,0,0]
-//   gather_spring (role-aware sign flip on gradient; Hessian no flip):
-//     v0 role 0 sign=+1: g[0] += (−1,0,0)  →  (−5,−8,−12)
-//                        h += hess         →  [5,0,0,4,0,4]
-//     v1 role 1 sign=−1: g[1] += (+1,0,0)  →  (1,0,0)
-//                        h += hess         →  [3,0,0,2,0,2]
+//   s0:  a=0, b=1, L=2, k=1  (same as PR #60 spring test)
+//   a0:  pins v2 to fixedPos=(0,0,10), stiffness k=4
+//
+// vbd_init writes (w=2m):
+//   v0: g=(-4,-8,-12) h_diag=4
+//   v1: g=(0,0,0)     h_diag=2
+//   v2: g=(0,0,0)     h_diag=2
+//
+// Spring path: (matches PR #60)
+//   v0: g+=(-1,0,0)  h+=[1,0,0,0,0,0]  →  g=(-5,-8,-12) h=[5,0,0,4,0,4]
+//   v1: g+=(1,0,0)   h+=[1,0,0,0,0,0]  →  g=(1,0,0)     h=[3,0,0,2,0,2]
+//
+// Attachment path:
+//   v2 has one attachment c=0; gradV = k·(p_v - fixed) = 4·(0-0, 0-0, 0-10) = (0,0,-40)
+//   hessScalar = k = 4
+//   gather: g[2] += (0,0,-40)  →  (0,0,-40)
+//           h[2] diag += 4     →  [6,0,0,6,0,6]
+//
+// vbd_solve_apply per vertex:
+//   v0:  H=diag(5,4,4), g=(-5,-8,-12)
+//        Δx = -(1/80)·(16·-5, 20·-8, 20·-12) = (1, 2, 3)
+//        new pos = (1, 2, 3)
+//   v1:  H=diag(3,2,2), g=(1,0,0)
+//        Δx = -(1/12)·(4·1, 0, 0) = (-1/3, 0, 0)
+//        new pos = (3-1/3, 0, 0) = (8/3, 0, 0)
+//   v2:  H=diag(6,6,6), g=(0,0,-40)
+//        det = 6·(36-0) + 0 + 0 = 216
+//        Δx = -(1/216)·(36·0, 36·0, 36·-40) = (0, 0, 40/6) ≈ (0,0,6.6667)
+//        new pos = (0, 0, 0) + (0, 0, 40/6) = (0, 0, 20/3)
+//        — attachment pulls v2 partially toward the (0,0,10) anchor
 
 #include "AvbdSolver.h"
 
@@ -42,25 +60,33 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    constexpr uint32_t N = 2;
+    constexpr uint32_t N = 3;
     const float positions[3 * N] = {
         0.0f, 0.0f, 0.0f,
         3.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f,
     };
     const float predicted[3 * N] = {
         1.0f, 2.0f, 3.0f,
         3.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f,
     };
-    const float mass[N] = {2.0f, 1.0f};
+    const float mass[N] = {2.0f, 1.0f, 1.0f};
     constexpr float invHSquared = 2.0f;
     solver.setupMesh(N, positions, predicted, mass, invHSquared);
 
     constexpr uint32_t N_S = 1;
-    const uint32_t p1Idx[N_S]    = {0u};
-    const uint32_t p2Idx[N_S]    = {1u};
-    const float restLen[N_S]     = {2.0f};
-    const float stiffness[N_S]   = {1.0f};
-    solver.uploadSprings(N_S, p1Idx, p2Idx, restLen, stiffness);
+    const uint32_t spP1[N_S]   = {0u};
+    const uint32_t spP2[N_S]   = {1u};
+    const float spLen[N_S]     = {2.0f};
+    const float spK[N_S]       = {1.0f};
+    solver.uploadSprings(N_S, spP1, spP2, spLen, spK);
+
+    constexpr uint32_t N_A = 1;
+    const uint32_t atVert[N_A] = {2u};
+    const float atFixed[3 * N_A] = {0.0f, 0.0f, 10.0f};
+    const float atK[N_A]       = {4.0f};
+    solver.uploadAttachments(N_A, atVert, atFixed, atK);
 
     const int rc = solver.step();
     if (rc != 0) {
@@ -68,26 +94,13 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    // After step(), check positions were updated by vbd_solve_apply.
-    //
-    // Per-vertex math: Δx = −H⁻¹ g, where (g, H) is the inertial term
-    // plus the spring contribution from the gather kernel.
-    //
-    // v0:  g=(-5,-8,-12), H=diag(5,4,4)
-    //   adj=diag(16,20,20), det=80, invDet=1/80
-    //   Δx = -(1/80)·(16·-5, 20·-8, 20·-12) = (1, 2, 3)
-    //   new pos = (0,0,0) + (1,2,3) = (1, 2, 3)
-    //
-    // v1:  g=(1,0,0), H=diag(3,2,2)
-    //   adj=diag(4,6,6), det=12, invDet=1/12
-    //   Δx = -(1/12)·(4·1, 6·0, 6·0) = (-1/3, 0, 0)
-    //   new pos = (3,0,0) + (-1/3,0,0) = (8/3, 0, 0)
     std::vector<float> posOut;
     solver.readPositions(posOut);
 
     const float expected_pos[3 * N] = {
         1.0f, 2.0f, 3.0f,
         8.0f / 3.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 20.0f / 3.0f,
     };
 
     int fails = 0;
@@ -107,10 +120,11 @@ int main(int argc, char** argv) {
     for (uint32_t i = 0; i < 3 * N; ++i) check(posOut[i], expected_pos[i], "pos", i);
 
     if (fails == 0) {
-        std::printf("test_avbd_solver: OK (full AVBD step on %u verts/%u spring, max_abs_diff=%g)\n",
-                    N, N_S, max_abs_diff);
-        std::printf("  v0 pos: (%g, %g, %g) — expected (1, 2, 3)\n",     posOut[0], posOut[1], posOut[2]);
-        std::printf("  v1 pos: (%g, %g, %g) — expected (8/3, 0, 0)\n",   posOut[3], posOut[4], posOut[5]);
+        std::printf("test_avbd_solver: OK (full AVBD step on %u verts, %u spring, %u attachment, max_abs_diff=%g)\n",
+                    N, N_S, N_A, max_abs_diff);
+        std::printf("  v0 pos: (%g, %g, %g) — expected (1, 2, 3)\n",      posOut[0], posOut[1], posOut[2]);
+        std::printf("  v1 pos: (%g, %g, %g) — expected (8/3, 0, 0)\n",    posOut[3], posOut[4], posOut[5]);
+        std::printf("  v2 pos: (%g, %g, %g) — expected (0, 0, 20/3)\n",   posOut[6], posOut[7], posOut[8]);
         return 0;
     }
     std::fprintf(stderr, "test_avbd_solver: %d FAIL\n", fails);


### PR DESCRIPTION
## Summary
Extends the spring-only AVBD step (#60) with the attachment constraint path. \`step()\` now dispatches 6 kernels in one command buffer:
\`\`\`
1. vbd_init
2. spring_force          (if nSprings > 0)
3. vbd_gather_spring     (if nSprings > 0)
4. attachment_force      (if nAttach > 0)
5. vbd_gather_attachment (if nAttach > 0)
6. vbd_solve_apply
\`\`\`

Adds:
- \`uploadAttachments(nAttach, vertIdx, fixedPos, stiffness)\` — uploads attachment inputs + builds K=1 CSR (single entry per attachment, no role flip)
- \`psoAttachmentForce\` PSO loaded at construction (8 kernels total)

## Verification (real Apple Silicon Metal)
\`\`\`
test_avbd_solver: OK (full AVBD step on 3 verts, 1 spring, 1 attachment, max_abs_diff=2.38e-07)
  v0 pos: (1, 2, 3)       — inertial only, lands at predicted
  v1 pos: (8/3, 0, 0)     — spring pulls 1/3 toward v0
  v2 pos: (0, 0, 20/3)    — attachment pulls 2/3 toward (0,0,10) anchor
\`\`\`

Spring + attachment cleanly compose into the same scratch buffers — the gather kernels accumulate their respective contributions before \`vbd_solve_apply\` inverts and writes positions. Each per-vertex physics outcome matches hand-computed reference at fp32 ULP level.

## Roadmap (#42) — PR-E progress

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E stub / vbd_init / spring_force / gather_spring / solve_apply (#56-60)
- 🟡 **PR-E attachment path** — this PR
- PR-E triangle membrane path (K=3 gather)
- PR-E dihedral bending path (K=4 gather)
- PR-E Simulation.cpp routing (\`USE_AVBD=1\`)
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`make -C src/code/slang_solver test-avbd\` — 6-kernel chain bit-accurate at fp32 ULP, three distinct physics outcomes
- [ ] CI lean-slang validate