### PR TITLE
AvbdSolver: wire AL attachment path + stepDualAttachments (PR-F)

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -104,18 +104,27 @@ public:
 
     // Dispatch one full AVBD outer iteration covering every constraint
     // type DiffCloth uses:
-    //   1. vbd_init                   inertial term per vertex
-    //   2. spring_force + gather      (if nSprings > 0)
-    //   3. attachment_force + gather  (if nAttach > 0)
-    //   4. triangle_membrane_force
-    //        + vbd_gather_triangle    (if nTri > 0)
-    //   5. triangle_bending_force
-    //        + vbd_gather_bending     (if nBend > 0)
-    //   6. vbd_solve_apply            invert 3x3 H, update positions
+    //   1. vbd_init                       inertial term per vertex
+    //   2. spring_force + gather          (if nSprings > 0)
+    //   3. attachment_force_al + gather   (if nAttach > 0)
+    //                                      AL-augmented: gradient
+    //                                      includes accumulated λ_c
+    //                                      (initially zero; ramped by
+    //                                      stepDualAttachments())
+    //   4. triangle_membrane_force + gather  (if nTri > 0)
+    //   5. triangle_bending_force + gather   (if nBend > 0)
+    //   6. vbd_solve_apply                3x3 inverse + position update
     //
     // After step() returns, `readPositions(out)` returns the updated
     // vertex positions. Returns 0 on success, -1 if not set up.
     int step();
+
+    // Augmented-Lagrangian dual ramp for attachments. Per attachment
+    // c, updates λ_c ← λ_c + γ_c · (p_v − fixedPos[c]). Call after
+    // step() each AVBD outer iter to suppress oscillation on hard
+    // pins (see PR #73 convergence probe for the failure mode this
+    // fixes). No-op if nAttach == 0. Returns 0 on success.
+    int stepDualAttachments();
 
     // Per-step state refresh: re-upload positions + predicted into the
     // existing GPU buffers (no realloc). Cheap when called every step

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -37,7 +37,9 @@ struct AvbdSolver::Impl {
     // current positions before the gather kernel scatters them
     // per-vertex).
     id<MTLComputePipelineState> psoSpringForce      = nil;
-    id<MTLComputePipelineState> psoAttachmentForce  = nil;
+    id<MTLComputePipelineState> psoAttachmentForce  = nil;        // legacy non-AL path (kept for fallback)
+    id<MTLComputePipelineState> psoAttachmentForceAl = nil;       // AL-augmented (active)
+    id<MTLComputePipelineState> psoAttachmentDualUpdate = nil;    // per-iter λ ramp
     id<MTLComputePipelineState> psoTriangleMembraneForce = nil;
     id<MTLComputePipelineState> psoTriangleBendingForce  = nil;
 
@@ -71,6 +73,12 @@ struct AvbdSolver::Impl {
     id<MTLBuffer> bufAttachStiffness   = nil; // float per attachment
     id<MTLBuffer> bufAttachGradV       = nil; // padded float3 per attachment
     id<MTLBuffer> bufAttachHessScalar  = nil; // float per attachment
+
+    // Augmented-Lagrangian state per attachment (PR-F).
+    // λ_c — dual multiplier, accumulates across outer iters (padded float3).
+    // γ_c — AL penalty (per-attachment, defaults to stiffness).
+    id<MTLBuffer> bufAttachLambda      = nil;
+    id<MTLBuffer> bufAttachGamma       = nil;
 
     // Vertex → attachment CSR. Role is implicit (always 0 for K=1).
     id<MTLBuffer> bufVertAttachOffset  = nil; // uint per (nVerts+1)
@@ -162,10 +170,13 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     id<MTLLibrary> libSolve      = Impl::loadLib(impl_->device, root + "vbd_solve_apply.metallib",      "vbd_solve_apply");
     id<MTLLibrary> libSpringForce         = Impl::loadLib(impl_->device, root + "spring_force.metallib",            "spring_force");
     id<MTLLibrary> libAttachmentForce     = Impl::loadLib(impl_->device, root + "attachment_force.metallib",        "attachment_force");
+    id<MTLLibrary> libAttachmentForceAl   = Impl::loadLib(impl_->device, root + "attachment_force_al.metallib",     "attachment_force_al");
+    id<MTLLibrary> libAttachmentDualUpdate= Impl::loadLib(impl_->device, root + "attachment_dual_update.metallib",  "attachment_dual_update");
     id<MTLLibrary> libTriMembraneForce    = Impl::loadLib(impl_->device, root + "triangle_membrane_force.metallib", "triangle_membrane_force");
     id<MTLLibrary> libTriBendingForce     = Impl::loadLib(impl_->device, root + "triangle_bending_force.metallib",  "triangle_bending_force");
     if (!libInit || !libSpring || !libAttachment || !libTriangle || !libBending || !libSolve ||
-        !libSpringForce || !libAttachmentForce || !libTriMembraneForce || !libTriBendingForce) return;
+        !libSpringForce || !libAttachmentForce || !libAttachmentForceAl ||
+        !libAttachmentDualUpdate || !libTriMembraneForce || !libTriBendingForce) return;
 
     impl_->psoInit             = Impl::makePSO(impl_->device, libInit,       "main_0", "vbd_init");
     impl_->psoGatherSpring     = Impl::makePSO(impl_->device, libSpring,     "main_0", "vbd_gather_spring");
@@ -175,16 +186,19 @@ AvbdSolver::AvbdSolver(const char* metallibPath)
     impl_->psoSolveApply       = Impl::makePSO(impl_->device, libSolve,      "main_0", "vbd_solve_apply");
     impl_->psoSpringForce            = Impl::makePSO(impl_->device, libSpringForce,         "main_0", "spring_force");
     impl_->psoAttachmentForce        = Impl::makePSO(impl_->device, libAttachmentForce,     "main_0", "attachment_force");
+    impl_->psoAttachmentForceAl      = Impl::makePSO(impl_->device, libAttachmentForceAl,   "main_0", "attachment_force_al");
+    impl_->psoAttachmentDualUpdate   = Impl::makePSO(impl_->device, libAttachmentDualUpdate,"main_0", "attachment_dual_update");
     impl_->psoTriangleMembraneForce  = Impl::makePSO(impl_->device, libTriMembraneForce,    "main_0", "triangle_membrane_force");
     impl_->psoTriangleBendingForce   = Impl::makePSO(impl_->device, libTriBendingForce,     "main_0", "triangle_bending_force");
     if (!impl_->psoInit || !impl_->psoGatherSpring || !impl_->psoGatherAttachment ||
         !impl_->psoGatherTriangle || !impl_->psoGatherBending || !impl_->psoSolveApply ||
         !impl_->psoSpringForce || !impl_->psoAttachmentForce ||
+        !impl_->psoAttachmentForceAl || !impl_->psoAttachmentDualUpdate ||
         !impl_->psoTriangleMembraneForce || !impl_->psoTriangleBendingForce) return;
 
     impl_->ok = true;
     std::fprintf(stderr,
-        "AvbdSolver: 10 kernels loaded — full AVBD pipeline (init, gather_*, solve_apply, spring/attach/tri/bend_force)\n");
+        "AvbdSolver: 12 kernels loaded — full AVBD pipeline + AL attachment path\n");
 }
 
 AvbdSolver::~AvbdSolver() { delete impl_; }
