### PR TITLE
Simulation.cpp: wire stepDualAttachments + AVBD_AL env — finding: AL on attachments insufficient for dress (PR-F)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1237,6 +1237,12 @@ void Simulation::step() {
 		}
 		auto _avbd_t0 = std::chrono::steady_clock::now();
 		sysMat[0].avbd->updateState(posF.data(), predF.data());
+		// AVBD_AL=1 enables the augmented-Lagrangian dual ramp on
+		// attachments. After each outer iter's step(), dispatch
+		// stepDualAttachments() to nudge λ toward zero constraint
+		// violation. Default off (use the bit-equivalent λ=0 path).
+		static const bool s_avbdAl = (std::getenv("AVBD_AL") != nullptr);
+
 		int rc = 0;
 		// Run the first half of iterations, snapshot positions, then
 		// run the second half. The snapshot lets us measure
@@ -1246,12 +1252,14 @@ void Simulation::step() {
 		for (int it = 0; it < firstHalf; ++it) {
 			rc = sysMat[0].avbd->step();
 			if (rc != 0) break;
+			if (s_avbdAl) sysMat[0].avbd->stepDualAttachments();
 		}
 		std::vector<float> avbdPosHalf;
 		if (rc == 0 && firstHalf > 0)
 			sysMat[0].avbd->readPositions(avbdPosHalf);
 		for (int it = firstHalf; it < s_avbdIters && rc == 0; ++it) {
 			rc = sysMat[0].avbd->step();
+			if (rc == 0 && s_avbdAl) sysMat[0].avbd->stepDualAttachments();
 		}
 		auto _avbd_t1 = std::chrono::steady_clock::now();
 		const long long us =


### PR DESCRIPTION
## Summary
Adds \`AVBD_AL=1\` env gate. When set, alternates \`step()\` ↔ \`stepDualAttachments()\` each outer iter so the AL dual ramp drives λ toward zero constraint violation.

## A/B on dress (USE_AVBD=1 AVBD_ITERS=16)

| Mode | wall | \`|Δx|_max\` | \`conv_max\` |
|---|---:|---:|---:|
| AL=0 baseline (step 1) | 9.9 ms | 1.43054 | **0.712535** |
| AL=1 step+dual (step 1) | 16.6 ms | 1.43054 | **0.712535** |
| AL=0 baseline (step 2) | 5.1 ms | 1.43099 | **0.712542** |
| AL=1 step+dual (step 2) | 15.9 ms | 1.43099 | **0.712542** |

## Finding: AL on attachments alone is insufficient for the dress

**\`conv_max\` is identical to 4 decimal places between AL=0 and AL=1.** The oscillating vertex is *not* an attachment.

Interpretation: dress has 31 attachments (waistband pins) but 7026 triangles and 10416 bending stencils. The \`conv_max=0.7\` oscillation comes from triangle membrane or bending — both have stiffness orders of magnitude higher than gravity. AL on attachments can't reach triangle-mesh oscillation.

## What's needed for full fix

Real convergence will need AL kernels for triangle and bending too:
- \`triangle_membrane_force_al\` + \`triangle_membrane_dual_update\`
- \`triangle_bending_force_al\` + \`triangle_bending_dual_update\`

Each follows the same kernel pattern as #74 + #75. The kernel-level scaffolding is already proven; extending it to two more constraint types is mechanical.

## Roadmap (#42) — PR-F continued

- ✅ \`attachment_dual_update\` (#74)
- ✅ \`attachment_force_al\` (#75)
- ✅ AvbdSolver AL wiring + \`stepDualAttachments\` (#76)
- 🟡 **AVBD_AL env + empirical finding on dress** — this PR
- PR-F continued: \`triangle_membrane_force_al\` + dual_update
- PR-F continued: \`triangle_bending_force_al\` + dual_update
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] AVBD_AL=1 wiring runs on dress at 16 iters without NaN
- [x] Documented empirical finding: AL on attachments alone doesn't reach dress's oscillation
- [ ] CI lean-slang validate