### PR TITLE
AvbdSolver: dispatch triangle_bending_force + gather_bending — constraint coverage COMPLETE (PR-E slice 8)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -89,13 +89,29 @@ public:
                          const uint32_t* triIdx,
                          const float* stiffness);
 
-    // Dispatch one full AVBD outer iteration:
+    // Upload dihedral bending constraints. `nBend` bending stencils
+    // with 4-vertex indices `bendIdx` (length 4*nBend), bind-time
+    // Laplacian `weight` (length 4*nBend), rest magnitude
+    // `nTarget[c]` (degenerate stencils have nTarget=0 → no
+    // contribution), and stiffness `stiffness[c]`. Allocates output
+    // buffers for triangle_bending_force (grad, hessScalar at slot
+    // 4*c+r).
+    void uploadBendings(uint32_t nBend,
+                        const uint32_t* bendIdx,
+                        const float* weight,
+                        const float* nTarget,
+                        const float* stiffness);
+
+    // Dispatch one full AVBD outer iteration covering every constraint
+    // type DiffCloth uses:
     //   1. vbd_init                   inertial term per vertex
     //   2. spring_force + gather      (if nSprings > 0)
     //   3. attachment_force + gather  (if nAttach > 0)
     //   4. triangle_membrane_force
     //        + vbd_gather_triangle    (if nTri > 0)
-    //   5. vbd_solve_apply            invert 3x3 H, update positions
+    //   5. triangle_bending_force
+    //        + vbd_gather_bending     (if nBend > 0)
+    //   6. vbd_solve_apply            invert 3x3 H, update positions
     //
     // After step() returns, `readPositions(out)` returns the updated
     // vertex positions. Returns 0 on success, -1 if not set up.

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -39,6 +39,7 @@ struct AvbdSolver::Impl {
     id<MTLComputePipelineState> psoSpringForce      = nil;
     id<MTLComputePipelineState> psoAttachmentForce  = nil;
     id<MTLComputePipelineState> psoTriangleMembraneForce = nil;
+    id<MTLComputePipelineState> psoTriangleBendingForce  = nil;
 
     // Per-vertex state buffers (allocated by setupMesh).
     id<MTLBuffer> bufPositions = nil;   // length = 3 * nVerts (float)
@@ -86,10 +87,24 @@ struct AvbdSolver::Impl {
     id<MTLBuffer> bufVertTriIdx        = nil; // uint per (3 * nTri)
     id<MTLBuffer> bufVertTriRole       = nil; // uint per (3 * nTri)
 
+    // Bending constraint buffers (allocated by uploadBendings).
+    id<MTLBuffer> bufBendIdx           = nil; // uint per (4 * nBend) — 4-vert stencil
+    id<MTLBuffer> bufBendWeight        = nil; // float per (4 * nBend) — Laplacian weights
+    id<MTLBuffer> bufBendNTarget       = nil; // float per nBend — rest magnitude
+    id<MTLBuffer> bufBendStiffness     = nil; // float per nBend
+    id<MTLBuffer> bufBendGrad          = nil; // padded float3 per (4 * nBend)
+    id<MTLBuffer> bufBendHessScalar    = nil; // float per (4 * nBend)
+
+    // Vertex → bending CSR. K=4, role ∈ {0, 1, 2, 3}.
+    id<MTLBuffer> bufVertBendOffset    = nil; // uint per (nVerts+1)
+    id<MTLBuffer> bufVertBendIdx       = nil; // uint per (4 * nBend)
+    id<MTLBuffer> bufVertBendRole      = nil; // uint per (4 * nBend)
+
     uint32_t nVerts   = 0;
     uint32_t nSprings = 0;
     uint32_t nAttach  = 0;
     uint32_t nTri     = 0;
+    uint32_t nBend    = 0;
 
     bool ok = false;
     bool meshReady = false;
@@ -148,8 +163,9 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     id<MTLLibrary> libSpringForce         = Impl::loadLib(impl_->device, root + "spring_force.metallib",            "spring_force");
     id<MTLLibrary> libAttachmentForce     = Impl::loadLib(impl_->device, root + "attachment_force.metallib",        "attachment_force");
     id<MTLLibrary> libTriMembraneForce    = Impl::loadLib(impl_->device, root + "triangle_membrane_force.metallib", "triangle_membrane_force");
+    id<MTLLibrary> libTriBendingForce     = Impl::loadLib(impl_->device, root + "triangle_bending_force.metallib",  "triangle_bending_force");
     if (!libInit || !libSpring || !libAttachment || !libTriangle || !libBending || !libSolve ||
-        !libSpringForce || !libAttachmentForce || !libTriMembraneForce) return;
+        !libSpringForce || !libAttachmentForce || !libTriMembraneForce || !libTriBendingForce) return;
 
     impl_->psoInit             = Impl::makePSO(impl_->device, libInit,       "main_0", "vbd_init");
     impl_->psoGatherSpring     = Impl::makePSO(impl_->device, libSpring,     "main_0", "vbd_gather_spring");
@@ -160,14 +176,15 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     impl_->psoSpringForce            = Impl::makePSO(impl_->device, libSpringForce,         "main_0", "spring_force");
     impl_->psoAttachmentForce        = Impl::makePSO(impl_->device, libAttachmentForce,     "main_0", "attachment_force");
     impl_->psoTriangleMembraneForce  = Impl::makePSO(impl_->device, libTriMembraneForce,    "main_0", "triangle_membrane_force");
+    impl_->psoTriangleBendingForce   = Impl::makePSO(impl_->device, libTriBendingForce,     "main_0", "triangle_bending_force");
     if (!impl_->psoInit || !impl_->psoGatherSpring || !impl_->psoGatherAttachment ||
         !impl_->psoGatherTriangle || !impl_->psoGatherBending || !impl_->psoSolveApply ||
         !impl_->psoSpringForce || !impl_->psoAttachmentForce ||
-        !impl_->psoTriangleMembraneForce) return;
+        !impl_->psoTriangleMembraneForce || !impl_->psoTriangleBendingForce) return;
 
     impl_->ok = true;
     std::fprintf(stderr,
-        "AvbdSolver: 9 kernels loaded (init, gather_*, solve_apply, spring/attachment/triangle_force)\n");
+        "AvbdSolver: 10 kernels loaded — full AVBD pipeline (init, gather_*, solve_apply, spring/attach/tri/bend_force)\n");
 }
 
 AvbdSolver::~AvbdSolver() { delete impl_; }
