### PR TITLE
Simulation.cpp: USE_AVBD env-gate scaffold (PR-E continued)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,9 @@ source_group("Sources" FILES ${SRCFILES})
 # call sites #ifdef out and DiffCloth's Eigen LLT remains the only
 # solver.
 if (APPLE)
-    set(SLANG_SOLVER_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/code/slang_solver/MetalCGSolver.mm")
+    set(SLANG_SOLVER_SRC
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/code/slang_solver/MetalCGSolver.mm"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/code/slang_solver/AvbdSolver.mm")
     set_source_files_properties(${SLANG_SOLVER_SRC}
         PROPERTIES COMPILE_FLAGS "-fobjc-arc")
     list(APPEND SRCFILES ${SLANG_SOLVER_SRC})

--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -31,12 +31,21 @@
 
 #ifdef __APPLE__
 #include "../slang_solver/MetalCGSolver.h"
+#include "../slang_solver/AvbdSolver.h"
 #endif
 
 namespace {
     // Runtime selector. Set USE_SLANG_CG=1 in the environment to route
     // the LLT back-solve in step() through the Metal CG dispatcher.
     bool g_useSlangCG = (std::getenv("USE_SLANG_CG") != nullptr);
+
+    // Runtime selector. Set USE_AVBD=1 in the environment to route the
+    // PD outer loop through the Apple Silicon AVBD vertex-block-update
+    // pipeline (see todo.md / AvbdSolver). When set, an AvbdSolver
+    // instance is constructed at scene initialization. This slice only
+    // wires the scaffold — actual step() routing through AVBD lands
+    // in a follow-up PR.
+    bool g_useAvbd = (std::getenv("USE_AVBD") != nullptr);
 
     // metallib search path. Override with SLANG_METALLIB_DIR=... in env.
     std::string slangMetallibDir() {
@@ -3155,6 +3164,24 @@ void Simulation::initializePrefactoredMatrices() {
 				             "[slang-cg] FAILED to build MetalCGSolver for "
 				             "sysMat[%d] (rows=%u); falling back to Eigen LLT\n",
 				             sysMatId, csr.rows);
+			}
+		}
+
+		if (g_useAvbd && sysMatId == 0) {
+			// PR-E scaffold: instantiate AvbdSolver at scene init to
+			// confirm all 10 AVBD kernels load on this device. The
+			// solver is constructed but not yet wired into step()
+			// — that's a follow-up PR. We attach to sysMat[0] only
+			// because AvbdSolver is per-scene (not per-sysMat).
+			auto avbd = std::make_shared<cloth::AvbdSolver>(
+				slangMetallibDir().c_str());
+			if (avbd->ok()) {
+				sysMat[sysMatId].avbd = avbd;
+				std::printf("[avbd] AvbdSolver loaded — 10 AVBD kernels ready (scaffold; step() routing in follow-up PR)\n");
+			} else {
+				std::fprintf(stderr,
+				             "[avbd] FAILED to construct AvbdSolver; "
+				             "USE_AVBD=1 will be ignored\n");
 			}
 		}
 #endif

--- a/src/code/simulation/Simulation.h
+++ b/src/code/simulation/Simulation.h
@@ -38,7 +38,7 @@
 #include "AttachmentSpring.h"
 #include <memory>
 
-namespace cloth { class MetalCGSolver; }
+namespace cloth { class MetalCGSolver; class AvbdSolver; }
 
 #include "Constraint.h"
 #include "FixedPoint.h"
@@ -409,6 +409,14 @@ public:
 		// CSR to the GPU.
 		std::shared_ptr<cloth::MetalCGSolver> slangCG;
 
+		// Optional AVBD vertex-block-update solver, attached to sysMat[0]
+		// when USE_AVBD=1. Loads all 10 AVBD kernels (vbd_init,
+		// vbd_gather_{spring,attachment,triangle,bending},
+		// vbd_solve_apply, and the four per-constraint *_force kernels).
+		// Per-step routing through this solver is the PR-E continuation;
+		// the scaffold PR only constructs it at scene init.
+		std::shared_ptr<cloth::AvbdSolver> avbd;
+
 		SystemMatrix() {}
 
 		SystemMatrix(const SystemMatrix &other) {
@@ -424,6 +432,7 @@ public:
 			fixedPoints = other.fixedPoints;
 			constraintNum = other.constraintNum;
 			slangCG = other.slangCG;       // share; not deep-copied
+			avbd    = other.avbd;          // share; not deep-copied
 
 			for (int i = 0; i < Constraint::CONSTRAINT_NUM; i++) {
 				A_t_times_A_pertype[i] = other.A_t_times_A_pertype[i];


### PR DESCRIPTION
## Summary
First wiring step for AVBD into DiffCloth's \`Simulation.cpp\`. Set \`USE_AVBD=1\` in the environment to construct an \`AvbdSolver\` at scene initialization; the solver loads all 10 AVBD kernels (vbd_init, vbd_gather_*, vbd_solve_apply, spring/attachment/triangle/bending_force) and attaches as a \`shared_ptr\` to \`sysMat[0]\`.

**This PR ships only the lifecycle scaffold** — actual \`step()\` routing through AVBD lands in a follow-up PR once the host-side data shuttle (DiffCloth constraints → AvbdSolver upload, positions → setupMesh, result → particle state) is wired.

## Changes
- \`Simulation.cpp\`: \`USE_AVBD\` env var, AvbdSolver construction next to MetalCGSolver at scene init, log line
- \`Simulation.h\`: new \`shared_ptr<cloth::AvbdSolver> avbd\` field on \`SystemMatrix\`; copy-ctor shares like \`slangCG\`; forward-decl extended
- \`CMakeLists.txt\`: \`AvbdSolver.mm\` added to APPLE-only \`SLANG_SOLVER_SRC\` with \`-fobjc-arc\`

## Verification
\`\`\`
$ env USE_AVBD=1 ./build_diffcloth/tool_cloth_dynamics -demo dress -seed 0
AvbdSolver: 10 kernels loaded — full AVBD pipeline (init, gather_*, solve_apply, spring/attach/tri/bend_force)
[avbd] AvbdSolver loaded — 10 AVBD kernels ready (scaffold; step() routing in follow-up PR)
\`\`\`

Dress demo continues running on the PD path with the AVBD solver constructed but unused.

## Roadmap (#42) — PR-E progress

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver + all 10 kernels dispatched on Metal (#56-63)
- 🟡 **PR-E Simulation.cpp env-gate scaffold** — this PR
- PR-E continued — host-side data shuttle (constraints → AvbdSolver)
- PR-E continued — actual step() routing through AVBD
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] DiffCloth builds with \`AvbdSolver.mm\` added to CMake
- [x] Dress demo runs with \`USE_AVBD=1\` — AvbdSolver constructs successfully, all 10 kernels load
- [ ] CI lean-slang validate (Lean side only; Simulation.cpp Metal wiring is local-test only)