### PR TITLE
Simulation.cpp: upload attachments to AvbdSolver (PR-E continued)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -3227,10 +3227,28 @@ void Simulation::initializePrefactoredMatrices() {
 				}
 				avbd->uploadTriangles(nT, triIdx.data(), triK.data());
 
+				// Upload attachment (point-pin) constraints from this
+				// sysMat's `attachments` vector. Each AttachmentSpring
+				// pins p1_idx to a world-space anchor (fixedPointPos)
+				// with stiffness AttachmentSpring::k_stiff.
+				const uint32_t nA = uint32_t(sysMat[sysMatId].attachments.size());
+				std::vector<uint32_t> atVert(nA);
+				std::vector<float>    atFixed(3 * nA);
+				std::vector<float>    atK(nA, float(AttachmentSpring::k_stiff));
+				for (uint32_t i = 0; i < nA; ++i) {
+					auto &a = sysMat[sysMatId].attachments[i];
+					atVert[i] = uint32_t(a.p1_idx);
+					Vec3d fp = a.fixedPointPos();
+					atFixed[3*i + 0] = float(fp[0]);
+					atFixed[3*i + 1] = float(fp[1]);
+					atFixed[3*i + 2] = float(fp[2]);
+				}
+				avbd->uploadAttachments(nA, atVert.data(), atFixed.data(), atK.data());
+
 				sysMat[sysMatId].avbd = avbd;
 				std::printf("[avbd] AvbdSolver loaded + uploaded "
-				            "(nVerts=%u, nSprings=%u, nTri=%u, h=%g, invH²=%g)\n",
-				            nV, nS, nT, h, invHSq);
+				            "(nVerts=%u, nSprings=%u, nTri=%u, nAttach=%u, h=%g, invH²=%g)\n",
+				            nV, nS, nT, nA, h, invHSq);
 			} else {
 				std::fprintf(stderr,
 				             "[avbd] FAILED to construct AvbdSolver; "


### PR DESCRIPTION
## Summary
Adds attachment (point-pin) upload to the per-scene init shuttle. Iterates this sysMat's \`attachments\` vector and uploads (p1_idx, fixedPointPos.xyz) plus \`AttachmentSpring::k_stiff\` per pin.

## Verification on dress demo

\`\`\`
$ env USE_AVBD=1 ./build_diffcloth/tool_cloth_dynamics -demo dress -seed 0
backward sysmat (579 verts):  nTri=1099  nAttach=2
forward dress (3634 verts):   nTri=7026  nAttach=31
\`\`\`

The 31 attachments on the dress are the waistband pins that keep the skirt from falling through the body — exactly the kind of hard-ish boundary condition AVBD's augmented Lagrangian will eventually extend in PR-F.

## Roadmap (#42)

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver, Simulation scaffold, mesh/spring/triangle uploads (#56-67)
- 🟡 **PR-E attachment upload** — this PR
- PR-E bending upload — next
- PR-E per-step shuttle + step() routing
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] DiffCloth builds + dress uploads 31 attachments via USE_AVBD=1
- [ ] CI lean-slang validate