### PR TITLE
Add attachment_dual_update: AVBD augmented-Lagrangian ramp (PR-F start)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -22,6 +22,7 @@ import Cloth.SlangCodegen.VbdGatherSpring
 import Cloth.SlangCodegen.VbdGatherAttachment
 import Cloth.SlangCodegen.VbdGatherTriangle
 import Cloth.SlangCodegen.VbdGatherBending
+import Cloth.SlangCodegen.AttachmentDualUpdate
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/AttachmentDualUpdate.lean
+++ b/lean/Cloth/SlangCodegen/AttachmentDualUpdate.lean
@@ -1,0 +1,122 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.AttachmentDualUpdate` — AVBD augmented-Lagrangian dual ramp
+
+First kernel for PR-F augmented Lagrangian (todo.md). The convergence
+probe in #73 showed AVBD's per-vertex Gauss-Seidel oscillates at high
+constraint stiffness — at least one attachment vertex stays
+`conv_max ≈ 0.7` even at 64 iters. The Roblox SIGGRAPH 2025 AVBD paper
+addresses this exact failure mode with augmented Lagrangian dual
+updates: progressively ramp a Lagrange multiplier λ_c per hard
+constraint to drive the constraint violation toward zero.
+
+For each attachment `c` pinning vertex `v = vertIdx[c]` to anchor
+`fixedPos[c]` with augmented-Lagrangian penalty `gamma[c]`:
+
+```
+C(x_v)  = x_v − fixedPos[c]              -- constraint violation (3-vec)
+λ_c    ← λ_c + gamma[c] · C(x_v)         -- dual ascent
+```
+
+`λ` becomes an external force the attachment force kernel reads each
+outer iter. The combined effect on the AVBD vertex-block update is:
+
+```
+gradV[c]  = (k + γ_c) · C(x_v) + λ_c     -- when attachment_force_al
+                                            (next PR) adds the dual term
+hess      = (k + γ_c)
+```
+
+This kernel runs once per AVBD outer-iter sweep, AFTER vbd_solve_apply
+has updated positions. The accumulated λ is then read by the
+attachment-force kernel on the next iter's force compute.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions    length = N_verts
+  1  StructuredBuffer<uint>     vertIdx      length = N_attach
+  2  StructuredBuffer<float3>   fixedPos     length = N_attach
+  3  StructuredBuffer<float>    gamma        length = N_attach
+  4  RWStructuredBuffer<float3> lambda       length = N_attach
+                                              (initialized to zero
+                                              at scene init; accumulates
+                                              across iters / steps)
+-/
+
+namespace Cloth.SlangCodegen.AttachmentDualUpdate
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"   (.member (.var "tid") "x")
+  , .declInit u  "v"   (.index (.var "vertIdx") (.var "c"))
+  , .declInit f3 "p"   (.index (.var "positions") (.var "v"))
+  , .declInit f3 "fp"  (.index (.var "fixedPos") (.var "c"))
+  , .declInit f  "g"   (.index (.var "gamma") (.var "c"))
+  , .declInit f3 "lam" (.index (.var "lambda") (.var "c"))
+  , .assign (.index (.var "lambda") (.var "c"))
+      (.call "float3"
+        [ .bin "+" (.member (.var "lam") "x")
+            (.bin "*" (.var "g")
+              (.bin "-" (.member (.var "p") "x") (.member (.var "fp") "x")))
+        , .bin "+" (.member (.var "lam") "y")
+            (.bin "*" (.var "g")
+              (.bin "-" (.member (.var "p") "y") (.member (.var "fp") "y")))
+        , .bin "+" (.member (.var "lam") "z")
+            (.bin "*" (.var "g")
+              (.bin "-" (.member (.var "p") "z") (.member (.var "fp") "z"))) ])
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions" (.roBuf f3)
+      , bnd 1 "vertIdx"   (.roBuf u)
+      , bnd 2 "fixedPos"  (.roBuf f3)
+      , bnd 3 "gamma"     (.roBuf f)
+      , bnd 4 "lambda"    (.rwBuf f3)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> vertIdx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float3> fixedPos;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> gamma;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float3> lambda;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint v = vertIdx[c];
+  float3 p = positions[v];
+  float3 fp = fixedPos[c];
+  float g = gamma[c];
+  float3 lam = lambda[c];
+  lambda[c] = float3((lam.x + (g * (p.x - fp.x))), (lam.y + (g * (p.y - fp.y))), (lam.z + (g * (p.z - fp.z))));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.AttachmentDualUpdate

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -42,6 +42,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("vbd_gather_attachment", VbdGatherAttachment.shader)
   , ("vbd_gather_triangle", VbdGatherTriangle.shader)
   , ("vbd_gather_bending", VbdGatherBending.shader)
+  , ("attachment_dual_update", AttachmentDualUpdate.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -56,7 +56,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               vbd_gather_spring:vbd_gather_spring \
               vbd_gather_attachment:vbd_gather_attachment \
               vbd_gather_triangle:vbd_gather_triangle \
-              vbd_gather_bending:vbd_gather_bending
+              vbd_gather_bending:vbd_gather_bending \
+              attachment_dual_update:attachment_dual_update
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/attachment_dual_update_test.cpp
+++ b/tests/slang_validate/attachment_dual_update_test.cpp
@@ -1,0 +1,108 @@
+// Real-input validator for Cloth.SlangCodegen.AttachmentDualUpdate —
+// AVBD augmented-Lagrangian dual ramp per attachment.
+//
+// Per attachment c pinning vertex v=vertIdx[c] to fixedPos[c] with
+// AL penalty gamma[c], updates the multiplier:
+//   λ_c ← λ_c + γ_c · (p_v − fixedPos[c])
+//
+// Test fixture (2 attachments over 3 verts):
+//   v0 = (1, 2, 3)   v1 = (4, 5, 6)   v2 = (0, 0, 0)
+//   c0: pin v0 to (1, 0, 3), γ=2, λ_init=(10, 20, 30)
+//       C = (0, 2, 0); update += 2·C = (0, 4, 0)
+//       λ_new = (10, 24, 30)
+//   c1: pin v1 to (4, 5, 0), γ=1, λ_init=(-1, -2, -3)
+//       C = (0, 0, 6); update += 1·C = (0, 0, 6)
+//       λ_new = (-1, -2, 3)
+//
+// Padding (slots 2..63): vertIdx=2 (v2=zero), fixedPos=zero, γ=0 →
+// no-op update.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "attachment_dual_update_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_ATTACH = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(1.0f, 2.0f, 3.0f),
+        Vector<float, 3>(4.0f, 5.0f, 6.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+    };
+
+    std::vector<uint32_t>         vertIdx(GROUP_SIZE, 2u);
+    std::vector<Vector<float, 3>> fixedPos(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            gamma(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> lambda(GROUP_SIZE, Vector<float, 3>(0.0f));
+
+    vertIdx[0] = 0u;
+    fixedPos[0] = Vector<float, 3>(1.0f, 0.0f, 3.0f);
+    gamma[0] = 2.0f;
+    lambda[0] = Vector<float, 3>(10.0f, 20.0f, 30.0f);
+
+    vertIdx[1] = 1u;
+    fixedPos[1] = Vector<float, 3>(4.0f, 5.0f, 0.0f);
+    gamma[1] = 1.0f;
+    lambda[1] = Vector<float, 3>(-1.0f, -2.0f, -3.0f);
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data = positions.data();  gp.positions_0.count = positions.size();
+    gp.vertIdx_0.data   = vertIdx.data();    gp.vertIdx_0.count   = vertIdx.size();
+    gp.fixedPos_0.data  = fixedPos.data();   gp.fixedPos_0.count  = fixedPos.size();
+    gp.gamma_0.data     = gamma.data();      gp.gamma_0.count     = gamma.size();
+    gp.lambda_0.data    = lambda.data();     gp.lambda_0.count    = lambda.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_lambda[N_ATTACH][3] = {
+        {10.0f, 24.0f, 30.0f},
+        {-1.0f, -2.0f,  3.0f},
+    };
+
+    int fails = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, uint32_t c, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "lambda mismatch at c=%u axis=%d: got %g, expected %g\n",
+                    c, axis, got, ref);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_ATTACH; ++c) {
+        for (int axis = 0; axis < 3; ++axis) {
+            check(lambda[c][axis], expected_lambda[c][axis], c, axis);
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "attachment_dual_update: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("attachment_dual_update: %u/%u OK (max_abs_diff=%g, %.1fms)\n",
+                    N_ATTACH, N_ATTACH, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "attachment_dual_update: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary
First kernel for **PR-F augmented Lagrangian** — the "A" in AVBD that the convergence probe in #73 identified as needed. The single oscillating attachment vertex held \`conv_max ≈ 0.7\` even at 64 iters of per-vertex Gauss-Seidel; the dual-multiplier ramp drives that violation down by adding an external "force" proportional to accumulated violation.

Per attachment c pinning vertex v to fixedPos with AL penalty γ:
\`\`\`
C(x_v) = x_v − fixedPos[c]              -- constraint violation
λ_c ← λ_c + γ_c · C(x_v)                -- dual ascent
\`\`\`

The dual variable \`λ_c\` (Vec3 per attachment) becomes an extra gradient term the next \`attachment_force_al\` kernel will consume. After this kernel runs every outer-iter sweep, the subsequent iter's gradient includes \`λ_c\`, effectively a growing force that pulls the vertex toward \`fixedPos\` until \`C → 0\`.

## Verification
\`\`\`
attachment_dual_update: 2/2 OK (max_abs_diff=0, 0.0ms)
\`\`\`

2-attachment / 3-vert fixture, bit-exact match against hand-computed dual ramp.

## Roadmap (#42) — PR-F starts

- ✅ PR-A four force kernels
- ✅ PR-B vertex CSR adjacency
- ✅ PR-C vertex graph coloring
- ✅ PR-D six vertex-block-update kernels
- ✅ PR-E AvbdSolver + Simulation integration + shadow + convergence probe (#56-73)
- 🟡 **PR-F start: attachment_dual_update kernel** — this PR
- PR-F continued: \`attachment_force_al\` (consumes λ)
- PR-F continued: AvbdSolver wiring (allocate λ, dispatch dual_update each outer iter)
- PR-F continued: re-run convergence probe — expect conv_max to drop into the 1e-3 range
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on 2-attachment fixture
- [ ] CI lean-slang validate