### PR TITLE
Add triangle_membrane_force_al: AL-augmented ARAP membrane force (PR-F)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -25,6 +25,7 @@ import Cloth.SlangCodegen.VbdGatherBending
 import Cloth.SlangCodegen.AttachmentDualUpdate
 import Cloth.SlangCodegen.AttachmentForceAl
 import Cloth.SlangCodegen.TriangleMembraneDualUpdate
+import Cloth.SlangCodegen.TriangleMembraneForceAl
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/TriangleMembraneForceAl.lean
+++ b/lean/Cloth/SlangCodegen/TriangleMembraneForceAl.lean
@@ -1,0 +1,248 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.TriangleMembraneForceAl` — AL-augmented ARAP membrane force
+
+Companion to `TriangleMembraneDualUpdate` (#78). Same per-triangle
+force + GN Hessian as `triangle_membrane_force` (#45) but with two
+extra `lambda` input columns folded into the per-vertex gradient:
+
+```
+e0 = F.col(0) − R.col(0)                  -- physics residual col 0
+e1 = F.col(1) − R.col(1)                  -- physics residual col 1
+
+grad[3c+0] = -k · (e0 + e1)   - (λ0 + λ1)  -- vertex 0 (sits on both cols)
+grad[3c+1] = +k · e0          + λ0         -- vertex 1
+grad[3c+2] = +k · e1          + λ1         -- vertex 2
+
+hessScalar[3c+0] = 2k                      -- unchanged
+hessScalar[3c+1] = k
+hessScalar[3c+2] = k
+```
+
+`k` here is the effective stiffness `k_phys + γ_al`. The Hessian
+shape is unchanged — AL augmentation only shifts the gradient.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions   length = N_verts
+  1  StructuredBuffer<uint>     idx         length = 3 · N_tri
+  2  StructuredBuffer<float>    stiffness   length = N_tri
+  3  StructuredBuffer<float3>   lambda0     length = N_tri
+  4  StructuredBuffer<float3>   lambda1     length = N_tri
+  5  RWStructuredBuffer<float3> grad        length = 3 · N_tri
+  6  RWStructuredBuffer<float>  hessScalar  length = 3 · N_tri
+-/
+
+namespace Cloth.SlangCodegen.TriangleMembraneForceAl
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def pmv (s : String) (field : String) : SlangExpr :=
+  .member (.var s) field
+
+private def sum3 (a b c : SlangExpr) : SlangExpr :=
+  .bin "+" (.bin "+" a b) c
+
+private def len3 (x y z : SlangExpr) : SlangExpr :=
+  .call "sqrt" [ sum3 (.bin "*" x x) (.bin "*" y y) (.bin "*" z z) ]
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"    (.member (.var "tid") "x")
+  , .declInit u  "base" (.bin "*" (.var "c") (.litUint 3))
+  , .declInit u  "i0"   (.index (.var "idx") (.var "base"))
+  , .declInit u  "i1"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 1)))
+  , .declInit u  "i2"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 2)))
+  , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
+  , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
+  , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
+  , .declInit f "f0x" (.bin "-" (pmv "p1" "x") (pmv "p0" "x"))
+  , .declInit f "f0y" (.bin "-" (pmv "p1" "y") (pmv "p0" "y"))
+  , .declInit f "f0z" (.bin "-" (pmv "p1" "z") (pmv "p0" "z"))
+  , .declInit f "f1x" (.bin "-" (pmv "p2" "x") (pmv "p0" "x"))
+  , .declInit f "f1y" (.bin "-" (pmv "p2" "y") (pmv "p0" "y"))
+  , .declInit f "f1z" (.bin "-" (pmv "p2" "z") (pmv "p0" "z"))
+  , .declInit f "a"   (len3 (.var "f0x") (.var "f0y") (.var "f0z"))
+  , .declInit f "e1x" (.bin "/" (.var "f0x") (.var "a"))
+  , .declInit f "e1y" (.bin "/" (.var "f0y") (.var "a"))
+  , .declInit f "e1z" (.bin "/" (.var "f0z") (.var "a"))
+  , .declInit f "b"
+      (sum3 (.bin "*" (.var "e1x") (.var "f1x"))
+            (.bin "*" (.var "e1y") (.var "f1y"))
+            (.bin "*" (.var "e1z") (.var "f1z")))
+  , .declInit f "tx" (.bin "-" (.var "f1x") (.bin "*" (.var "b") (.var "e1x")))
+  , .declInit f "ty" (.bin "-" (.var "f1y") (.bin "*" (.var "b") (.var "e1y")))
+  , .declInit f "tz" (.bin "-" (.var "f1z") (.bin "*" (.var "b") (.var "e1z")))
+  , .declInit f "d"   (len3 (.var "tx") (.var "ty") (.var "tz"))
+  , .declInit f "e2x" (.bin "/" (.var "tx") (.var "d"))
+  , .declInit f "e2y" (.bin "/" (.var "ty") (.var "d"))
+  , .declInit f "e2z" (.bin "/" (.var "tz") (.var "d"))
+  , .declInit f "xv" (.bin "+" (.var "a") (.var "d"))
+  , .declInit f "yv" (.bin "-" (.litFloat 0.0) (.var "b"))
+  , .declInit f "rn"
+      (.call "sqrt" [.bin "+" (.bin "*" (.var "xv") (.var "xv"))
+                              (.bin "*" (.var "yv") (.var "yv"))])
+  , .declInit f "r00" (.bin "/" (.var "xv") (.var "rn"))
+  , .declInit f "r01" (.bin "/" (.var "b")  (.var "rn"))
+  , .declInit f "r10" (.bin "/" (.var "yv") (.var "rn"))
+  , .declInit f "r11" (.bin "/" (.var "xv") (.var "rn"))
+  , .declInit f "n0x" (.bin "+" (.bin "*" (.var "e1x") (.var "r00"))
+                                (.bin "*" (.var "e2x") (.var "r10")))
+  , .declInit f "n0y" (.bin "+" (.bin "*" (.var "e1y") (.var "r00"))
+                                (.bin "*" (.var "e2y") (.var "r10")))
+  , .declInit f "n0z" (.bin "+" (.bin "*" (.var "e1z") (.var "r00"))
+                                (.bin "*" (.var "e2z") (.var "r10")))
+  , .declInit f "n1x" (.bin "+" (.bin "*" (.var "e1x") (.var "r01"))
+                                (.bin "*" (.var "e2x") (.var "r11")))
+  , .declInit f "n1y" (.bin "+" (.bin "*" (.var "e1y") (.var "r01"))
+                                (.bin "*" (.var "e2y") (.var "r11")))
+  , .declInit f "n1z" (.bin "+" (.bin "*" (.var "e1z") (.var "r01"))
+                                (.bin "*" (.var "e2z") (.var "r11")))
+  , .declInit f "e0x" (.bin "-" (.var "f0x") (.var "n0x"))
+  , .declInit f "e0y" (.bin "-" (.var "f0y") (.var "n0y"))
+  , .declInit f "e0z" (.bin "-" (.var "f0z") (.var "n0z"))
+  , .declInit f "e1rx" (.bin "-" (.var "f1x") (.var "n1x"))
+  , .declInit f "e1ry" (.bin "-" (.var "f1y") (.var "n1y"))
+  , .declInit f "e1rz" (.bin "-" (.var "f1z") (.var "n1z"))
+  , .declInit f  "k"   (.index (.var "stiffness") (.var "c"))
+  , .declInit f3 "l0"  (.index (.var "lambda0")   (.var "c"))
+  , .declInit f3 "l1"  (.index (.var "lambda1")   (.var "c"))
+  , .declInit u "gb"  (.bin "*" (.var "c") (.litUint 3))
+  , .assign (.index (.var "grad") (.var "gb"))
+      (.call "float3"
+        [ .bin "-"
+            (.bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
+              (.bin "+" (.var "e0x") (.var "e1rx")))
+            (.bin "+" (pmv "l0" "x") (pmv "l1" "x"))
+        , .bin "-"
+            (.bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
+              (.bin "+" (.var "e0y") (.var "e1ry")))
+            (.bin "+" (pmv "l0" "y") (pmv "l1" "y"))
+        , .bin "-"
+            (.bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
+              (.bin "+" (.var "e0z") (.var "e1rz")))
+            (.bin "+" (pmv "l0" "z") (pmv "l1" "z")) ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 1)))
+      (.call "float3"
+        [ .bin "+" (.bin "*" (.var "k") (.var "e0x")) (pmv "l0" "x")
+        , .bin "+" (.bin "*" (.var "k") (.var "e0y")) (pmv "l0" "y")
+        , .bin "+" (.bin "*" (.var "k") (.var "e0z")) (pmv "l0" "z") ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 2)))
+      (.call "float3"
+        [ .bin "+" (.bin "*" (.var "k") (.var "e1rx")) (pmv "l1" "x")
+        , .bin "+" (.bin "*" (.var "k") (.var "e1ry")) (pmv "l1" "y")
+        , .bin "+" (.bin "*" (.var "k") (.var "e1rz")) (pmv "l1" "z") ])
+  , .assign (.index (.var "hessScalar") (.var "gb"))
+      (.bin "*" (.litFloat 2.0) (.var "k"))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 1)))
+      (.var "k")
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 2)))
+      (.var "k")
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "idx"        (.roBuf u)
+      , bnd 2 "stiffness"  (.roBuf f)
+      , bnd 3 "lambda0"    (.roBuf f3)
+      , bnd 4 "lambda1"    (.roBuf f3)
+      , bnd 5 "grad"       (.rwBuf f3)
+      , bnd 6 "hessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float3> lambda0;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float3> lambda1;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> grad;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float> hessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint base = (c * 3u);
+  uint i0 = idx[base];
+  uint i1 = idx[(base + 1u)];
+  uint i2 = idx[(base + 2u)];
+  float3 p0 = positions[i0];
+  float3 p1 = positions[i1];
+  float3 p2 = positions[i2];
+  float f0x = (p1.x - p0.x);
+  float f0y = (p1.y - p0.y);
+  float f0z = (p1.z - p0.z);
+  float f1x = (p2.x - p0.x);
+  float f1y = (p2.y - p0.y);
+  float f1z = (p2.z - p0.z);
+  float a = sqrt((((f0x * f0x) + (f0y * f0y)) + (f0z * f0z)));
+  float e1x = (f0x / a);
+  float e1y = (f0y / a);
+  float e1z = (f0z / a);
+  float b = (((e1x * f1x) + (e1y * f1y)) + (e1z * f1z));
+  float tx = (f1x - (b * e1x));
+  float ty = (f1y - (b * e1y));
+  float tz = (f1z - (b * e1z));
+  float d = sqrt((((tx * tx) + (ty * ty)) + (tz * tz)));
+  float e2x = (tx / d);
+  float e2y = (ty / d);
+  float e2z = (tz / d);
+  float xv = (a + d);
+  float yv = (0.000000 - b);
+  float rn = sqrt(((xv * xv) + (yv * yv)));
+  float r00 = (xv / rn);
+  float r01 = (b / rn);
+  float r10 = (yv / rn);
+  float r11 = (xv / rn);
+  float n0x = ((e1x * r00) + (e2x * r10));
+  float n0y = ((e1y * r00) + (e2y * r10));
+  float n0z = ((e1z * r00) + (e2z * r10));
+  float n1x = ((e1x * r01) + (e2x * r11));
+  float n1y = ((e1y * r01) + (e2y * r11));
+  float n1z = ((e1z * r01) + (e2z * r11));
+  float e0x = (f0x - n0x);
+  float e0y = (f0y - n0y);
+  float e0z = (f0z - n0z);
+  float e1rx = (f1x - n1x);
+  float e1ry = (f1y - n1y);
+  float e1rz = (f1z - n1z);
+  float k = stiffness[c];
+  float3 l0 = lambda0[c];
+  float3 l1 = lambda1[c];
+  uint gb = (c * 3u);
+  grad[gb] = float3((((0.000000 - k) * (e0x + e1rx)) - (l0.x + l1.x)), (((0.000000 - k) * (e0y + e1ry)) - (l0.y + l1.y)), (((0.000000 - k) * (e0z + e1rz)) - (l0.z + l1.z)));
+  grad[(gb + 1u)] = float3(((k * e0x) + l0.x), ((k * e0y) + l0.y), ((k * e0z) + l0.z));
+  grad[(gb + 2u)] = float3(((k * e1rx) + l1.x), ((k * e1ry) + l1.y), ((k * e1rz) + l1.z));
+  hessScalar[gb] = (2.000000 * k);
+  hessScalar[(gb + 1u)] = k;
+  hessScalar[(gb + 2u)] = k;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.TriangleMembraneForceAl

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -45,6 +45,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("attachment_dual_update", AttachmentDualUpdate.shader)
   , ("attachment_force_al", AttachmentForceAl.shader)
   , ("triangle_membrane_dual_update", TriangleMembraneDualUpdate.shader)
+  , ("triangle_membrane_force_al", TriangleMembraneForceAl.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -59,7 +59,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               vbd_gather_bending:vbd_gather_bending \
               attachment_dual_update:attachment_dual_update \
               attachment_force_al:attachment_force_al \
-              triangle_membrane_dual_update:triangle_membrane_dual_update
+              triangle_membrane_dual_update:triangle_membrane_dual_update \
+              triangle_membrane_force_al:triangle_membrane_force_al
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/triangle_membrane_force_al_test.cpp
+++ b/tests/slang_validate/triangle_membrane_force_al_test.cpp
@@ -1,0 +1,122 @@
+// Real-input validator for Cloth.SlangCodegen.TriangleMembraneForceAl —
+// AL-augmented ARAP membrane force.
+//
+// Same as triangle_membrane_force but with λ_col0 and λ_col1 added to
+// the per-vertex gradients with the corotational sign pattern:
+//   grad[3c+0] = -k·(e0+e1) - (λ0 + λ1)
+//   grad[3c+1] = +k·e0      + λ0
+//   grad[3c+2] = +k·e1      + λ1
+//
+// Test fixture (3 verts, 1 triangle, 2× stretched both axes, k=1):
+//   v0=(0,0,0), v1=(2,0,0), v2=(0,2,0)
+//   F=[(2,0,0)|(0,2,0)]; closest 2D rot = I → R=[(1,0,0)|(0,1,0)]
+//   e0=(1,0,0), e1=(0,1,0)
+//
+//   Test 1 (λ=0):  matches triangle_membrane_force output exactly.
+//     grad[0]=(-1,-1,0), grad[1]=(1,0,0), grad[2]=(0,1,0)
+//     hess=[2, 1, 1]
+//
+//   Test 2 (λ0=(1,2,3), λ1=(4,5,6)):
+//     grad[0] = (-1,-1,0) - (5,7,9) = (-6,-8,-9)
+//     grad[1] = (1,0,0)   + (1,2,3) = (2,2,3)
+//     grad[2] = (0,1,0)   + (4,5,6) = (4,6,6)
+//     hess unchanged: [2, 1, 1]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "triangle_membrane_force_al_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_TRI = 2;  // T0=λ-zero, T1=λ-nonzero
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(2.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 2.0f, 0.0f),
+    };
+
+    std::vector<uint32_t>         idx(3 * GROUP_SIZE, 0u);
+    std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> lambda0(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<Vector<float, 3>> lambda1(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<Vector<float, 3>> grad(3 * GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hessScalar(3 * GROUP_SIZE, 0.0f);
+
+    for (uint32_t c = 0; c < GROUP_SIZE; ++c) {
+        idx[3*c+0] = 0u; idx[3*c+1] = 1u; idx[3*c+2] = 2u;
+    }
+    stiffness[0] = 1.0f;  // λ=0 case
+    stiffness[1] = 1.0f;  // λ≠0 case
+    lambda0[1] = Vector<float, 3>(1.0f, 2.0f, 3.0f);
+    lambda1[1] = Vector<float, 3>(4.0f, 5.0f, 6.0f);
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.idx_0.data        = idx.data();        gp.idx_0.count        = idx.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.lambda0_0.data    = lambda0.data();    gp.lambda0_0.count    = lambda0.size();
+    gp.lambda1_0.data    = lambda1.data();    gp.lambda1_0.count    = lambda1.size();
+    gp.grad_0.data       = grad.data();       gp.grad_0.count       = grad.size();
+    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_grad[N_TRI][3][3] = {
+        // T0 with λ=0: matches triangle_membrane_force
+        { {-1.0f, -1.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f} },
+        // T1 with λ0=(1,2,3), λ1=(4,5,6)
+        { {-6.0f, -8.0f, -9.0f}, {2.0f, 2.0f, 3.0f}, {4.0f, 6.0f, 6.0f} },
+    };
+    const float expected_hess[N_TRI][3] = {
+        {2.0f, 1.0f, 1.0f},
+        {2.0f, 1.0f, 1.0f},
+    };
+
+    int fails = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t c, int r, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            if (fails < 5) {
+                std::fprintf(stderr, "%s mismatch c=%u r=%d axis=%d: got %g, expected %g\n",
+                             label, c, r, axis, got, ref);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_TRI; ++c) {
+        for (int r = 0; r < 3; ++r) {
+            for (int axis = 0; axis < 3; ++axis) {
+                check(grad[3*c + r][axis], expected_grad[c][r][axis], "grad", c, r, axis);
+            }
+            check(hessScalar[3*c + r], expected_hess[c][r], "hess", c, r, 0);
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "triangle_membrane_force_al: TIMEOUT\n");
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("triangle_membrane_force_al: %u/%u tris OK (max_abs_diff=%g, %.1fms)\n",
+                    N_TRI, N_TRI, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "triangle_membrane_force_al: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Companion to \`triangle_membrane_dual_update\` (#78). Same per-triangle force + GN Hessian as \`triangle_membrane_force\` (#45) but with two extra \`lambda\` input columns folded into the per-vertex gradient with the corotational sign pattern:

\`\`\`
grad[3c+0] = -k · (e0 + e1)  -  (λ0 + λ1)   -- vertex 0
grad[3c+1] = +k · e0         +  λ0          -- vertex 1
grad[3c+2] = +k · e1         +  λ1          -- vertex 2

hessScalar unchanged: [2k, k, k]
\`\`\`

Hessian shape unchanged — AL only shifts the gradient. \`k\` here is the effective stiffness \`k_phys + γ_al\`.

## Verification
\`\`\`
triangle_membrane_force_al: 2/2 tris OK (max_abs_diff=0, 0.0ms)
\`\`\`

Fixture covers backward-compat (λ=0 matches \`triangle_membrane_force\`) and the AL case (λ0≠0, λ1≠0). Both bit-exact.

## Roadmap (#42) — PR-F continued

- ✅ \`attachment_dual_update\` (#74)
- ✅ \`attachment_force_al\` (#75)
- ✅ AvbdSolver AL wiring (#76)
- ✅ Simulation.cpp \`AVBD_AL\` env + empirical finding (#77)
- ✅ \`triangle_membrane_dual_update\` (#78)
- 🟡 **\`triangle_membrane_force_al\`** — this PR
- PR-F: \`triangle_bending_dual_update\` + \`force_al\`
- PR-F: AvbdSolver triangle AL wiring
- PR-F: re-run conv probe — expect conv_max from 0.7 → ~1e-3
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on both λ=0 and λ≠0 fixtures
- [ ] CI lean-slang validate