@@ -318,6 +332,12 @@ void AvbdSolver::uploadAttachments(uint32_t nAttach,
     impl_->bufAttachStiffness  = [impl_->device newBufferWithBytes:stiffness length:bytesF options:opts];
     impl_->bufAttachGradV      = [impl_->device newBufferWithLength:bytesVec3Padded options:opts];
     impl_->bufAttachHessScalar = [impl_->device newBufferWithLength:bytesF options:opts];
+    // AL state: λ_c starts at zero (any prior accumulation discarded
+    // on re-upload); γ_c defaults to k_c so dual ramp tracks the
+    // physical stiffness.
+    impl_->bufAttachLambda     = [impl_->device newBufferWithLength:bytesVec3Padded options:opts];
+    impl_->bufAttachGamma      = [impl_->device newBufferWithBytes:stiffness length:bytesF options:opts];
+    std::memset(impl_->bufAttachLambda.contents, 0, bytesVec3Padded);
     uploadVec3Padded(impl_->bufAttachFixedPos, fixedPos, nAttach);
 
     // Build vertex→attachment CSR. K=1, so each attachment contributes
@@ -502,15 +522,20 @@ int AvbdSolver::step() {
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
     }
 
-    // 4. attachment_force + vbd_gather_attachment (if nAttach > 0).
+    // 4. attachment_force_al + vbd_gather_attachment (if nAttach > 0).
+    //    AL force kernel includes accumulated dual multiplier λ in the
+    //    gradient — with λ initialized to zero the behavior matches
+    //    the non-AL kernel exactly; once stepDualAttachments() starts
+    //    ramping λ this drives oscillation away.
     if (impl_->nAttach > 0) {
-        [enc setComputePipelineState:impl_->psoAttachmentForce];
+        [enc setComputePipelineState:impl_->psoAttachmentForceAl];
         [enc setBuffer:impl_->bufPositions          offset:0 atIndex:0];
         [enc setBuffer:impl_->bufAttachVertIdx      offset:0 atIndex:1];
         [enc setBuffer:impl_->bufAttachFixedPos     offset:0 atIndex:2];
         [enc setBuffer:impl_->bufAttachStiffness    offset:0 atIndex:3];
-        [enc setBuffer:impl_->bufAttachGradV        offset:0 atIndex:4];
-        [enc setBuffer:impl_->bufAttachHessScalar   offset:0 atIndex:5];
+        [enc setBuffer:impl_->bufAttachLambda       offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufAttachGradV        offset:0 atIndex:5];
+        [enc setBuffer:impl_->bufAttachHessScalar   offset:0 atIndex:6];
         [enc dispatchThreads:MTLSizeMake(impl_->nAttach, 1, 1)
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
 
@@ -605,6 +630,25 @@ void AvbdSolver::updateState(const float* positions, const float* predicted) {
     if (!ok() || !impl_->meshReady) return;
     uploadVec3Padded(impl_->bufPositions, positions, impl_->nVerts);
     uploadVec3Padded(impl_->bufPredicted, predicted, impl_->nVerts);
+}
+
+int AvbdSolver::stepDualAttachments() {
+    if (!ok() || !impl_->meshReady) return -1;
+    if (impl_->nAttach == 0) return 0;
+    id<MTLCommandBuffer> cb = [impl_->queue commandBuffer];
+    id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+    [enc setComputePipelineState:impl_->psoAttachmentDualUpdate];
+    [enc setBuffer:impl_->bufPositions       offset:0 atIndex:0];
+    [enc setBuffer:impl_->bufAttachVertIdx   offset:0 atIndex:1];
+    [enc setBuffer:impl_->bufAttachFixedPos  offset:0 atIndex:2];
+    [enc setBuffer:impl_->bufAttachGamma     offset:0 atIndex:3];
+    [enc setBuffer:impl_->bufAttachLambda    offset:0 atIndex:4];
+    [enc dispatchThreads:MTLSizeMake(impl_->nAttach, 1, 1)
+   threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+    [enc endEncoding];
+    [cb commit];
+    [cb waitUntilCompleted];
+    return 0;
 }
 
 void AvbdSolver::readPositions(std::vector<float>& positions_out) const {

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force vbd_init vbd_solve_apply vbd_gather_spring vbd_gather_attachment vbd_gather_triangle vbd_gather_bending
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force vbd_init vbd_solve_apply vbd_gather_spring vbd_gather_attachment vbd_gather_triangle vbd_gather_bending attachment_force_al attachment_dual_update
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++


### PR DESCRIPTION
## Summary
Wires the two AL kernels (#74, #75) into the runtime wrapper. \`AvbdSolver\` now loads **12 kernels** and exposes a new entry point.

\`\`\`
step()                 attachment_force → attachment_force_al
                       (binds bufAttachLambda, otherwise identical dispatch)
                       λ=0 initial → AL output bit-identical to non-AL

stepDualAttachments()  NEW; dispatches attachment_dual_update to ramp
                       λ_c ← λ_c + γ_c · (p_v − fixedPos[c])
                       Caller alternates step() ↔ stepDualAttachments()
                       each outer iter to drive hard-pin oscillation → 0
\`\`\`

State allocation in \`uploadAttachments\`:
- \`bufAttachLambda\` — padded float3 per attachment, zero-initialized
- \`bufAttachGamma\` — float per attachment, defaults to \`stiffness[c]\`

## Verification (real Apple Silicon Metal)
\`\`\`
AvbdSolver: 12 kernels loaded — full AVBD pipeline + AL attachment path
test_avbd_solver: OK (full AVBD step on 4 verts: 1 spring 1 attach 1 tri 1 bend, max_abs_diff=0)
\`\`\`

Bit-exact backward compatibility on the existing 4-vert / 4-constraint smoke test — with λ=0, the AL force kernel produces the same gradient as the legacy attachment_force.

## Roadmap (#42) — PR-F

- ✅ \`attachment_dual_update\` (#74)
- ✅ \`attachment_force_al\` (#75)
- 🟡 **AvbdSolver wiring + stepDualAttachments** — this PR
- PR-F continued: wire stepDualAttachments into Simulation.cpp shadow loop
- PR-F continued: re-run convergence probe — expect conv_max from 0.7 → ~1e-3
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`make -C src/code/slang_solver test-avbd\` — 12 kernels load, AL force bit-equivalent at λ=0
- [ ] CI lean-slang validate