### PR TITLE
Simulation.cpp: upload triangle mesh to AvbdSolver (PR-E continued)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -3213,10 +3213,24 @@ void Simulation::initializePrefactoredMatrices() {
 				avbd->uploadSprings(nS, spP1.data(), spP2.data(),
 				                    spL.data(), spK.data());
 
+				// Upload triangle (membrane in-plane stretch) constraints.
+				// DiffCloth's `mesh` vector holds Triangle constraints
+				// with (p0, p1, p2). Stiffness is Triangle::k_stiff
+				// (shared static; per-triangle override is uncommon).
+				const uint32_t nT = uint32_t(mesh.size());
+				std::vector<uint32_t> triIdx(3 * nT);
+				std::vector<float>    triK(nT, float(Triangle::k_stiff));
+				for (uint32_t i = 0; i < nT; ++i) {
+					triIdx[3*i + 0] = uint32_t(mesh[i].p0_idx);
+					triIdx[3*i + 1] = uint32_t(mesh[i].p1_idx);
+					triIdx[3*i + 2] = uint32_t(mesh[i].p2_idx);
+				}
+				avbd->uploadTriangles(nT, triIdx.data(), triK.data());
+
 				sysMat[sysMatId].avbd = avbd;
 				std::printf("[avbd] AvbdSolver loaded + uploaded "
-				            "(nVerts=%u, nSprings=%u, h=%g, invH²=%g)\n",
-				            nV, nS, h, invHSq);
+				            "(nVerts=%u, nSprings=%u, nTri=%u, h=%g, invH²=%g)\n",
+				            nV, nS, nT, h, invHSq);
 			} else {
 				std::fprintf(stderr,
 				             "[avbd] FAILED to construct AvbdSolver; "


### PR DESCRIPTION
## Summary
Adds triangle membrane (in-plane stretch) upload to the per-scene init shuttle. Iterates DiffCloth's \`mesh\` vector of \`Triangle\` constraints and uploads (p0, p1, p2) interleaved triplets plus \`Triangle::k_stiff\` as the per-triangle stiffness.

## Verification on real DiffCloth dress demo

\`\`\`
$ env USE_AVBD=1 ./build_diffcloth/tool_cloth_dynamics -demo dress -seed 0
[avbd] AvbdSolver loaded + uploaded (nVerts=579,  nSprings=0, nTri=1099, h=0.01,     invH²=10000)   (backward solver scene)
[avbd] AvbdSolver loaded + uploaded (nVerts=3634, nSprings=0, nTri=7026, h=0.0111,   invH²=8100)    (forward dress scene)
\`\`\`

**3634-vert / 7026-triangle dress mesh** is the actual workload AVBD will eventually need to handle in production. Both the membrane constraints and the per-vertex CSR adjacency (built host-side in \`AvbdSolver.uploadTriangles\`) are now uploaded successfully — the same upload codepath the bit-exact 4-vert / 1-triangle test in #62 exercised, now feeding 7026× the data.

## Roadmap (#42)

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver, Simulation scaffold, mesh upload, springs (#56-66)
- 🟡 **PR-E triangle upload** — this PR
- PR-E attachment upload — next
- PR-E bending upload
- PR-E per-step shuttle + step() routing
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] DiffCloth builds + dress demo uploads 7026 triangles via USE_AVBD=1
- [ ] CI lean-slang validate