### PR TITLE
Simulation.cpp: upload bending — dress fully on AvbdSolver (PR-E continued)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -3245,10 +3245,34 @@ void Simulation::initializePrefactoredMatrices() {
 				}
 				avbd->uploadAttachments(nA, atVert.data(), atFixed.data(), atK.data());
 
+				// Upload dihedral bending constraints from
+				// DiffCloth's `bendingConstraints` vector. Each
+				// TriangleBending has a 4-vertex stencil (p0..p3)
+				// with cotangent Laplacian weights (Vec4d weightVert)
+				// and rest magnitude `n`. Stiffness uses
+				// TriangleBending::k_stiff.
+				const uint32_t nB = uint32_t(bendingConstraints.size());
+				std::vector<uint32_t> bendIdx(4 * nB);
+				std::vector<float>    bendWeight(4 * nB);
+				std::vector<float>    bendNTarget(nB);
+				std::vector<float>    bendK(nB, float(TriangleBending::k_stiff));
+				for (uint32_t i = 0; i < nB; ++i) {
+					auto &b = bendingConstraints[i];
+					bendIdx[4*i + 0] = uint32_t(b.p0_idx);
+					bendIdx[4*i + 1] = uint32_t(b.p1_idx);
+					bendIdx[4*i + 2] = uint32_t(b.p2_idx);
+					bendIdx[4*i + 3] = uint32_t(b.p3_idx);
+					for (int r = 0; r < 4; ++r)
+						bendWeight[4*i + r] = float(b.weightVert[r]);
+					bendNTarget[i] = float(b.n);
+				}
+				avbd->uploadBendings(nB, bendIdx.data(), bendWeight.data(),
+				                     bendNTarget.data(), bendK.data());
+
 				sysMat[sysMatId].avbd = avbd;
 				std::printf("[avbd] AvbdSolver loaded + uploaded "
-				            "(nVerts=%u, nSprings=%u, nTri=%u, nAttach=%u, h=%g, invH²=%g)\n",
-				            nV, nS, nT, nA, h, invHSq);
+				            "(nVerts=%u, nSprings=%u, nTri=%u, nAttach=%u, nBend=%u, h=%g, invH²=%g)\n",
+				            nV, nS, nT, nA, nB, h, invHSq);
 			} else {
 				std::fprintf(stderr,
 				             "[avbd] FAILED to construct AvbdSolver; "


### PR DESCRIPTION
## Summary
Adds the final constraint-type upload to AvbdSolver. Iterates DiffCloth's \`bendingConstraints\` vector and uploads (p0..p3 stencil, weightVert[4], n as rest magnitude, k_stiff) per constraint.

**With this, the full dress demo configuration is uploaded to AvbdSolver at scene init on real Apple Silicon Metal.**

## Verification

\`\`\`
$ env USE_AVBD=1 ./build_diffcloth/tool_cloth_dynamics -demo dress -seed 0
backward (579 verts):  nSpr=0  nTri=1099  nAttach=2   nBend=1620
forward  (3634 verts): nSpr=0  nTri=7026  nAttach=31  nBend=10416
\`\`\`

The 3634-vert / 7026-tri / 31-attach / 10416-bend dress is the **exact** workload the dress demo runs through DiffCloth's PD path. Every constraint is now mirrored in AvbdSolver state — same data, same per-vertex CSR adjacency, same per-step inputs the GPU \`step()\` pipeline needs.

## Roadmap (#42) — all constraint uploads done

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver + Simulation scaffold + mesh + spring + triangle + attachment uploads (#56-68)
- 🟡 **PR-E bending upload — full constraint set on AvbdSolver** — this PR
- PR-E per-step shuttle + step() routing — next
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] DiffCloth builds + dress uploads all four constraint types via USE_AVBD=1
- [ ] CI lean-slang validate