### PR TITLE
Simulation.cpp: upload mesh state to AvbdSolver (PR-E continued)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -3168,16 +3168,39 @@ void Simulation::initializePrefactoredMatrices() {
 		}
 
 		if (g_useAvbd && sysMatId == 0) {
-			// PR-E scaffold: instantiate AvbdSolver at scene init to
-			// confirm all 10 AVBD kernels load on this device. The
-			// solver is constructed but not yet wired into step()
-			// — that's a follow-up PR. We attach to sysMat[0] only
-			// because AvbdSolver is per-scene (not per-sysMat).
+			// PR-E continued: instantiate AvbdSolver at scene init and
+			// upload mesh state (positions, masses, invH²). Constraint
+			// uploads (springs, attachments, triangles, bendings)
+			// follow in subsequent PRs.
 			auto avbd = std::make_shared<cloth::AvbdSolver>(
 				slangMetallibDir().c_str());
 			if (avbd->ok()) {
+				// Convert DiffCloth's fp64 particle state to the fp32
+				// flat arrays AvbdSolver.setupMesh consumes.
+				const uint32_t nV = uint32_t(particles.size());
+				std::vector<float> posF(3 * nV), predF(3 * nV), massF(nV);
+				for (uint32_t i = 0; i < nV; ++i) {
+					posF[3*i+0]  = float(particles[i].pos[0]);
+					posF[3*i+1]  = float(particles[i].pos[1]);
+					posF[3*i+2]  = float(particles[i].pos[2]);
+					// At scene init the predictor equals current pos —
+					// real per-step predictors come from the time-step
+					// integrator and will be uploaded in the per-step
+					// shuttle (follow-up PR).
+					predF[3*i+0] = posF[3*i+0];
+					predF[3*i+1] = posF[3*i+1];
+					predF[3*i+2] = posF[3*i+2];
+					massF[i]     = float(particles[i].mass);
+				}
+				const float h = float(sceneConfig.timeStep);
+				const float invHSq = 1.0f / (h * h);
+				avbd->setupMesh(nV, posF.data(), predF.data(),
+				                massF.data(), invHSq);
+
 				sysMat[sysMatId].avbd = avbd;
-				std::printf("[avbd] AvbdSolver loaded — 10 AVBD kernels ready (scaffold; step() routing in follow-up PR)\n");
+				std::printf("[avbd] AvbdSolver loaded + mesh uploaded "
+				            "(nVerts=%u, h=%g, invH²=%g)\n",
+				            nV, h, invHSq);
 			} else {
 				std::fprintf(stderr,
 				             "[avbd] FAILED to construct AvbdSolver; "


### PR DESCRIPTION
## Summary
Extends the USE_AVBD env-gate scaffold (#64) with the first piece of the host-side data shuttle: at scene init, convert DiffCloth's fp64 particle state (pos, mass) to fp32 flat arrays and call \`AvbdSolver::setupMesh(nVerts, positions, predicted, mass, invH²)\`.

The "predicted" position is initialized to the current position at scene init time — real per-step predictors come from the time-step integrator and will be re-uploaded in the per-step shuttle (follow-up PR). \`invHSquared = 1 / (sceneConfig.timeStep²)\`.

Constraint uploads (springs, attachments, triangles, bendings) and actual \`step()\` routing follow in subsequent PRs.

## Verification (real DiffCloth dress demo)
\`\`\`
$ env USE_AVBD=1 ./build_diffcloth/tool_cloth_dynamics -demo dress -seed 0
[avbd] AvbdSolver loaded + mesh uploaded (nVerts=579, h=0.01, invH²=10000)
[avbd] AvbdSolver loaded + mesh uploaded (nVerts=3634, h=0.0111111, invH²=8100)
\`\`\`

The 3634-vert / h=1/90 line matches the dress demo's published specs (10902 DoF = 3634 verts × 3, timestep 1/90). PD path continues to run — AvbdSolver state is uploaded but not yet consulted.

## Roadmap (#42)

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver + 10 kernels dispatched (#56-63)
- ✅ PR-E Simulation.cpp env-gate scaffold (#64)
- 🟡 **PR-E mesh upload** — this PR
- PR-E continued — spring upload from DiffCloth's Spring vector
- PR-E continued — attachment/triangle/bending uploads
- PR-E continued — per-step shuttle + step() routing
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] DiffCloth builds clean
- [x] Dress demo runs with \`USE_AVBD=1\`, AvbdSolver constructs + uploads 3634-vert mesh
- [ ] CI lean-slang validate (Lean side only)