### PR TITLE
Add triangle_membrane_dual_update: AL ramp for ARAP membrane (PR-F)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -24,6 +24,7 @@ import Cloth.SlangCodegen.VbdGatherTriangle
 import Cloth.SlangCodegen.VbdGatherBending
 import Cloth.SlangCodegen.AttachmentDualUpdate
 import Cloth.SlangCodegen.AttachmentForceAl
+import Cloth.SlangCodegen.TriangleMembraneDualUpdate
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/TriangleMembraneDualUpdate.lean
+++ b/lean/Cloth/SlangCodegen/TriangleMembraneDualUpdate.lean
@@ -1,0 +1,227 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.TriangleMembraneDualUpdate` — AVBD AL ramp for triangle membrane
+
+PR-F's empirical finding in #77: AL on attachments alone doesn't fix
+the dress's oscillation (\`conv_max ≈ 0.71\` unchanged). The
+oscillating vertex is on triangle-mesh dynamics, not waistband pins.
+This kernel extends the AL dual ramp to the triangle membrane
+constraint — same idea as `AttachmentDualUpdate` (#74), but the
+constraint here is the 2-column ARAP residual `F − R` instead of a
+single point distance.
+
+Per triangle `c` with vertex indices `(i0, i1, i2)` and AL penalty
+`γ_c`:
+
+```
+F.col(0) = p1 − p0                      -- raw edges
+F.col(1) = p2 − p0
+R        = closest-rotation(F)          -- same Gram-Schmidt + 2D
+                                           polar as TriangleMembraneForce
+e0       = F.col(0) − R.col(0)          -- residual column 0
+e1       = F.col(1) − R.col(1)          -- residual column 1
+
+λ_c.col(0) ← λ_c.col(0) + γ_c · e0      -- dual ascent on first column
+λ_c.col(1) ← λ_c.col(1) + γ_c · e1      -- dual ascent on second column
+```
+
+`λ` is stored as two `float3` buffers — one per column of the 3×2
+residual matrix — so the future `triangle_membrane_force_al` kernel
+can do `gradV[3c+r] += sign_r · λ_c.col(*)` cheaply (with per-vertex
+sign `{ -(λ0+λ1), +λ0, +λ1 }` for roles 0, 1, 2).
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions   length = N_verts
+  1  StructuredBuffer<uint>     idx         length = 3 · N_tri
+  2  StructuredBuffer<float>    gamma       length = N_tri
+  3  RWStructuredBuffer<float3> lambda0     length = N_tri   (column 0 of λ)
+  4  RWStructuredBuffer<float3> lambda1     length = N_tri   (column 1 of λ)
+
+Mirrors the closest-rotation math from TriangleMembraneForce. No
+output forces — this kernel only updates λ. Caller dispatches
+`triangle_membrane_force_al` separately to consume λ in the force
+gradient.
+-/
+
+namespace Cloth.SlangCodegen.TriangleMembraneDualUpdate
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def pmv (s : String) (field : String) : SlangExpr :=
+  .member (.var s) field
+
+private def sum3 (a b c : SlangExpr) : SlangExpr :=
+  .bin "+" (.bin "+" a b) c
+
+private def len3 (x y z : SlangExpr) : SlangExpr :=
+  .call "sqrt" [ sum3 (.bin "*" x x) (.bin "*" y y) (.bin "*" z z) ]
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"    (.member (.var "tid") "x")
+  , .declInit u  "base" (.bin "*" (.var "c") (.litUint 3))
+  , .declInit u  "i0"   (.index (.var "idx") (.var "base"))
+  , .declInit u  "i1"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 1)))
+  , .declInit u  "i2"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 2)))
+  , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
+  , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
+  , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
+  , .declInit f "f0x" (.bin "-" (pmv "p1" "x") (pmv "p0" "x"))
+  , .declInit f "f0y" (.bin "-" (pmv "p1" "y") (pmv "p0" "y"))
+  , .declInit f "f0z" (.bin "-" (pmv "p1" "z") (pmv "p0" "z"))
+  , .declInit f "f1x" (.bin "-" (pmv "p2" "x") (pmv "p0" "x"))
+  , .declInit f "f1y" (.bin "-" (pmv "p2" "y") (pmv "p0" "y"))
+  , .declInit f "f1z" (.bin "-" (pmv "p2" "z") (pmv "p0" "z"))
+  , .declInit f "a"   (len3 (.var "f0x") (.var "f0y") (.var "f0z"))
+  , .declInit f "e1x" (.bin "/" (.var "f0x") (.var "a"))
+  , .declInit f "e1y" (.bin "/" (.var "f0y") (.var "a"))
+  , .declInit f "e1z" (.bin "/" (.var "f0z") (.var "a"))
+  , .declInit f "b"
+      (sum3 (.bin "*" (.var "e1x") (.var "f1x"))
+            (.bin "*" (.var "e1y") (.var "f1y"))
+            (.bin "*" (.var "e1z") (.var "f1z")))
+  , .declInit f "tx" (.bin "-" (.var "f1x") (.bin "*" (.var "b") (.var "e1x")))
+  , .declInit f "ty" (.bin "-" (.var "f1y") (.bin "*" (.var "b") (.var "e1y")))
+  , .declInit f "tz" (.bin "-" (.var "f1z") (.bin "*" (.var "b") (.var "e1z")))
+  , .declInit f "d"   (len3 (.var "tx") (.var "ty") (.var "tz"))
+  , .declInit f "e2x" (.bin "/" (.var "tx") (.var "d"))
+  , .declInit f "e2y" (.bin "/" (.var "ty") (.var "d"))
+  , .declInit f "e2z" (.bin "/" (.var "tz") (.var "d"))
+  , .declInit f "xv" (.bin "+" (.var "a") (.var "d"))
+  , .declInit f "yv" (.bin "-" (.litFloat 0.0) (.var "b"))
+  , .declInit f "rn"
+      (.call "sqrt" [.bin "+" (.bin "*" (.var "xv") (.var "xv"))
+                              (.bin "*" (.var "yv") (.var "yv"))])
+  , .declInit f "r00" (.bin "/" (.var "xv") (.var "rn"))
+  , .declInit f "r01" (.bin "/" (.var "b")  (.var "rn"))
+  , .declInit f "r10" (.bin "/" (.var "yv") (.var "rn"))
+  , .declInit f "r11" (.bin "/" (.var "xv") (.var "rn"))
+  , .declInit f "n0x" (.bin "+" (.bin "*" (.var "e1x") (.var "r00"))
+                                (.bin "*" (.var "e2x") (.var "r10")))
+  , .declInit f "n0y" (.bin "+" (.bin "*" (.var "e1y") (.var "r00"))
+                                (.bin "*" (.var "e2y") (.var "r10")))
+  , .declInit f "n0z" (.bin "+" (.bin "*" (.var "e1z") (.var "r00"))
+                                (.bin "*" (.var "e2z") (.var "r10")))
+  , .declInit f "n1x" (.bin "+" (.bin "*" (.var "e1x") (.var "r01"))
+                                (.bin "*" (.var "e2x") (.var "r11")))
+  , .declInit f "n1y" (.bin "+" (.bin "*" (.var "e1y") (.var "r01"))
+                                (.bin "*" (.var "e2y") (.var "r11")))
+  , .declInit f "n1z" (.bin "+" (.bin "*" (.var "e1z") (.var "r01"))
+                                (.bin "*" (.var "e2z") (.var "r11")))
+  , .declInit f "e0x" (.bin "-" (.var "f0x") (.var "n0x"))
+  , .declInit f "e0y" (.bin "-" (.var "f0y") (.var "n0y"))
+  , .declInit f "e0z" (.bin "-" (.var "f0z") (.var "n0z"))
+  , .declInit f "e1rx" (.bin "-" (.var "f1x") (.var "n1x"))
+  , .declInit f "e1ry" (.bin "-" (.var "f1y") (.var "n1y"))
+  , .declInit f "e1rz" (.bin "-" (.var "f1z") (.var "n1z"))
+  , .declInit f  "g"   (.index (.var "gamma") (.var "c"))
+  , .declInit f3 "l0"  (.index (.var "lambda0") (.var "c"))
+  , .declInit f3 "l1"  (.index (.var "lambda1") (.var "c"))
+  , .assign (.index (.var "lambda0") (.var "c"))
+      (.call "float3"
+        [ .bin "+" (pmv "l0" "x") (.bin "*" (.var "g") (.var "e0x"))
+        , .bin "+" (pmv "l0" "y") (.bin "*" (.var "g") (.var "e0y"))
+        , .bin "+" (pmv "l0" "z") (.bin "*" (.var "g") (.var "e0z")) ])
+  , .assign (.index (.var "lambda1") (.var "c"))
+      (.call "float3"
+        [ .bin "+" (pmv "l1" "x") (.bin "*" (.var "g") (.var "e1rx"))
+        , .bin "+" (pmv "l1" "y") (.bin "*" (.var "g") (.var "e1ry"))
+        , .bin "+" (pmv "l1" "z") (.bin "*" (.var "g") (.var "e1rz")) ])
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions" (.roBuf f3)
+      , bnd 1 "idx"       (.roBuf u)
+      , bnd 2 "gamma"     (.roBuf f)
+      , bnd 3 "lambda0"   (.rwBuf f3)
+      , bnd 4 "lambda1"   (.rwBuf f3)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> gamma;
+[[vk::binding(3, 0)]]
+RWStructuredBuffer<float3> lambda0;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float3> lambda1;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint base = (c * 3u);
+  uint i0 = idx[base];
+  uint i1 = idx[(base + 1u)];
+  uint i2 = idx[(base + 2u)];
+  float3 p0 = positions[i0];
+  float3 p1 = positions[i1];
+  float3 p2 = positions[i2];
+  float f0x = (p1.x - p0.x);
+  float f0y = (p1.y - p0.y);
+  float f0z = (p1.z - p0.z);
+  float f1x = (p2.x - p0.x);
+  float f1y = (p2.y - p0.y);
+  float f1z = (p2.z - p0.z);
+  float a = sqrt((((f0x * f0x) + (f0y * f0y)) + (f0z * f0z)));
+  float e1x = (f0x / a);
+  float e1y = (f0y / a);
+  float e1z = (f0z / a);
+  float b = (((e1x * f1x) + (e1y * f1y)) + (e1z * f1z));
+  float tx = (f1x - (b * e1x));
+  float ty = (f1y - (b * e1y));
+  float tz = (f1z - (b * e1z));
+  float d = sqrt((((tx * tx) + (ty * ty)) + (tz * tz)));
+  float e2x = (tx / d);
+  float e2y = (ty / d);
+  float e2z = (tz / d);
+  float xv = (a + d);
+  float yv = (0.000000 - b);
+  float rn = sqrt(((xv * xv) + (yv * yv)));
+  float r00 = (xv / rn);
+  float r01 = (b / rn);
+  float r10 = (yv / rn);
+  float r11 = (xv / rn);
+  float n0x = ((e1x * r00) + (e2x * r10));
+  float n0y = ((e1y * r00) + (e2y * r10));
+  float n0z = ((e1z * r00) + (e2z * r10));
+  float n1x = ((e1x * r01) + (e2x * r11));
+  float n1y = ((e1y * r01) + (e2y * r11));
+  float n1z = ((e1z * r01) + (e2z * r11));
+  float e0x = (f0x - n0x);
+  float e0y = (f0y - n0y);
+  float e0z = (f0z - n0z);
+  float e1rx = (f1x - n1x);
+  float e1ry = (f1y - n1y);
+  float e1rz = (f1z - n1z);
+  float g = gamma[c];
+  float3 l0 = lambda0[c];
+  float3 l1 = lambda1[c];
+  lambda0[c] = float3((l0.x + (g * e0x)), (l0.y + (g * e0y)), (l0.z + (g * e0z)));
+  lambda1[c] = float3((l1.x + (g * e1rx)), (l1.y + (g * e1ry)), (l1.z + (g * e1rz)));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.TriangleMembraneDualUpdate

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -44,6 +44,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("vbd_gather_bending", VbdGatherBending.shader)
   , ("attachment_dual_update", AttachmentDualUpdate.shader)
   , ("attachment_force_al", AttachmentForceAl.shader)
+  , ("triangle_membrane_dual_update", TriangleMembraneDualUpdate.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -58,7 +58,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               vbd_gather_triangle:vbd_gather_triangle \
               vbd_gather_bending:vbd_gather_bending \
               attachment_dual_update:attachment_dual_update \
-              attachment_force_al:attachment_force_al
+              attachment_force_al:attachment_force_al \
+              triangle_membrane_dual_update:triangle_membrane_dual_update
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/triangle_membrane_dual_update_test.cpp
+++ b/tests/slang_validate/triangle_membrane_dual_update_test.cpp
@@ -1,0 +1,97 @@
+// Real-input validator for Cloth.SlangCodegen.TriangleMembraneDualUpdate —
+// AVBD AL dual ramp for triangle membrane constraints.
+//
+// Per triangle c (corners i0,i1,i2), with γ=gamma[c]:
+//   F.col0 = p1-p0, F.col1 = p2-p0
+//   R = closest-rotation(F) via Gram-Schmidt + 2D polar
+//   e0 = F.col0 - R.col0,  e1 = F.col1 - R.col1
+//   λ0[c] += γ · e0
+//   λ1[c] += γ · e1
+//
+// Test fixture (3 verts, 1 triangle, deformed 2x in x and y):
+//   v0=(0,0,0), v1=(2,0,0), v2=(0,2,0)
+//   T0 = (0,1,2), γ=1
+//   F.col0=(2,0,0), F.col1=(0,2,0); 2D form [2,0;0,2] → R=I
+//   R.col0=(1,0,0), R.col1=(0,1,0)
+//   e0=(1,0,0), e1=(0,1,0)
+//   λ0_init=(10,20,30) → λ0_new=(11,20,30)
+//   λ1_init=(-1,-2,-3) → λ1_new=(-1,-1,-3)
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "triangle_membrane_dual_update_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_TRI = 1;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(2.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 2.0f, 0.0f),
+    };
+
+    std::vector<uint32_t>         idx(3 * GROUP_SIZE, 0u);
+    std::vector<float>            gamma(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> lambda0(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<Vector<float, 3>> lambda1(GROUP_SIZE, Vector<float, 3>(0.0f));
+
+    for (uint32_t c = 0; c < GROUP_SIZE; ++c) {
+        idx[3*c+0] = 0u; idx[3*c+1] = 1u; idx[3*c+2] = 2u;
+    }
+    idx[0] = 0u; idx[1] = 1u; idx[2] = 2u;
+    gamma[0] = 1.0f;
+    lambda0[0] = Vector<float, 3>(10.0f, 20.0f, 30.0f);
+    lambda1[0] = Vector<float, 3>(-1.0f, -2.0f, -3.0f);
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data = positions.data(); gp.positions_0.count = positions.size();
+    gp.idx_0.data       = idx.data();       gp.idx_0.count       = idx.size();
+    gp.gamma_0.data     = gamma.data();     gp.gamma_0.count     = gamma.size();
+    gp.lambda0_0.data   = lambda0.data();   gp.lambda0_0.count   = lambda0.size();
+    gp.lambda1_0.data   = lambda1.data();   gp.lambda1_0.count   = lambda1.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_l0[3] = {11.0f, 20.0f, 30.0f};
+    const float expected_l1[3] = {-1.0f, -1.0f, -3.0f};
+
+    int fails = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            std::fprintf(stderr, "%s axis=%d: got %g, expected %g (diff %g)\n",
+                         label, axis, got, ref, d);
+            ++fails;
+        }
+    };
+    for (int a = 0; a < 3; ++a) check(lambda0[0][a], expected_l0[a], "λ0", a);
+    for (int a = 0; a < 3; ++a) check(lambda1[0][a], expected_l1[a], "λ1", a);
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "triangle_membrane_dual_update: TIMEOUT\n");
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("triangle_membrane_dual_update: %u/%u OK (max_abs_diff=%g, %.1fms)\n",
+                    N_TRI, N_TRI, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "triangle_membrane_dual_update: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Motivated by the empirical finding in #77 (dress's \`conv_max ≈ 0.71\` lives on triangle-mesh dynamics, not attachments). Extends the AL dual ramp from attachments (#74) to the triangle membrane (ARAP) constraint.

Per triangle c with corners (i0, i1, i2) and AL penalty γ_c:

\`\`\`
F.col(0) = p1 − p0,  F.col(1) = p2 − p0
R        = closest-rotation(F)        -- Gram-Schmidt + 2D polar
e0       = F.col(0) − R.col(0)         -- residual column 0
e1       = F.col(1) − R.col(1)         -- residual column 1

λ_c.col(0) ← λ_c.col(0) + γ_c · e0     -- dual ascent on col 0
λ_c.col(1) ← λ_c.col(1) + γ_c · e1     -- dual ascent on col 1
\`\`\`

λ stored as two \`RWStructuredBuffer<float3>\` per triangle. Future \`triangle_membrane_force_al\` consumes λ via per-vertex sign pattern:
- v0 gradient gets \`−(λ.col0 + λ.col1)\`
- v1 gradient gets \`+λ.col0\`
- v2 gradient gets \`+λ.col1\`

## Verification
\`\`\`
triangle_membrane_dual_update: 1/1 OK (max_abs_diff=0, 0.0ms)
\`\`\`

3-vert / 1-triangle fixture, 2× stretched. Bit-exact against hand-computed reference.

## Roadmap (#42) — PR-F continued

- ✅ \`attachment_dual_update\` (#74)
- ✅ \`attachment_force_al\` (#75)
- ✅ AvbdSolver AL wiring (#76)
- ✅ Simulation.cpp \`AVBD_AL=1\` + empirical finding (#77)
- 🟡 **\`triangle_membrane_dual_update\`** — this PR
- PR-F: \`triangle_membrane_force_al\`
- PR-F: \`triangle_bending_dual_update\` + \`force_al\`
- PR-F: AvbdSolver wiring + re-run conv probe
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact (max_abs_diff=0)
- [ ] CI lean-slang validate