### PR TITLE
AvbdSolver: dispatch triangle_membrane_force + gather_triangle (PR-E slice 7)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -80,13 +80,22 @@ public:
                            const float* fixedPos,
                            const float* stiffness);
 
+    // Upload triangle membrane (in-plane stretch) constraints.
+    // `nTri` triangles with corner vertex indices `triIdx` (length
+    // 3*nTri, interleaved (i0,i1,i2) per triangle) and stiffness
+    // `stiffness[c]`. Allocates output buffers for
+    // triangle_membrane_force (grad, hessScalar at slot 3*c+r).
+    void uploadTriangles(uint32_t nTri,
+                         const uint32_t* triIdx,
+                         const float* stiffness);
+
     // Dispatch one full AVBD outer iteration:
-    //   1. vbd_init               inertial term per vertex
-    //   2. spring_force           per-spring force + Hess (if nSprings > 0)
-    //   3. vbd_gather_spring      per-vertex spring CSR gather
-    //   4. attachment_force       per-attachment force + Hess (if nAttach > 0)
-    //   5. vbd_gather_attachment  per-vertex attachment CSR gather
-    //   6. vbd_solve_apply        invert 3x3 H, update positions in place
+    //   1. vbd_init                   inertial term per vertex
+    //   2. spring_force + gather      (if nSprings > 0)
+    //   3. attachment_force + gather  (if nAttach > 0)
+    //   4. triangle_membrane_force
+    //        + vbd_gather_triangle    (if nTri > 0)
+    //   5. vbd_solve_apply            invert 3x3 H, update positions
     //
     // After step() returns, `readPositions(out)` returns the updated
     // vertex positions. Returns 0 on success, -1 if not set up.

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -38,6 +38,7 @@ struct AvbdSolver::Impl {
     // per-vertex).
     id<MTLComputePipelineState> psoSpringForce      = nil;
     id<MTLComputePipelineState> psoAttachmentForce  = nil;
+    id<MTLComputePipelineState> psoTriangleMembraneForce = nil;
 
     // Per-vertex state buffers (allocated by setupMesh).
     id<MTLBuffer> bufPositions = nil;   // length = 3 * nVerts (float)
@@ -74,9 +75,21 @@ struct AvbdSolver::Impl {
     id<MTLBuffer> bufVertAttachOffset  = nil; // uint per (nVerts+1)
     id<MTLBuffer> bufVertAttachIdx     = nil; // uint per nAttach
 
+    // Triangle membrane constraint buffers (allocated by uploadTriangles).
+    id<MTLBuffer> bufTriIdx            = nil; // uint per (3 * nTri) — corners
+    id<MTLBuffer> bufTriStiffness      = nil; // float per nTri
+    id<MTLBuffer> bufTriGrad           = nil; // padded float3 per (3 * nTri)
+    id<MTLBuffer> bufTriHessScalar     = nil; // float per (3 * nTri)
+
+    // Vertex → triangle CSR. K=3, so role ∈ {0, 1, 2}.
+    id<MTLBuffer> bufVertTriOffset     = nil; // uint per (nVerts+1)
+    id<MTLBuffer> bufVertTriIdx        = nil; // uint per (3 * nTri)
+    id<MTLBuffer> bufVertTriRole       = nil; // uint per (3 * nTri)
+
     uint32_t nVerts   = 0;
     uint32_t nSprings = 0;
     uint32_t nAttach  = 0;
+    uint32_t nTri     = 0;
 
     bool ok = false;
     bool meshReady = false;
@@ -132,10 +145,11 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     id<MTLLibrary> libTriangle   = Impl::loadLib(impl_->device, root + "vbd_gather_triangle.metallib",  "vbd_gather_triangle");
     id<MTLLibrary> libBending    = Impl::loadLib(impl_->device, root + "vbd_gather_bending.metallib",   "vbd_gather_bending");
     id<MTLLibrary> libSolve      = Impl::loadLib(impl_->device, root + "vbd_solve_apply.metallib",      "vbd_solve_apply");
-    id<MTLLibrary> libSpringForce     = Impl::loadLib(impl_->device, root + "spring_force.metallib",     "spring_force");
-    id<MTLLibrary> libAttachmentForce = Impl::loadLib(impl_->device, root + "attachment_force.metallib", "attachment_force");
+    id<MTLLibrary> libSpringForce         = Impl::loadLib(impl_->device, root + "spring_force.metallib",            "spring_force");
+    id<MTLLibrary> libAttachmentForce     = Impl::loadLib(impl_->device, root + "attachment_force.metallib",        "attachment_force");
+    id<MTLLibrary> libTriMembraneForce    = Impl::loadLib(impl_->device, root + "triangle_membrane_force.metallib", "triangle_membrane_force");
     if (!libInit || !libSpring || !libAttachment || !libTriangle || !libBending || !libSolve ||
-        !libSpringForce || !libAttachmentForce) return;
+        !libSpringForce || !libAttachmentForce || !libTriMembraneForce) return;
 
     impl_->psoInit             = Impl::makePSO(impl_->device, libInit,       "main_0", "vbd_init");
     impl_->psoGatherSpring     = Impl::makePSO(impl_->device, libSpring,     "main_0", "vbd_gather_spring");
@@ -143,15 +157,17 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     impl_->psoGatherTriangle   = Impl::makePSO(impl_->device, libTriangle,   "main_0", "vbd_gather_triangle");
     impl_->psoGatherBending    = Impl::makePSO(impl_->device, libBending,    "main_0", "vbd_gather_bending");
     impl_->psoSolveApply       = Impl::makePSO(impl_->device, libSolve,      "main_0", "vbd_solve_apply");
-    impl_->psoSpringForce      = Impl::makePSO(impl_->device, libSpringForce,     "main_0", "spring_force");
-    impl_->psoAttachmentForce  = Impl::makePSO(impl_->device, libAttachmentForce, "main_0", "attachment_force");
+    impl_->psoSpringForce            = Impl::makePSO(impl_->device, libSpringForce,         "main_0", "spring_force");
+    impl_->psoAttachmentForce        = Impl::makePSO(impl_->device, libAttachmentForce,     "main_0", "attachment_force");
+    impl_->psoTriangleMembraneForce  = Impl::makePSO(impl_->device, libTriMembraneForce,    "main_0", "triangle_membrane_force");
     if (!impl_->psoInit || !impl_->psoGatherSpring || !impl_->psoGatherAttachment ||
         !impl_->psoGatherTriangle || !impl_->psoGatherBending || !impl_->psoSolveApply ||
-        !impl_->psoSpringForce || !impl_->psoAttachmentForce) return;
+        !impl_->psoSpringForce || !impl_->psoAttachmentForce ||
+        !impl_->psoTriangleMembraneForce) return;
 
     impl_->ok = true;
     std::fprintf(stderr,
-        "AvbdSolver: 8 kernels loaded (init, gather_*, solve_apply, spring_force, attachment_force)\n");
+        "AvbdSolver: 9 kernels loaded (init, gather_*, solve_apply, spring/attachment/triangle_force)\n");
 }
 
 AvbdSolver::~AvbdSolver() { delete impl_; }
