### PR TITLE
Add triangle_bending_dual_update: AL ramp for bending (PR-F dual-update set complete)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -26,6 +26,7 @@ import Cloth.SlangCodegen.AttachmentDualUpdate
 import Cloth.SlangCodegen.AttachmentForceAl
 import Cloth.SlangCodegen.TriangleMembraneDualUpdate
 import Cloth.SlangCodegen.TriangleMembraneForceAl
+import Cloth.SlangCodegen.TriangleBendingDualUpdate
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/TriangleBendingDualUpdate.lean
+++ b/lean/Cloth/SlangCodegen/TriangleBendingDualUpdate.lean
@@ -1,0 +1,185 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.TriangleBendingDualUpdate` — AVBD AL ramp for dihedral bending
+
+Completes the AL dual-update set: attachment (#74), triangle membrane
+(#78), and now dihedral bending. The bending energy targets a fixed
+4-vertex weighted sum magnitude `n_target`; AL adds a single Vec3
+multiplier per stencil that ramps with the constraint violation.
+
+Per bending constraint `c` with 4-vertex stencil indices, cotangent
+Laplacian weights `w[0..3]`, rest magnitude `n_target`, and AL
+penalty `γ_c`:
+
+```
+s         = Σ_r  w[4c+r] · positions[idx[4c+r]]
+C(x)      = s − target  =  s · (1 − n_target/|s|)
+                                                 -- residual vector
+                                                    (zero if |s| == n_target)
+λ_c ← λ_c + γ_c · C(x)                           -- dual ascent
+```
+
+Degenerate stencils (`n_target = 0`) are no-op — λ stays unchanged.
+This matches the `n_target ≤ eps` early-out semantics in
+`TriangleBendingForce` (#46).
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions   length = N_verts
+  1  StructuredBuffer<uint>     idx         length = 4 · N_bend
+  2  StructuredBuffer<float>    weight      length = 4 · N_bend
+  3  StructuredBuffer<float>    nTarget     length = N_bend
+  4  StructuredBuffer<float>    gamma       length = N_bend
+  5  RWStructuredBuffer<float3> lambda      length = N_bend
+
+Mirrors the weighted-sum + projection math from TriangleBendingForce.
+No output forces — caller dispatches `triangle_bending_force_al`
+separately to consume λ in the gradient.
+-/
+
+namespace Cloth.SlangCodegen.TriangleBendingDualUpdate
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"     (.member (.var "tid") "x")
+  , .declInit f  "n_c"   (.index (.var "nTarget") (.var "c"))
+  , .declInit u  "base"  (.bin "*" (.var "c") (.litUint 4))
+  , .declInit f  "w0"    (.index (.var "weight") (.var "base"))
+  , .declInit f  "w1"    (.index (.var "weight") (.bin "+" (.var "base") (.litUint 1)))
+  , .declInit f  "w2"    (.index (.var "weight") (.bin "+" (.var "base") (.litUint 2)))
+  , .declInit f  "w3"    (.index (.var "weight") (.bin "+" (.var "base") (.litUint 3)))
+  , .declInit f  "ex"    (.litFloat 0.0)
+  , .declInit f  "ey"    (.litFloat 0.0)
+  , .declInit f  "ez"    (.litFloat 0.0)
+  , .declInit f  "g_eff" (.litFloat 0.0)
+  , .ifNoElse (.bin ">" (.var "n_c") (.litFloat 0.000001))
+      [ .declInit u  "i0"   (.index (.var "idx") (.var "base"))
+      , .declInit u  "i1"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 1)))
+      , .declInit u  "i2"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 2)))
+      , .declInit u  "i3"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 3)))
+      , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
+      , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
+      , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
+      , .declInit f3 "p3"   (.index (.var "positions") (.var "i3"))
+      , .declInit f  "sx"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "x"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "x")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "x"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "x"))))
+      , .declInit f  "sy"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "y"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "y")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "y"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "y"))))
+      , .declInit f  "sz"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "z"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "z")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "z"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "z"))))
+      , .declInit f  "len"
+          (.call "sqrt"
+            [ .bin "+"
+                (.bin "+" (.bin "*" (.var "sx") (.var "sx"))
+                          (.bin "*" (.var "sy") (.var "sy")))
+                (.bin "*" (.var "sz") (.var "sz")) ])
+      , .declInit f  "scale" (.bin "/" (.var "n_c") (.var "len"))
+      , .declInit f  "om"    (.bin "-" (.litFloat 1.0) (.var "scale"))
+      , .assign (.var "ex")  (.bin "*" (.var "sx") (.var "om"))
+      , .assign (.var "ey")  (.bin "*" (.var "sy") (.var "om"))
+      , .assign (.var "ez")  (.bin "*" (.var "sz") (.var "om"))
+      , .assign (.var "g_eff") (.index (.var "gamma") (.var "c"))
+      ]
+  , .declInit f3 "lam" (.index (.var "lambda") (.var "c"))
+  , .assign (.index (.var "lambda") (.var "c"))
+      (.call "float3"
+        [ .bin "+" (.member (.var "lam") "x") (.bin "*" (.var "g_eff") (.var "ex"))
+        , .bin "+" (.member (.var "lam") "y") (.bin "*" (.var "g_eff") (.var "ey"))
+        , .bin "+" (.member (.var "lam") "z") (.bin "*" (.var "g_eff") (.var "ez")) ])
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions" (.roBuf f3)
+      , bnd 1 "idx"       (.roBuf u)
+      , bnd 2 "weight"    (.roBuf f)
+      , bnd 3 "nTarget"   (.roBuf f)
+      , bnd 4 "gamma"     (.roBuf f)
+      , bnd 5 "lambda"    (.rwBuf f3)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> weight;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> nTarget;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> gamma;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float3> lambda;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  float n_c = nTarget[c];
+  uint base = (c * 4u);
+  float w0 = weight[base];
+  float w1 = weight[(base + 1u)];
+  float w2 = weight[(base + 2u)];
+  float w3 = weight[(base + 3u)];
+  float ex = 0.000000;
+  float ey = 0.000000;
+  float ez = 0.000000;
+  float g_eff = 0.000000;
+  if ((n_c > 0.000001)) {
+    uint i0 = idx[base];
+    uint i1 = idx[(base + 1u)];
+    uint i2 = idx[(base + 2u)];
+    uint i3 = idx[(base + 3u)];
+    float3 p0 = positions[i0];
+    float3 p1 = positions[i1];
+    float3 p2 = positions[i2];
+    float3 p3 = positions[i3];
+    float sx = (((w0 * p0.x) + (w1 * p1.x)) + ((w2 * p2.x) + (w3 * p3.x)));
+    float sy = (((w0 * p0.y) + (w1 * p1.y)) + ((w2 * p2.y) + (w3 * p3.y)));
+    float sz = (((w0 * p0.z) + (w1 * p1.z)) + ((w2 * p2.z) + (w3 * p3.z)));
+    float len = sqrt((((sx * sx) + (sy * sy)) + (sz * sz)));
+    float scale = (n_c / len);
+    float om = (1.000000 - scale);
+    ex = (sx * om);
+    ey = (sy * om);
+    ez = (sz * om);
+    g_eff = gamma[c];
+  }
+  float3 lam = lambda[c];
+  lambda[c] = float3((lam.x + (g_eff * ex)), (lam.y + (g_eff * ey)), (lam.z + (g_eff * ez)));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.TriangleBendingDualUpdate

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -46,6 +46,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("attachment_force_al", AttachmentForceAl.shader)
   , ("triangle_membrane_dual_update", TriangleMembraneDualUpdate.shader)
   , ("triangle_membrane_force_al", TriangleMembraneForceAl.shader)
+  , ("triangle_bending_dual_update", TriangleBendingDualUpdate.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -60,7 +60,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               attachment_dual_update:attachment_dual_update \
               attachment_force_al:attachment_force_al \
               triangle_membrane_dual_update:triangle_membrane_dual_update \
-              triangle_membrane_force_al:triangle_membrane_force_al
+              triangle_membrane_force_al:triangle_membrane_force_al \
+              triangle_bending_dual_update:triangle_bending_dual_update
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/triangle_bending_dual_update_test.cpp
+++ b/tests/slang_validate/triangle_bending_dual_update_test.cpp
@@ -1,0 +1,108 @@
+// Real-input validator for Cloth.SlangCodegen.TriangleBendingDualUpdate —
+// AVBD AL dual ramp for dihedral bending.
+//
+// Per constraint c (4-vertex weighted sum, rest magnitude n_target, AL γ):
+//   s    = Σ_r w[4c+r] · p[idx[4c+r]]
+//   C    = s · (1 − n_target/|s|)   if n_target > eps, else 0
+//   λ_c ← λ_c + γ_c · C
+//
+// Test fixture (2 bending stencils):
+//   c0 non-degenerate:
+//     v0..v3 with weights (1,1,-1,-1), n_target=1, γ=1
+//     positions: v0=v1=v2=(0,0,0), v3=(0,0,2)
+//     s = (0,0,-2), |s|=2, scale=0.5, om=0.5
+//     C = s · 0.5 = (0, 0, -1)
+//     λ_init=(10,20,30) → λ_new = (10, 20, 29)
+//
+//   c1 degenerate (n_target=0):
+//     Same weights/positions, γ=1
+//     C=(0,0,0); λ unchanged at (5, 6, 7)
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "triangle_bending_dual_update_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_BEND = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 2.0f),
+    };
+
+    std::vector<uint32_t>         idx(4 * GROUP_SIZE, 0u);
+    std::vector<float>            weight(4 * GROUP_SIZE, 0.0f);
+    std::vector<float>            nTarget(GROUP_SIZE, 0.0f);
+    std::vector<float>            gamma(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> lambda(GROUP_SIZE, Vector<float, 3>(0.0f));
+
+    // c0 — non-degenerate
+    for (int r = 0; r < 4; ++r) idx[4*0 + r] = uint32_t(r);
+    weight[0]=1.0f; weight[1]=1.0f; weight[2]=-1.0f; weight[3]=-1.0f;
+    nTarget[0] = 1.0f;  gamma[0] = 1.0f;
+    lambda[0] = Vector<float, 3>(10.0f, 20.0f, 30.0f);
+
+    // c1 — degenerate (n_target=0)
+    for (int r = 0; r < 4; ++r) idx[4*1 + r] = uint32_t(r);
+    weight[4]=1.0f; weight[5]=1.0f; weight[6]=-1.0f; weight[7]=-1.0f;
+    nTarget[1] = 0.0f;  gamma[1] = 1.0f;
+    lambda[1] = Vector<float, 3>(5.0f, 6.0f, 7.0f);
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data = positions.data(); gp.positions_0.count = positions.size();
+    gp.idx_0.data       = idx.data();       gp.idx_0.count       = idx.size();
+    gp.weight_0.data    = weight.data();    gp.weight_0.count    = weight.size();
+    gp.nTarget_0.data   = nTarget.data();   gp.nTarget_0.count   = nTarget.size();
+    gp.gamma_0.data     = gamma.data();     gp.gamma_0.count     = gamma.size();
+    gp.lambda_0.data    = lambda.data();    gp.lambda_0.count    = lambda.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected[N_BEND][3] = {
+        {10.0f, 20.0f, 29.0f},   // c0: +γ·(0,0,-1)
+        { 5.0f,  6.0f,  7.0f},   // c1: unchanged (degenerate)
+    };
+
+    int fails = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, uint32_t c, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            std::fprintf(stderr, "λ mismatch c=%u axis=%d: got %g, expected %g\n",
+                         c, axis, got, ref);
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_BEND; ++c)
+        for (int axis = 0; axis < 3; ++axis)
+            check(lambda[c][axis], expected[c][axis], c, axis);
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "triangle_bending_dual_update: TIMEOUT\n");
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("triangle_bending_dual_update: %u/%u OK (max_abs_diff=%g, %.1fms)\n",
+                    N_BEND, N_BEND, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "triangle_bending_dual_update: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Third and final AL dual-update kernel of PR-F. Completes the {attachment, triangle_membrane, triangle_bending} ramp set so the augmented Lagrangian has full coverage of DiffCloth's hard constraint types.

Per bending constraint c with 4-vertex weighted-sum stencil:

\`\`\`
s         = Σ_r w[4c+r] · positions[idx[4c+r]]
C(x)      = s · (1 − n_target/|s|)         -- residual; zero when |s|=n_target
λ_c ← λ_c + γ_c · C(x)                     -- dual ascent
\`\`\`

Degenerate stencils (`n_target=0`) are no-ops — matches the early-out semantics of \`triangle_bending_force\` (#46).

## Verification
\`\`\`
triangle_bending_dual_update: 2/2 OK (max_abs_diff=0, 0.0ms)
\`\`\`

Fixture covers both non-degenerate (with non-trivial residual) and degenerate (`n_target=0`) cases. Bit-exact.

## Roadmap (#42) — PR-F dual-update set complete

- ✅ \`attachment_dual_update\` (#74)
- ✅ \`triangle_membrane_dual_update\` (#78)
- 🟡 **\`triangle_bending_dual_update\`** — this PR
- PR-F: \`triangle_bending_force_al\` (consumes λ via weighted gradient)
- PR-F: AvbdSolver wiring (swap force kernels, allocate λ, dispatch dual updates per outer iter)
- PR-F: re-run conv probe — expect conv_max from 0.7 → ~1e-3
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on non-degenerate + degenerate fixtures
- [ ] CI lean-slang validate