@@ -381,6 +398,62 @@ void AvbdSolver::uploadTriangles(uint32_t nTri,
                                   options:opts];
 }
 
+void AvbdSolver::uploadBendings(uint32_t nBend,
+                                 const uint32_t* bendIdx,
+                                 const float* weight,
+                                 const float* nTarget,
+                                 const float* stiffness) {
+    if (!ok()) return;
+    impl_->nBend = nBend;
+    const NSUInteger bytesBendIdx    = 4 * nBend * sizeof(uint32_t);
+    const NSUInteger bytesBendWeight = 4 * nBend * sizeof(float);
+    const NSUInteger bytesF          = nBend * sizeof(float);
+    const NSUInteger bytesGradPadded = 4 * 4 * nBend * sizeof(float);
+    const NSUInteger bytesHessScalar = 4 * nBend * sizeof(float);
+    const MTLResourceOptions opts = MTLResourceStorageModeShared;
+
+    impl_->bufBendIdx        = [impl_->device newBufferWithBytes:bendIdx   length:bytesBendIdx    options:opts];
+    impl_->bufBendWeight     = [impl_->device newBufferWithBytes:weight    length:bytesBendWeight options:opts];
+    impl_->bufBendNTarget    = [impl_->device newBufferWithBytes:nTarget   length:bytesF          options:opts];
+    impl_->bufBendStiffness  = [impl_->device newBufferWithBytes:stiffness length:bytesF          options:opts];
+    impl_->bufBendGrad       = [impl_->device newBufferWithLength:bytesGradPadded options:opts];
+    impl_->bufBendHessScalar = [impl_->device newBufferWithLength:bytesHessScalar options:opts];
+
+    // Build vertex→bending CSR. K=4, role ∈ {0,1,2,3} per stencil corner.
+    const uint32_t nV = impl_->nVerts;
+    std::vector<uint32_t> counts(nV, 0u);
+    for (uint32_t c = 0; c < nBend; ++c)
+        for (uint32_t r = 0; r < 4; ++r) counts[bendIdx[4*c + r]]++;
+    std::vector<uint32_t> offsets(nV + 1, 0u);
+    for (uint32_t v = 0; v < nV; ++v) offsets[v + 1] = offsets[v] + counts[v];
+    const uint32_t totalInc = offsets[nV];
+    std::vector<uint32_t> idxArr(totalInc, 0u);
+    std::vector<uint32_t> roleArr(totalInc, 0u);
+    std::vector<uint32_t> cursor(nV, 0u);
+    for (uint32_t c = 0; c < nBend; ++c) {
+        for (uint32_t r = 0; r < 4; ++r) {
+            const uint32_t v = bendIdx[4*c + r];
+            const uint32_t p = offsets[v] + cursor[v];
+            idxArr[p]  = c;
+            roleArr[p] = r;
+            cursor[v]++;
+        }
+    }
+
+    impl_->bufVertBendOffset =
+        [impl_->device newBufferWithBytes:offsets.data()
+                                   length:offsets.size() * sizeof(uint32_t)
+                                  options:opts];
+    impl_->bufVertBendIdx =
+        [impl_->device newBufferWithBytes:idxArr.data()
+                                   length:idxArr.size() * sizeof(uint32_t)
+                                  options:opts];
+    impl_->bufVertBendRole =
+        [impl_->device newBufferWithBytes:roleArr.data()
+                                   length:roleArr.size() * sizeof(uint32_t)
+                                  options:opts];
+}
+
 int AvbdSolver::step() {
     if (!ok() || !impl_->meshReady) return -1;
 
@@ -475,7 +548,32 @@ int AvbdSolver::step() {
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
     }
 
-    // 6. vbd_solve_apply: invert 3x3 H, write positions += -H⁻¹ g.
+    // 6. triangle_bending_force + vbd_gather_bending (if nBend > 0).
+    if (impl_->nBend > 0) {
+        [enc setComputePipelineState:impl_->psoTriangleBendingForce];
+        [enc setBuffer:impl_->bufPositions       offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufBendIdx         offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufBendWeight      offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufBendNTarget     offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufBendStiffness   offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufBendGrad        offset:0 atIndex:5];
+        [enc setBuffer:impl_->bufBendHessScalar  offset:0 atIndex:6];
+        [enc dispatchThreads:MTLSizeMake(impl_->nBend, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+
+        [enc setComputePipelineState:impl_->psoGatherBending];
+        [enc setBuffer:impl_->bufBendGrad        offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufBendHessScalar  offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufVertBendOffset  offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufVertBendIdx     offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufVertBendRole    offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufGScratch        offset:0 atIndex:5];
+        [enc setBuffer:impl_->bufHScratch        offset:0 atIndex:6];
+        [enc dispatchThreads:MTLSizeMake(impl_->nVerts, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+    }
+
+    // 7. vbd_solve_apply: invert 3x3 H, write positions += -H⁻¹ g.
     [enc setComputePipelineState:impl_->psoSolveApply];
     [enc setBuffer:impl_->bufGScratch  offset:0 atIndex:0];
     [enc setBuffer:impl_->bufHScratch  offset:0 atIndex:1];

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -1,55 +1,42 @@
-// Smoke test for AvbdSolver — full AVBD chain over springs + attachments
-// + triangle membrane on real Metal hardware.
+// Smoke test for AvbdSolver — full AVBD pipeline (all 10 kernels)
+// over springs + attachments + triangle membrane + bending on real
+// Metal hardware.
 //
-// Test fixture (3 verts, 1 spring, 1 attachment, 1 triangle):
+// Test fixture (4 verts, 1 spring, 1 attachment, 1 triangle, 1 bending):
 //   v0:  x=(0,0,0)  pred=(1,2,3)  m=2
 //   v1:  x=(3,0,0)  pred=(3,0,0)  m=1
 //   v2:  x=(0,4,0)  pred=(0,4,0)  m=1
+//   v3:  x=(3,4,0)  pred=(3,4,0)  m=1
 //   invH²=2
 //
 //   s0:  spring(0,1) L=2 k=1
 //   a0:  attach v2 to (0,4,10) k=4
-//   T0:  triangle (0,1,2) k=1  — current shape is a 3-4-5 right tri,
-//        rest shape (after corotational projection) is unit edges in x,y;
-//        deformation residual drives a per-vertex force/Hessian.
-//
-// vbd_init (w=2m):
-//   v0: g=(-4,-8,-12), h_diag=4
-//   v1: g=(0,0,0),     h_diag=2
-//   v2: g=(0,0,0),     h_diag=2
-//
-// Spring (a=0, b=1, d=(-3,0,0), len=3, c=1, scale=1/3 → gradA=(-1,0,0), hess=[1,0,0,0,0,0]):
-//   v0 role 0, sign=+1: g+=(-1,0,0)  h+=[1,0,0,0,0,0]
-//   v1 role 1, sign=-1: g+=(1,0,0)   h+=[1,0,0,0,0,0]
-//
-// Attachment (pins v2 to (0,4,10), k=4):
-//   gradV = k·(p-fixed) = 4·(0,0,-10) = (0,0,-40), hessScalar = 4
-//   v2: g+=(0,0,-40)   h_diag+=4
-//
-// Triangle membrane:
-//   F = [(3,0,0)|(0,4,0)]; a=3, b=0, d=4, R=I
-//   newF.col(0)=(1,0,0), newF.col(1)=(0,1,0)
-//   e0 = (2,0,0), e1_resid=(0,3,0)
-//   With k=1:
-//     grad[0] = -(2,3,0)  hessScalar[0] = 2
-//     grad[1] = +(2,0,0)  hessScalar[1] = 1
-//     grad[2] = +(0,3,0)  hessScalar[2] = 1
-//   v0 (role 0): g+=(-2,-3,0)  h_diag+=2
-//   v1 (role 1): g+=(2,0,0)    h_diag+=1
-//   v2 (role 2): g+=(0,3,0)    h_diag+=1
+//   T0:  triangle (0,1,2) k=1 (3-4-5 right tri being projected toward
+//        unit-edges rest)
+//   B0:  bending stencil (0,1,2,3) weights=(1,1,-1,-1) nTarget=4 k=1
+//        Σ w·p = (0,0,0)+(3,0,0)-(0,4,0)-(3,4,0) = (0,-8,0)
+//        |s|=8, scale=4/8=0.5, om=0.5, resid=(0,-4,0)
+//        Per-corner: grad = k·w·resid; hessScalar = k·w²
+//          v0 (w=+1):  grad=(0,-4,0)  hs=1
+//          v1 (w=+1):  grad=(0,-4,0)  hs=1
+//          v2 (w=-1):  grad=(0,+4,0)  hs=1
+//          v3 (w=-1):  grad=(0,+4,0)  hs=1
 //
 // Accumulated per-vertex (g, H=diag(Hxx,Hyy,Hzz)):
-//   v0:  g=(-7,-11,-12)  H=diag(7,6,6)
-//   v1:  g=(3,0,0)       H=diag(4,3,3)
-//   v2:  g=(0,3,-40)     H=diag(7,7,7)
+//   v0: inertial(-4,-8,-12)/4 + spring(-1,0,0)/+1 + tri(-2,-3,0)/+2 + bend(0,-4,0)/+1
+//       → g=(-7,-15,-12)  H=diag(8,7,7)
+//   v1: inertial 0/2 + spring(+1,0,0)/+1 + tri(+2,0,0)/+1 + bend(0,-4,0)/+1
+//       → g=(3,-4,0)      H=diag(5,4,4)
+//   v2: inertial 0/2 + attachment(0,0,-40)/+4 + tri(0,+3,0)/+1 + bend(0,+4,0)/+1
+//       → g=(0,7,-40)     H=diag(8,8,8)
+//   v3: inertial 0/2 + bend(0,+4,0)/+1
+//       → g=(0,4,0)       H=diag(3,3,3)
 //
-// vbd_solve_apply Δx = -H⁻¹·g (diagonal H → componentwise):
-//   v0:  Δx = (7/7, 11/6, 12/6) = (1, 11/6, 2)
-//        new pos = (1, 11/6, 2)
-//   v1:  Δx = (-3/4, 0, 0)
-//        new pos = (9/4, 0, 0)
-//   v2:  Δx = (0, -3/7, 40/7)
-//        new pos = (0, 25/7, 40/7)
+// vbd_solve_apply Δx = −H⁻¹·g (diagonal):
+//   v0: Δx=(7/8, 15/7, 12/7)     pos=(7/8, 15/7, 12/7)
+//   v1: Δx=(-3/5, 1, 0)          pos=(3-3/5, 1, 0) = (12/5, 1, 0)
+//   v2: Δx=(0, -7/8, 5)          pos=(0, 4-7/8, 5) = (0, 25/8, 5)
+//   v3: Δx=(0, -4/3, 0)          pos=(3, 4-4/3, 0) = (3, 8/3, 0)
 
 #include "AvbdSolver.h"
 
@@ -71,38 +58,47 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    constexpr uint32_t N = 3;
+    constexpr uint32_t N = 4;
     const float positions[3 * N] = {
         0.0f, 0.0f, 0.0f,
         3.0f, 0.0f, 0.0f,
         0.0f, 4.0f, 0.0f,
+        3.0f, 4.0f, 0.0f,
     };
     const float predicted[3 * N] = {
         1.0f, 2.0f, 3.0f,
         3.0f, 0.0f, 0.0f,
         0.0f, 4.0f, 0.0f,
+        3.0f, 4.0f, 0.0f,
     };
-    const float mass[N] = {2.0f, 1.0f, 1.0f};
+    const float mass[N] = {2.0f, 1.0f, 1.0f, 1.0f};
     constexpr float invHSquared = 2.0f;
     solver.setupMesh(N, positions, predicted, mass, invHSquared);
 
     constexpr uint32_t N_S = 1;
-    const uint32_t spP1[N_S]   = {0u};
-    const uint32_t spP2[N_S]   = {1u};
-    const float spLen[N_S]     = {2.0f};
-    const float spK[N_S]       = {1.0f};
+    const uint32_t spP1[N_S] = {0u};
+    const uint32_t spP2[N_S] = {1u};
+    const float spLen[N_S]   = {2.0f};
+    const float spK[N_S]     = {1.0f};
     solver.uploadSprings(N_S, spP1, spP2, spLen, spK);
 
     constexpr uint32_t N_A = 1;
-    const uint32_t atVert[N_A]     = {2u};
-    const float atFixed[3 * N_A]   = {0.0f, 4.0f, 10.0f};
-    const float atK[N_A]           = {4.0f};
+    const uint32_t atVert[N_A]   = {2u};
+    const float atFixed[3 * N_A] = {0.0f, 4.0f, 10.0f};
+    const float atK[N_A]         = {4.0f};
     solver.uploadAttachments(N_A, atVert, atFixed, atK);
 
     constexpr uint32_t N_T = 1;
     const uint32_t triIdx[3 * N_T] = {0u, 1u, 2u};
     const float triK[N_T]          = {1.0f};
     solver.uploadTriangles(N_T, triIdx, triK);
+
+    constexpr uint32_t N_B = 1;
+    const uint32_t bendIdx[4 * N_B]    = {0u, 1u, 2u, 3u};
+    const float bendWeight[4 * N_B]    = {1.0f, 1.0f, -1.0f, -1.0f};
+    const float bendNTarget[N_B]       = {4.0f};
+    const float bendK[N_B]             = {1.0f};
+    solver.uploadBendings(N_B, bendIdx, bendWeight, bendNTarget, bendK);
 
     const int rc = solver.step();
     if (rc != 0) {
@@ -114,9 +110,10 @@ int main(int argc, char** argv) {
     solver.readPositions(posOut);
 
     const float expected_pos[3 * N] = {
-        1.0f, 11.0f / 6.0f, 2.0f,
-        9.0f / 4.0f, 0.0f, 0.0f,
-        0.0f, 25.0f / 7.0f, 40.0f / 7.0f,
+        7.0f / 8.0f, 15.0f / 7.0f, 12.0f / 7.0f,
+        12.0f / 5.0f, 1.0f, 0.0f,
+        0.0f, 25.0f / 8.0f, 5.0f,
+        3.0f, 8.0f / 3.0f, 0.0f,
     };
 
     int fails = 0;
@@ -136,11 +133,12 @@ int main(int argc, char** argv) {
     for (uint32_t i = 0; i < 3 * N; ++i) check(posOut[i], expected_pos[i], "pos", i);
 
     if (fails == 0) {
-        std::printf("test_avbd_solver: OK (full AVBD step on %u verts: %u springs, %u attach, %u tri, max_abs_diff=%g)\n",
-                    N, N_S, N_A, N_T, max_abs_diff);
-        std::printf("  v0 pos: (%g, %g, %g) — expected (1, 11/6, 2)\n",       posOut[0], posOut[1], posOut[2]);
-        std::printf("  v1 pos: (%g, %g, %g) — expected (9/4, 0, 0)\n",        posOut[3], posOut[4], posOut[5]);
-        std::printf("  v2 pos: (%g, %g, %g) — expected (0, 25/7, 40/7)\n",    posOut[6], posOut[7], posOut[8]);
+        std::printf("test_avbd_solver: OK (full AVBD step on %u verts: %u spring %u attach %u tri %u bend, max_abs_diff=%g)\n",
+                    N, N_S, N_A, N_T, N_B, max_abs_diff);
+        std::printf("  v0 pos: (%g, %g, %g) — expected (7/8, 15/7, 12/7)\n",  posOut[0], posOut[1], posOut[2]);
+        std::printf("  v1 pos: (%g, %g, %g) — expected (12/5, 1, 0)\n",       posOut[3], posOut[4], posOut[5]);
+        std::printf("  v2 pos: (%g, %g, %g) — expected (0, 25/8, 5)\n",       posOut[6], posOut[7], posOut[8]);
+        std::printf("  v3 pos: (%g, %g, %g) — expected (3, 8/3, 0)\n",        posOut[9], posOut[10], posOut[11]);
         return 0;
     }
     std::fprintf(stderr, "test_avbd_solver: %d FAIL\n", fails);


### PR DESCRIPTION
## Summary
**AVBD constraint coverage is now complete on real Metal hardware.**

\`step()\` dispatches the full 10-kernel AVBD outer iteration in a single Metal command buffer:
\`\`\`
1. vbd_init                                       inertial
2. spring_force + vbd_gather_spring               (if nSprings)
3. attachment_force + vbd_gather_attachment       (if nAttach)
4. triangle_membrane_force + vbd_gather_triangle  (if nTri)
5. triangle_bending_force + vbd_gather_bending    (if nBend)
6. vbd_solve_apply                                3x3 inverse + apply
\`\`\`

\`uploadBendings\` builds the K=4 CSR adjacency (role ∈ {0,1,2,3}) and uploads the 4-vertex stencil indices + Laplacian weights + rest magnitude + stiffness.

## Verification (real Apple Silicon Metal)
\`\`\`
AvbdSolver: 10 kernels loaded — full AVBD pipeline
test_avbd_solver: OK (max_abs_diff=0)   ← BIT-EXACT
  v0 pos: (7/8, 15/7, 12/7)    inertial + spring r0 + tri r0 + bend r0
  v1 pos: (12/5, 1, 0)         spring r1 + tri r1 + bend r1
  v2 pos: (0, 25/8, 5)         attachment + tri r2 + bend r2
  v3 pos: (3, 8/3, 0)          bend r3
\`\`\`

4 verts, 1 of each constraint type. All four DiffCloth constraint types (spring / attachment / triangle membrane / dihedral bending) compose into the same per-vertex scratch buffers; the final \`vbd_solve_apply\` inverts each 3x3 H and writes back positions.

## Roadmap (#42) — PR-E constraint coverage COMPLETE

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E stub + per-constraint paths (#56-62)
- ✅ **PR-E dihedral bending** — this PR
- PR-E Simulation.cpp routing (\`USE_AVBD=1\`) — next
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`make -C src/code/slang_solver test-avbd\` — full 10-kernel chain, bit-exact (max_abs_diff=0)
- [ ] CI lean-slang validate