### PR TITLE
Add attachment_force_al: AVBD AL-augmented attachment force (PR-F)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -23,6 +23,7 @@ import Cloth.SlangCodegen.VbdGatherAttachment
 import Cloth.SlangCodegen.VbdGatherTriangle
 import Cloth.SlangCodegen.VbdGatherBending
 import Cloth.SlangCodegen.AttachmentDualUpdate
+import Cloth.SlangCodegen.AttachmentForceAl
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/AttachmentForceAl.lean
+++ b/lean/Cloth/SlangCodegen/AttachmentForceAl.lean
@@ -1,0 +1,128 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.AttachmentForceAl` — AVBD augmented-Lagrangian attachment force
+
+Companion to `AttachmentDualUpdate` (#74). After the dual-ramp kernel
+updates `λ_c` each outer-iter sweep, the next force-compute pass reads
+the accumulated multiplier and folds it into the per-attachment
+gradient.
+
+Augmented-Lagrangian energy for attachment c pinning vertex
+`v = vertIdx[c]` to anchor `fixedPos[c]` with effective stiffness
+`k_eff[c] = k + γ_c`:
+
+```
+E_al(x_v)   = (1/2) · k_eff · |C(x_v)|²  +  λ_cᵀ C(x_v)
+              where C(x_v) = x_v − fixedPos[c]
+
+∇_v E_al    = k_eff · C(x_v)  +  λ_c
+∇²_v E_al   = k_eff · I₃                 -- same scalar·I shape as
+                                            the original
+                                            attachment_force
+```
+
+Drop-in replacement for `attachment_force` (PR #44) with one extra
+input buffer (`lambda`) and one extra add-per-axis in the gradient.
+Hessian shape unchanged — the AL augmentation only shifts the
+gradient by `λ_c`, not the curvature.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions    length = N_verts
+  1  StructuredBuffer<uint>     vertIdx      length = N_attach
+  2  StructuredBuffer<float3>   fixedPos     length = N_attach
+  3  StructuredBuffer<float>    stiffness    length = N_attach   (= k_eff)
+  4  StructuredBuffer<float3>   lambda       length = N_attach   (accumulated
+                                                                   by attachment_dual_update)
+  5  RWStructuredBuffer<float3> gradV        length = N_attach
+  6  RWStructuredBuffer<float>  hessScalar   length = N_attach
+-/
+
+namespace Cloth.SlangCodegen.AttachmentForceAl
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"   (.member (.var "tid") "x")
+  , .declInit u  "v"   (.index (.var "vertIdx") (.var "c"))
+  , .declInit f3 "p"   (.index (.var "positions") (.var "v"))
+  , .declInit f3 "fp"  (.index (.var "fixedPos") (.var "c"))
+  , .declInit f  "k"   (.index (.var "stiffness") (.var "c"))
+  , .declInit f3 "lam" (.index (.var "lambda") (.var "c"))
+  , .assign (.index (.var "gradV") (.var "c"))
+      (.call "float3"
+        [ .bin "+"
+            (.bin "*" (.var "k")
+              (.bin "-" (.member (.var "p") "x") (.member (.var "fp") "x")))
+            (.member (.var "lam") "x")
+        , .bin "+"
+            (.bin "*" (.var "k")
+              (.bin "-" (.member (.var "p") "y") (.member (.var "fp") "y")))
+            (.member (.var "lam") "y")
+        , .bin "+"
+            (.bin "*" (.var "k")
+              (.bin "-" (.member (.var "p") "z") (.member (.var "fp") "z")))
+            (.member (.var "lam") "z") ])
+  , .assign (.index (.var "hessScalar") (.var "c")) (.var "k")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "vertIdx"    (.roBuf u)
+      , bnd 2 "fixedPos"   (.roBuf f3)
+      , bnd 3 "stiffness"  (.roBuf f)
+      , bnd 4 "lambda"     (.roBuf f3)
+      , bnd 5 "gradV"      (.rwBuf f3)
+      , bnd 6 "hessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> vertIdx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float3> fixedPos;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float3> lambda;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> gradV;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float> hessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint v = vertIdx[c];
+  float3 p = positions[v];
+  float3 fp = fixedPos[c];
+  float k = stiffness[c];
+  float3 lam = lambda[c];
+  gradV[c] = float3(((k * (p.x - fp.x)) + lam.x), ((k * (p.y - fp.y)) + lam.y), ((k * (p.z - fp.z)) + lam.z));
+  hessScalar[c] = k;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.AttachmentForceAl

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -43,6 +43,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("vbd_gather_triangle", VbdGatherTriangle.shader)
   , ("vbd_gather_bending", VbdGatherBending.shader)
   , ("attachment_dual_update", AttachmentDualUpdate.shader)
+  , ("attachment_force_al", AttachmentForceAl.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -57,7 +57,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               vbd_gather_attachment:vbd_gather_attachment \
               vbd_gather_triangle:vbd_gather_triangle \
               vbd_gather_bending:vbd_gather_bending \
-              attachment_dual_update:attachment_dual_update
+              attachment_dual_update:attachment_dual_update \
+              attachment_force_al:attachment_force_al
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/attachment_force_al_test.cpp
+++ b/tests/slang_validate/attachment_force_al_test.cpp
@@ -1,0 +1,110 @@
+// Real-input validator for Cloth.SlangCodegen.AttachmentForceAl —
+// augmented-Lagrangian attachment force.
+//
+// Per attachment c, with C(x_v) = x_v − fixedPos[c]:
+//   gradV[c]      = stiffness[c] · C  +  lambda[c]
+//   hessScalar[c] = stiffness[c]
+//
+// Test fixture (2 attachments over 3 verts):
+//   v0 = (1, 2, 3)   v1 = (4, 5, 5)   v2 = (0, 0, 0)
+//   c0: pin v0 to (1, 0, 3), k=2, λ=(0, 0, 0)
+//       C = (0, 2, 0); grad = 2·(0,2,0) + 0 = (0, 4, 0)
+//       hess = 2
+//   c1: pin v1 to (4, 5, 0), k=1, λ=(10, -20, 30)
+//       C = (0, 0, 5); grad = 1·(0,0,5) + (10,-20,30) = (10, -20, 35)
+//       hess = 1
+//
+// Padding: vertIdx=2, fixedPos=zero, stiffness=0, lambda=zero → all
+// outputs zero.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "attachment_force_al_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_ATTACH = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(1.0f, 2.0f, 3.0f),
+        Vector<float, 3>(4.0f, 5.0f, 5.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+    };
+
+    std::vector<uint32_t>         vertIdx(GROUP_SIZE, 2u);
+    std::vector<Vector<float, 3>> fixedPos(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> lambda(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<Vector<float, 3>> gradV(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hessScalar(GROUP_SIZE, 0.0f);
+
+    vertIdx[0] = 0u; fixedPos[0] = Vector<float, 3>(1.0f, 0.0f, 3.0f);
+    stiffness[0] = 2.0f;
+    // λ_0 stays zero
+
+    vertIdx[1] = 1u; fixedPos[1] = Vector<float, 3>(4.0f, 5.0f, 0.0f);
+    stiffness[1] = 1.0f;
+    lambda[1] = Vector<float, 3>(10.0f, -20.0f, 30.0f);
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.vertIdx_0.data    = vertIdx.data();    gp.vertIdx_0.count    = vertIdx.size();
+    gp.fixedPos_0.data   = fixedPos.data();   gp.fixedPos_0.count   = fixedPos.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.lambda_0.data     = lambda.data();     gp.lambda_0.count     = lambda.size();
+    gp.gradV_0.data      = gradV.data();      gp.gradV_0.count      = gradV.size();
+    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_grad[N_ATTACH][3] = {
+        { 0.0f,  4.0f,  0.0f},
+        {10.0f, -20.0f, 35.0f},
+    };
+    const float expected_hess[N_ATTACH] = {2.0f, 1.0f};
+
+    int fails = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t c, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-6f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "%s mismatch at c=%u axis=%d: got %g, expected %g\n",
+                    label, c, axis, got, ref);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_ATTACH; ++c) {
+        for (int axis = 0; axis < 3; ++axis) check(gradV[c][axis], expected_grad[c][axis], "gradV", c, axis);
+        check(hessScalar[c], expected_hess[c], "hessScalar", c, 0);
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "attachment_force_al: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("attachment_force_al: %u/%u OK (max_abs_diff=%g, %.1fms)\n",
+                    N_ATTACH, N_ATTACH, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "attachment_force_al: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Companion to \`attachment_dual_update\` (#74). After the dual-ramp kernel updates \`λ_c\` each outer-iter sweep, this kernel reads the accumulated multiplier and folds it into the per-attachment gradient. Drop-in replacement for \`attachment_force\` (#44) with one extra \`lambda\` input and one extra add-per-axis in the gradient.

\`\`\`
E_al(x_v)   = (1/2) · k · |C|²  +  λ_cᵀ · C        where C = x_v − fixed
∇_v E_al    = k · C  +  λ_c                        ← the new term
∇²_v E_al   = k · I₃                                ← unchanged
\`\`\`

Same scalar·I Hessian shape. The "effective stiffness" k here is \`k_phys + γ_al\`; the caller picks \`γ_al\` and folds it into \`stiffness[c]\` before upload.

## Verification
\`\`\`
attachment_force_al: 2/2 OK (max_abs_diff=0, 0.0ms)
\`\`\`

2-attachment / 3-vert fixture exercises the λ=0 and λ≠0 cases against hand-computed reference.

## Roadmap (#42) — PR-F

- ✅ \`attachment_dual_update\` (#74)
- 🟡 **\`attachment_force_al\`** — this PR
- AvbdSolver wiring: allocate λ, dispatch dual_update each outer iter
- re-run convergence probe — expect conv_max from #73's 0.7 → 1e-3 range
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact (max_abs_diff=0)
- [ ] CI lean-slang validate