### PR TITLE
Simulation.cpp: upload springs to AvbdSolver (PR-E continued)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -3197,10 +3197,26 @@ void Simulation::initializePrefactoredMatrices() {
 				avbd->setupMesh(nV, posF.data(), predF.data(),
 				                massF.data(), invHSq);
 
+				// Upload spring constraints. DiffCloth's `springs` vector
+				// holds endpoint indices + rest length + per-spring
+				// stiffness `k_s`. AvbdSolver computes the vertex→spring
+				// CSR adjacency internally.
+				const uint32_t nS = uint32_t(springs.size());
+				std::vector<uint32_t> spP1(nS), spP2(nS);
+				std::vector<float>    spL(nS), spK(nS);
+				for (uint32_t i = 0; i < nS; ++i) {
+					spP1[i] = uint32_t(springs[i].p1_idx);
+					spP2[i] = uint32_t(springs[i].p2_idx);
+					spL[i]  = float(springs[i].l0);
+					spK[i]  = float(springs[i].k_s);
+				}
+				avbd->uploadSprings(nS, spP1.data(), spP2.data(),
+				                    spL.data(), spK.data());
+
 				sysMat[sysMatId].avbd = avbd;
-				std::printf("[avbd] AvbdSolver loaded + mesh uploaded "
-				            "(nVerts=%u, h=%g, invH²=%g)\n",
-				            nV, h, invHSq);
+				std::printf("[avbd] AvbdSolver loaded + uploaded "
+				            "(nVerts=%u, nSprings=%u, h=%g, invH²=%g)\n",
+				            nV, nS, h, invHSq);
 			} else {
 				std::fprintf(stderr,
 				             "[avbd] FAILED to construct AvbdSolver; "


### PR DESCRIPTION
## Summary
Adds spring upload after mesh setup. Iterates DiffCloth's \`springs\` vector and forwards (p1_idx, p2_idx, l0, k_s) to \`AvbdSolver.uploadSprings\`.

## Verification on real DiffCloth demos
\`\`\`
dress  (3634 verts): nSprings=0   triangle-mesh cloth, no individual springs
tshirt (1426 verts): nSprings=0   same
hat    (579 verts):  nSprings=0   same
\`\`\`

DiffCloth's standard demos use Triangle (membrane) + TriangleBending constraints, not the legacy Spring class. Spring upload still exercises the host-side CSR build path even with 0 springs.

The meaningful per-constraint upload for the dress demo is the triangle + bending paths, coming next.

## Roadmap (#42)

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver + Simulation.cpp scaffold + mesh upload (#56-65)
- 🟡 **PR-E spring upload** — this PR
- PR-E continued — attachment upload
- PR-E continued — triangle membrane upload
- PR-E continued — bending upload
- PR-E continued — per-step shuttle + step() routing
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] DiffCloth builds + runs with USE_AVBD=1 across dress/tshirt/hat demos
- [ ] CI lean-slang validate