@@ -314,6 +330,57 @@ void AvbdSolver::uploadAttachments(uint32_t nAttach,
                                   options:opts];
 }
 
+void AvbdSolver::uploadTriangles(uint32_t nTri,
+                                  const uint32_t* triIdx,
+                                  const float* stiffness) {
+    if (!ok()) return;
+    impl_->nTri = nTri;
+    const NSUInteger bytesTriIdx = 3 * nTri * sizeof(uint32_t);
+    const NSUInteger bytesF      = nTri * sizeof(float);
+    const NSUInteger bytesGradPadded   = 4 * 3 * nTri * sizeof(float);
+    const NSUInteger bytesHessScalar   = 3 * nTri * sizeof(float);
+    const MTLResourceOptions opts = MTLResourceStorageModeShared;
+
+    impl_->bufTriIdx        = [impl_->device newBufferWithBytes:triIdx    length:bytesTriIdx options:opts];
+    impl_->bufTriStiffness  = [impl_->device newBufferWithBytes:stiffness length:bytesF      options:opts];
+    impl_->bufTriGrad       = [impl_->device newBufferWithLength:bytesGradPadded options:opts];
+    impl_->bufTriHessScalar = [impl_->device newBufferWithLength:bytesHessScalar options:opts];
+
+    // Build vertex→triangle CSR. K=3, role ∈ {0,1,2} per corner.
+    const uint32_t nV = impl_->nVerts;
+    std::vector<uint32_t> counts(nV, 0u);
+    for (uint32_t c = 0; c < nTri; ++c)
+        for (uint32_t r = 0; r < 3; ++r) counts[triIdx[3*c + r]]++;
+    std::vector<uint32_t> offsets(nV + 1, 0u);
+    for (uint32_t v = 0; v < nV; ++v) offsets[v + 1] = offsets[v] + counts[v];
+    const uint32_t totalInc = offsets[nV];
+    std::vector<uint32_t> idxArr(totalInc, 0u);
+    std::vector<uint32_t> roleArr(totalInc, 0u);
+    std::vector<uint32_t> cursor(nV, 0u);
+    for (uint32_t c = 0; c < nTri; ++c) {
+        for (uint32_t r = 0; r < 3; ++r) {
+            const uint32_t v = triIdx[3*c + r];
+            const uint32_t p = offsets[v] + cursor[v];
+            idxArr[p]  = c;
+            roleArr[p] = r;
+            cursor[v]++;
+        }
+    }
+
+    impl_->bufVertTriOffset =
+        [impl_->device newBufferWithBytes:offsets.data()
+                                   length:offsets.size() * sizeof(uint32_t)
+                                  options:opts];
+    impl_->bufVertTriIdx =
+        [impl_->device newBufferWithBytes:idxArr.data()
+                                   length:idxArr.size() * sizeof(uint32_t)
+                                  options:opts];
+    impl_->bufVertTriRole =
+        [impl_->device newBufferWithBytes:roleArr.data()
+                                   length:roleArr.size() * sizeof(uint32_t)
+                                  options:opts];
+}
+
 int AvbdSolver::step() {
     if (!ok() || !impl_->meshReady) return -1;
 
@@ -385,7 +452,30 @@ int AvbdSolver::step() {
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
     }
 
-    // 5. vbd_solve_apply: invert 3x3 H, write positions += -H⁻¹ g.
+    // 5. triangle_membrane_force + vbd_gather_triangle (if nTri > 0).
+    if (impl_->nTri > 0) {
+        [enc setComputePipelineState:impl_->psoTriangleMembraneForce];
+        [enc setBuffer:impl_->bufPositions      offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufTriIdx         offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufTriStiffness   offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufTriGrad        offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufTriHessScalar  offset:0 atIndex:4];
+        [enc dispatchThreads:MTLSizeMake(impl_->nTri, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+
+        [enc setComputePipelineState:impl_->psoGatherTriangle];
+        [enc setBuffer:impl_->bufTriGrad        offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufTriHessScalar  offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufVertTriOffset  offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufVertTriIdx     offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufVertTriRole    offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufGScratch       offset:0 atIndex:5];
+        [enc setBuffer:impl_->bufHScratch       offset:0 atIndex:6];
+        [enc dispatchThreads:MTLSizeMake(impl_->nVerts, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+    }
+
+    // 6. vbd_solve_apply: invert 3x3 H, write positions += -H⁻¹ g.
     [enc setComputePipelineState:impl_->psoSolveApply];
     [enc setBuffer:impl_->bufGScratch  offset:0 atIndex:0];
     [enc setBuffer:impl_->bufHScratch  offset:0 atIndex:1];

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -1,44 +1,55 @@
-// Smoke test for AvbdSolver — verifies the AVBD pipeline dispatches
-// all wired kernels (vbd_init + spring_force + vbd_gather_spring +
-// attachment_force + vbd_gather_attachment + vbd_solve_apply) on real
-// Metal hardware and produces the expected updated positions.
+// Smoke test for AvbdSolver — full AVBD chain over springs + attachments
+// + triangle membrane on real Metal hardware.
 //
-// Test fixture (3 verts, 1 spring, 1 attachment):
+// Test fixture (3 verts, 1 spring, 1 attachment, 1 triangle):
 //   v0:  x=(0,0,0)  pred=(1,2,3)  m=2
 //   v1:  x=(3,0,0)  pred=(3,0,0)  m=1
-//   v2:  x=(0,0,0)  pred=(0,0,0)  m=1
+//   v2:  x=(0,4,0)  pred=(0,4,0)  m=1
 //   invH²=2
 //
-//   s0:  a=0, b=1, L=2, k=1  (same as PR #60 spring test)
-//   a0:  pins v2 to fixedPos=(0,0,10), stiffness k=4
+//   s0:  spring(0,1) L=2 k=1
+//   a0:  attach v2 to (0,4,10) k=4
+//   T0:  triangle (0,1,2) k=1  — current shape is a 3-4-5 right tri,
+//        rest shape (after corotational projection) is unit edges in x,y;
+//        deformation residual drives a per-vertex force/Hessian.
 //
-// vbd_init writes (w=2m):
-//   v0: g=(-4,-8,-12) h_diag=4
-//   v1: g=(0,0,0)     h_diag=2
-//   v2: g=(0,0,0)     h_diag=2
+// vbd_init (w=2m):
+//   v0: g=(-4,-8,-12), h_diag=4
+//   v1: g=(0,0,0),     h_diag=2
+//   v2: g=(0,0,0),     h_diag=2
 //
-// Spring path: (matches PR #60)
-//   v0: g+=(-1,0,0)  h+=[1,0,0,0,0,0]  →  g=(-5,-8,-12) h=[5,0,0,4,0,4]
-//   v1: g+=(1,0,0)   h+=[1,0,0,0,0,0]  →  g=(1,0,0)     h=[3,0,0,2,0,2]
+// Spring (a=0, b=1, d=(-3,0,0), len=3, c=1, scale=1/3 → gradA=(-1,0,0), hess=[1,0,0,0,0,0]):
+//   v0 role 0, sign=+1: g+=(-1,0,0)  h+=[1,0,0,0,0,0]
+//   v1 role 1, sign=-1: g+=(1,0,0)   h+=[1,0,0,0,0,0]
 //
-// Attachment path:
-//   v2 has one attachment c=0; gradV = k·(p_v - fixed) = 4·(0-0, 0-0, 0-10) = (0,0,-40)
-//   hessScalar = k = 4
-//   gather: g[2] += (0,0,-40)  →  (0,0,-40)
-//           h[2] diag += 4     →  [6,0,0,6,0,6]
+// Attachment (pins v2 to (0,4,10), k=4):
+//   gradV = k·(p-fixed) = 4·(0,0,-10) = (0,0,-40), hessScalar = 4
+//   v2: g+=(0,0,-40)   h_diag+=4
 //
-// vbd_solve_apply per vertex:
-//   v0:  H=diag(5,4,4), g=(-5,-8,-12)
-//        Δx = -(1/80)·(16·-5, 20·-8, 20·-12) = (1, 2, 3)
-//        new pos = (1, 2, 3)
-//   v1:  H=diag(3,2,2), g=(1,0,0)
-//        Δx = -(1/12)·(4·1, 0, 0) = (-1/3, 0, 0)
-//        new pos = (3-1/3, 0, 0) = (8/3, 0, 0)
-//   v2:  H=diag(6,6,6), g=(0,0,-40)
-//        det = 6·(36-0) + 0 + 0 = 216
-//        Δx = -(1/216)·(36·0, 36·0, 36·-40) = (0, 0, 40/6) ≈ (0,0,6.6667)
-//        new pos = (0, 0, 0) + (0, 0, 40/6) = (0, 0, 20/3)
-//        — attachment pulls v2 partially toward the (0,0,10) anchor
+// Triangle membrane:
+//   F = [(3,0,0)|(0,4,0)]; a=3, b=0, d=4, R=I
+//   newF.col(0)=(1,0,0), newF.col(1)=(0,1,0)
+//   e0 = (2,0,0), e1_resid=(0,3,0)
+//   With k=1:
+//     grad[0] = -(2,3,0)  hessScalar[0] = 2
+//     grad[1] = +(2,0,0)  hessScalar[1] = 1
+//     grad[2] = +(0,3,0)  hessScalar[2] = 1
+//   v0 (role 0): g+=(-2,-3,0)  h_diag+=2
+//   v1 (role 1): g+=(2,0,0)    h_diag+=1
+//   v2 (role 2): g+=(0,3,0)    h_diag+=1
+//
+// Accumulated per-vertex (g, H=diag(Hxx,Hyy,Hzz)):
+//   v0:  g=(-7,-11,-12)  H=diag(7,6,6)
+//   v1:  g=(3,0,0)       H=diag(4,3,3)
+//   v2:  g=(0,3,-40)     H=diag(7,7,7)
+//
+// vbd_solve_apply Δx = -H⁻¹·g (diagonal H → componentwise):
+//   v0:  Δx = (7/7, 11/6, 12/6) = (1, 11/6, 2)
+//        new pos = (1, 11/6, 2)
+//   v1:  Δx = (-3/4, 0, 0)
+//        new pos = (9/4, 0, 0)
+//   v2:  Δx = (0, -3/7, 40/7)
+//        new pos = (0, 25/7, 40/7)
 
 #include "AvbdSolver.h"
 
@@ -64,12 +75,12 @@ int main(int argc, char** argv) {
     const float positions[3 * N] = {
         0.0f, 0.0f, 0.0f,
         3.0f, 0.0f, 0.0f,
-        0.0f, 0.0f, 0.0f,
+        0.0f, 4.0f, 0.0f,
     };
     const float predicted[3 * N] = {
         1.0f, 2.0f, 3.0f,
         3.0f, 0.0f, 0.0f,
-        0.0f, 0.0f, 0.0f,
+        0.0f, 4.0f, 0.0f,
     };
     const float mass[N] = {2.0f, 1.0f, 1.0f};
     constexpr float invHSquared = 2.0f;
@@ -83,10 +94,15 @@ int main(int argc, char** argv) {
     solver.uploadSprings(N_S, spP1, spP2, spLen, spK);
 
     constexpr uint32_t N_A = 1;
-    const uint32_t atVert[N_A] = {2u};
-    const float atFixed[3 * N_A] = {0.0f, 0.0f, 10.0f};
-    const float atK[N_A]       = {4.0f};
+    const uint32_t atVert[N_A]     = {2u};
+    const float atFixed[3 * N_A]   = {0.0f, 4.0f, 10.0f};
+    const float atK[N_A]           = {4.0f};
     solver.uploadAttachments(N_A, atVert, atFixed, atK);
+
+    constexpr uint32_t N_T = 1;
+    const uint32_t triIdx[3 * N_T] = {0u, 1u, 2u};
+    const float triK[N_T]          = {1.0f};
+    solver.uploadTriangles(N_T, triIdx, triK);
 
     const int rc = solver.step();
     if (rc != 0) {
@@ -98,9 +114,9 @@ int main(int argc, char** argv) {
     solver.readPositions(posOut);
 
     const float expected_pos[3 * N] = {
-        1.0f, 2.0f, 3.0f,
-        8.0f / 3.0f, 0.0f, 0.0f,
-        0.0f, 0.0f, 20.0f / 3.0f,
+        1.0f, 11.0f / 6.0f, 2.0f,
+        9.0f / 4.0f, 0.0f, 0.0f,
+        0.0f, 25.0f / 7.0f, 40.0f / 7.0f,
     };
 
     int fails = 0;
@@ -120,11 +136,11 @@ int main(int argc, char** argv) {
     for (uint32_t i = 0; i < 3 * N; ++i) check(posOut[i], expected_pos[i], "pos", i);
 
     if (fails == 0) {
-        std::printf("test_avbd_solver: OK (full AVBD step on %u verts, %u spring, %u attachment, max_abs_diff=%g)\n",
-                    N, N_S, N_A, max_abs_diff);
-        std::printf("  v0 pos: (%g, %g, %g) — expected (1, 2, 3)\n",      posOut[0], posOut[1], posOut[2]);
-        std::printf("  v1 pos: (%g, %g, %g) — expected (8/3, 0, 0)\n",    posOut[3], posOut[4], posOut[5]);
-        std::printf("  v2 pos: (%g, %g, %g) — expected (0, 0, 20/3)\n",   posOut[6], posOut[7], posOut[8]);
+        std::printf("test_avbd_solver: OK (full AVBD step on %u verts: %u springs, %u attach, %u tri, max_abs_diff=%g)\n",
+                    N, N_S, N_A, N_T, max_abs_diff);
+        std::printf("  v0 pos: (%g, %g, %g) — expected (1, 11/6, 2)\n",       posOut[0], posOut[1], posOut[2]);
+        std::printf("  v1 pos: (%g, %g, %g) — expected (9/4, 0, 0)\n",        posOut[3], posOut[4], posOut[5]);
+        std::printf("  v2 pos: (%g, %g, %g) — expected (0, 25/7, 40/7)\n",    posOut[6], posOut[7], posOut[8]);
         return 0;
     }
     std::fprintf(stderr, "test_avbd_solver: %d FAIL\n", fails);


### PR DESCRIPTION
## Summary
Extends the AVBD step with the triangle membrane (in-plane stretch) constraint. \`step()\` now dispatches **8 kernels in a single Metal command buffer**:
\`\`\`
1. vbd_init
2. spring_force + vbd_gather_spring             (if nSprings)
3. attachment_force + vbd_gather_attachment     (if nAttach)
4. triangle_membrane_force + vbd_gather_triangle (if nTri)
5. vbd_solve_apply
\`\`\`

\`uploadTriangles\` builds the K=3 CSR adjacency (role ∈ {0,1,2}) and allocates per-corner output buffers at slot \`3·c+r\`.

## Verification (real Apple Silicon Metal)
\`\`\`
AvbdSolver: 9 kernels loaded
test_avbd_solver: OK (max_abs_diff=1.19e-07)
  v0 pos: (1, 11/6, 2)         — inertial + spring role 0 + triangle role 0
  v1 pos: (9/4, 0, 0)          — spring role 1 + triangle role 1
  v2 pos: (0, 25/7, 40/7)      — attachment + triangle role 2
\`\`\`

3-vert / 1-spring / 1-attachment / 1-triangle fixture. The triangle is a 3-4-5 right triangle being corotationally projected back toward its rest shape (unit edges along x and y). Each per-vertex outcome bit-accurate at fp32 ULP.

## Roadmap (#42) — PR-E progress

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E stub / spring + attachment paths (#56-61)
- 🟡 **PR-E triangle membrane path** — this PR
- PR-E dihedral bending path (K=4)
- PR-E Simulation.cpp routing (\`USE_AVBD=1\`)
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`make -C src/code/slang_solver test-avbd\` — 8-kernel chain bit-accurate at fp32 ULP
- [ ] CI lean-slang validate