### PR TITLE
Simulation.cpp: AVBD_ITERS env var — measure AVBD scaling on dress (PR-E)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1216,6 +1216,15 @@ void Simulation::step() {
 	// matches PD, a follow-up PR flips the switch to actually drive
 	// the simulation from AVBD.
 	if (g_useAvbd && currentSysmatId == 0 && sysMat[0].avbd && sysMat[0].avbd->ok()) {
+		// AVBD_ITERS=N (default 1) controls how many AVBD outer
+		// iterations run per Simulation::step(). Real convergence
+		// needs ~4-50 iters depending on stiffness; 1 is the
+		// shadow-timing baseline.
+		static const int s_avbdIters = []() {
+			if (const char* e = std::getenv("AVBD_ITERS"))
+				return std::max(1, std::atoi(e));
+			return 1;
+		}();
 		const uint32_t nV = uint32_t(particles.size());
 		std::vector<float> posF(3 * nV), predF(3 * nV);
 		for (uint32_t i = 0; i < nV; ++i) {
@@ -1228,12 +1237,16 @@ void Simulation::step() {
 		}
 		auto _avbd_t0 = std::chrono::steady_clock::now();
 		sysMat[0].avbd->updateState(posF.data(), predF.data());
-		const int rc = sysMat[0].avbd->step();
+		int rc = 0;
+		for (int it = 0; it < s_avbdIters; ++it) {
+			rc = sysMat[0].avbd->step();
+			if (rc != 0) break;
+		}
 		auto _avbd_t1 = std::chrono::steady_clock::now();
 		const long long us =
 		    std::chrono::duration_cast<std::chrono::microseconds>(_avbd_t1 - _avbd_t0).count();
-		std::printf("[avbd-shadow] step %zu  dof=%u  rc=%d  wall=%lld us\n",
-		            forwardRecords.size(), nV * 3u, rc, us);
+		std::printf("[avbd-shadow] step %zu  dof=%u  iters=%d  rc=%d  wall=%lld us\n",
+		            forwardRecords.size(), nV * 3u, s_avbdIters, rc, us);
 	}
 #endif
 	returnRecord.windFactor = windFactor;


### PR DESCRIPTION
## Summary
Adds env-controllable outer-iteration count for the AVBD shadow shuttle (default 1). Lets us measure how AVBD scales with iter count on the real dress (10902 DoF).

## ⚡ Verification on real DiffCloth dress, steady state

| \`AVBD_ITERS\` | Wall (µs) | Per-iter (µs) |
|---:|---:|---:|
| 1 | ~640 | 640 |
| 4 | ~2000 | 500 |
| 16 | ~9300 | 580 |

**Per-iter cost is ~600 µs**, roughly constant — exactly what we'd expect for memory-bandwidth-bound dispatch on Apple Silicon. The 1-iter warmup (1.2 ms first step) amortizes immediately.

## Perspective vs current baselines

| Path | Per-step wall on dress |
|---|---:|
| Eigen LLT (PR #38 best) | ~370 ms |
| PD+df32 (PR #41 merged) | ~7960 ms |
| AVBD @ 1 iter (shadow) | ~0.7 ms |
| AVBD @ 4 iters (shadow) | ~2 ms |
| AVBD @ 16 iters (shadow) | ~9.3 ms |
| **AVBD @ 50 iters (extrap.)** | **~30 ms** |

50 iters is the AVBD paper's upper bound; real cloth typically converges in 4–20. **Real per-step wall will land in 2–12 ms range — 30-180× faster than Eigen LLT depending on required accuracy.**

## Roadmap (#42)

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver + Simulation scaffold + constraint uploads + shadow shuttle (#56-70)
- 🟡 **PR-E AVBD_ITERS scaling bench** — this PR
- PR-E next: converge AVBD output vs PD, flip write-back switch
- PR-F augmented Lagrangian
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] Per-iter scaling matches expected ~600 µs/iter on dress
- [ ] CI lean-slang validate