### PR TITLE
Add triangle_bending_force_al — AL kernel set COMPLETE (PR-F)

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -27,6 +27,7 @@ import Cloth.SlangCodegen.AttachmentForceAl
 import Cloth.SlangCodegen.TriangleMembraneDualUpdate
 import Cloth.SlangCodegen.TriangleMembraneForceAl
 import Cloth.SlangCodegen.TriangleBendingDualUpdate
+import Cloth.SlangCodegen.TriangleBendingForceAl
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/TriangleBendingForceAl.lean
+++ b/lean/Cloth/SlangCodegen/TriangleBendingForceAl.lean
@@ -1,0 +1,235 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.TriangleBendingForceAl` — AL-augmented dihedral bending force
+
+Last kernel in PR-F's AL set. Companion to
+`TriangleBendingDualUpdate` (#80). Same per-constraint dihedral bending
+force + GN Hessian as `TriangleBendingForce` (#46) but adds the
+accumulated dual multiplier `λ_c` to each per-vertex gradient,
+weighted by the corresponding Laplacian weight.
+
+The constraint Jacobian for bending is `∂C/∂p_r = w_r · I` (each
+vertex contributes to the weighted sum `s` linearly in its
+weight). So the AL gradient contribution at vertex `r` is:
+
+```
+∂(λᵀ C)/∂p_r  =  ∂C/∂p_r · λ  =  w_r · λ
+```
+
+Added to the original physics gradient:
+
+```
+grad[4c+r]       = k · w_r · resid  +  w_r · λ      (= w_r · (k·resid + λ))
+hessScalar[4c+r] = k · w_r²                          -- unchanged
+```
+
+Degenerate stencils (`n_target ≤ eps`) zero both `k_eff` AND `λ_eff`
+so the entire contribution disappears — matches the early-out in the
+original bending force kernel.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<float3>   positions    length = N_verts
+  1  StructuredBuffer<uint>     idx          length = 4 · N_bend
+  2  StructuredBuffer<float>    weight       length = 4 · N_bend
+  3  StructuredBuffer<float>    nTarget      length = N_bend
+  4  StructuredBuffer<float>    stiffness    length = N_bend
+  5  StructuredBuffer<float3>   lambda       length = N_bend
+  6  RWStructuredBuffer<float3> grad         length = 4 · N_bend
+  7  RWStructuredBuffer<float>  hessScalar   length = 4 · N_bend
+-/
+
+namespace Cloth.SlangCodegen.TriangleBendingForceAl
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"     (.member (.var "tid") "x")
+  , .declInit f  "n_c"   (.index (.var "nTarget") (.var "c"))
+  , .declInit u  "base"  (.bin "*" (.var "c") (.litUint 4))
+  , .declInit f  "w0"    (.index (.var "weight") (.var "base"))
+  , .declInit f  "w1"    (.index (.var "weight") (.bin "+" (.var "base") (.litUint 1)))
+  , .declInit f  "w2"    (.index (.var "weight") (.bin "+" (.var "base") (.litUint 2)))
+  , .declInit f  "w3"    (.index (.var "weight") (.bin "+" (.var "base") (.litUint 3)))
+  , .declInit f  "ex"    (.litFloat 0.0)
+  , .declInit f  "ey"    (.litFloat 0.0)
+  , .declInit f  "ez"    (.litFloat 0.0)
+  , .declInit f  "k_eff" (.litFloat 0.0)
+  , .declInit f  "lx"    (.litFloat 0.0)
+  , .declInit f  "ly"    (.litFloat 0.0)
+  , .declInit f  "lz"    (.litFloat 0.0)
+  , .ifNoElse (.bin ">" (.var "n_c") (.litFloat 0.000001))
+      [ .declInit u  "i0"   (.index (.var "idx") (.var "base"))
+      , .declInit u  "i1"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 1)))
+      , .declInit u  "i2"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 2)))
+      , .declInit u  "i3"   (.index (.var "idx") (.bin "+" (.var "base") (.litUint 3)))
+      , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
+      , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
+      , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
+      , .declInit f3 "p3"   (.index (.var "positions") (.var "i3"))
+      , .declInit f  "sx"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "x"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "x")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "x"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "x"))))
+      , .declInit f  "sy"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "y"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "y")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "y"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "y"))))
+      , .declInit f  "sz"
+          (.bin "+"
+            (.bin "+" (.bin "*" (.var "w0") (.member (.var "p0") "z"))
+                      (.bin "*" (.var "w1") (.member (.var "p1") "z")))
+            (.bin "+" (.bin "*" (.var "w2") (.member (.var "p2") "z"))
+                      (.bin "*" (.var "w3") (.member (.var "p3") "z"))))
+      , .declInit f  "len"
+          (.call "sqrt"
+            [ .bin "+"
+                (.bin "+" (.bin "*" (.var "sx") (.var "sx"))
+                          (.bin "*" (.var "sy") (.var "sy")))
+                (.bin "*" (.var "sz") (.var "sz")) ])
+      , .declInit f  "scale" (.bin "/" (.var "n_c") (.var "len"))
+      , .declInit f  "om"    (.bin "-" (.litFloat 1.0) (.var "scale"))
+      , .assign (.var "ex")  (.bin "*" (.var "sx") (.var "om"))
+      , .assign (.var "ey")  (.bin "*" (.var "sy") (.var "om"))
+      , .assign (.var "ez")  (.bin "*" (.var "sz") (.var "om"))
+      , .assign (.var "k_eff") (.index (.var "stiffness") (.var "c"))
+      , .declInit f3 "lam" (.index (.var "lambda") (.var "c"))
+      , .assign (.var "lx") (.member (.var "lam") "x")
+      , .assign (.var "ly") (.member (.var "lam") "y")
+      , .assign (.var "lz") (.member (.var "lam") "z")
+      ]
+  , .assign (.index (.var "grad") (.var "base"))
+      (.call "float3"
+        [ .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w0")) (.var "ex")) (.bin "*" (.var "w0") (.var "lx"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w0")) (.var "ey")) (.bin "*" (.var "w0") (.var "ly"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w0")) (.var "ez")) (.bin "*" (.var "w0") (.var "lz")) ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "base") (.litUint 1)))
+      (.call "float3"
+        [ .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w1")) (.var "ex")) (.bin "*" (.var "w1") (.var "lx"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w1")) (.var "ey")) (.bin "*" (.var "w1") (.var "ly"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w1")) (.var "ez")) (.bin "*" (.var "w1") (.var "lz")) ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "base") (.litUint 2)))
+      (.call "float3"
+        [ .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w2")) (.var "ex")) (.bin "*" (.var "w2") (.var "lx"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w2")) (.var "ey")) (.bin "*" (.var "w2") (.var "ly"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w2")) (.var "ez")) (.bin "*" (.var "w2") (.var "lz")) ])
+  , .assign (.index (.var "grad") (.bin "+" (.var "base") (.litUint 3)))
+      (.call "float3"
+        [ .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w3")) (.var "ex")) (.bin "*" (.var "w3") (.var "lx"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w3")) (.var "ey")) (.bin "*" (.var "w3") (.var "ly"))
+        , .bin "+" (.bin "*" (.bin "*" (.var "k_eff") (.var "w3")) (.var "ez")) (.bin "*" (.var "w3") (.var "lz")) ])
+  , .assign (.index (.var "hessScalar") (.var "base"))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w0") (.var "w0")))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "base") (.litUint 1)))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w1") (.var "w1")))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "base") (.litUint 2)))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w2") (.var "w2")))
+  , .assign (.index (.var "hessScalar") (.bin "+" (.var "base") (.litUint 3)))
+      (.bin "*" (.var "k_eff") (.bin "*" (.var "w3") (.var "w3")))
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "positions"  (.roBuf f3)
+      , bnd 1 "idx"        (.roBuf u)
+      , bnd 2 "weight"     (.roBuf f)
+      , bnd 3 "nTarget"    (.roBuf f)
+      , bnd 4 "stiffness"  (.roBuf f)
+      , bnd 5 "lambda"     (.roBuf f3)
+      , bnd 6 "grad"       (.rwBuf f3)
+      , bnd 7 "hessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<float3> positions;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> weight;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> nTarget;
+[[vk::binding(4, 0)]]
+StructuredBuffer<float> stiffness;
+[[vk::binding(5, 0)]]
+StructuredBuffer<float3> lambda;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<float3> grad;
+[[vk::binding(7, 0)]]
+RWStructuredBuffer<float> hessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  float n_c = nTarget[c];
+  uint base = (c * 4u);
+  float w0 = weight[base];
+  float w1 = weight[(base + 1u)];
+  float w2 = weight[(base + 2u)];
+  float w3 = weight[(base + 3u)];
+  float ex = 0.000000;
+  float ey = 0.000000;
+  float ez = 0.000000;
+  float k_eff = 0.000000;
+  float lx = 0.000000;
+  float ly = 0.000000;
+  float lz = 0.000000;
+  if ((n_c > 0.000001)) {
+    uint i0 = idx[base];
+    uint i1 = idx[(base + 1u)];
+    uint i2 = idx[(base + 2u)];
+    uint i3 = idx[(base + 3u)];
+    float3 p0 = positions[i0];
+    float3 p1 = positions[i1];
+    float3 p2 = positions[i2];
+    float3 p3 = positions[i3];
+    float sx = (((w0 * p0.x) + (w1 * p1.x)) + ((w2 * p2.x) + (w3 * p3.x)));
+    float sy = (((w0 * p0.y) + (w1 * p1.y)) + ((w2 * p2.y) + (w3 * p3.y)));
+    float sz = (((w0 * p0.z) + (w1 * p1.z)) + ((w2 * p2.z) + (w3 * p3.z)));
+    float len = sqrt((((sx * sx) + (sy * sy)) + (sz * sz)));
+    float scale = (n_c / len);
+    float om = (1.000000 - scale);
+    ex = (sx * om);
+    ey = (sy * om);
+    ez = (sz * om);
+    k_eff = stiffness[c];
+    float3 lam = lambda[c];
+    lx = lam.x;
+    ly = lam.y;
+    lz = lam.z;
+  }
+  grad[base] = float3((((k_eff * w0) * ex) + (w0 * lx)), (((k_eff * w0) * ey) + (w0 * ly)), (((k_eff * w0) * ez) + (w0 * lz)));
+  grad[(base + 1u)] = float3((((k_eff * w1) * ex) + (w1 * lx)), (((k_eff * w1) * ey) + (w1 * ly)), (((k_eff * w1) * ez) + (w1 * lz)));
+  grad[(base + 2u)] = float3((((k_eff * w2) * ex) + (w2 * lx)), (((k_eff * w2) * ey) + (w2 * ly)), (((k_eff * w2) * ez) + (w2 * lz)));
+  grad[(base + 3u)] = float3((((k_eff * w3) * ex) + (w3 * lx)), (((k_eff * w3) * ey) + (w3 * ly)), (((k_eff * w3) * ez) + (w3 * lz)));
+  hessScalar[base] = (k_eff * (w0 * w0));
+  hessScalar[(base + 1u)] = (k_eff * (w1 * w1));
+  hessScalar[(base + 2u)] = (k_eff * (w2 * w2));
+  hessScalar[(base + 3u)] = (k_eff * (w3 * w3));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.TriangleBendingForceAl

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -47,6 +47,7 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("triangle_membrane_dual_update", TriangleMembraneDualUpdate.shader)
   , ("triangle_membrane_force_al", TriangleMembraneForceAl.shader)
   , ("triangle_bending_dual_update", TriangleBendingDualUpdate.shader)
+  , ("triangle_bending_force_al", TriangleBendingForceAl.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -61,7 +61,8 @@ TESTS      := spring_project:spring_project triangle_bending:triangle_bending \
               attachment_force_al:attachment_force_al \
               triangle_membrane_dual_update:triangle_membrane_dual_update \
               triangle_membrane_force_al:triangle_membrane_force_al \
-              triangle_bending_dual_update:triangle_bending_dual_update
+              triangle_bending_dual_update:triangle_bending_dual_update \
+              triangle_bending_force_al:triangle_bending_force_al
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
 KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))

--- a/tests/slang_validate/triangle_bending_force_al_test.cpp
+++ b/tests/slang_validate/triangle_bending_force_al_test.cpp
@@ -1,0 +1,136 @@
+// Real-input validator for Cloth.SlangCodegen.TriangleBendingForceAl —
+// AL-augmented dihedral bending force.
+//
+// Same per-constraint bending force + GN Hessian as
+// triangle_bending_force (#46) but adds λ_c · w_r to each per-vertex
+// gradient (where w_r is the cotangent Laplacian weight for vertex r).
+//
+//   grad[4c+r]       = k · w_r · resid  +  w_r · λ
+//   hessScalar[4c+r] = k · w_r²
+//
+// Test fixture (2 constraints over 4 verts):
+//   v0=v1=v2=(0,0,0), v3=(0,0,2), weights (1,1,-1,-1)
+//   s=(0,0,-2), om=0.5, resid=(0,0,-1)
+//
+// c0 — λ=0 backward compat: identical to triangle_bending_force
+//   grad=[(0,0,-1),(0,0,-1),(0,0,1),(0,0,1)]; hess=[1,1,1,1]
+//
+// c1 — λ=(2,3,5):
+//   v0 role 0 (w=+1):  grad = (0,0,-1) + 1·(2,3,5) = (2, 3, 4)
+//   v1 role 1 (w=+1):  same: (2, 3, 4)
+//   v2 role 2 (w=-1):  grad = (0,0,1) + (-1)·(2,3,5) = (-2, -3, -4)
+//   v3 role 3 (w=-1):  same: (-2, -3, -4)
+//   hess unchanged: [1, 1, 1, 1]
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "triangle_bending_force_al_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_BEND     = 2;
+    constexpr uint32_t GROUP_SIZE = 64;
+
+    std::vector<Vector<float, 3>> positions = {
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 0.0f),
+        Vector<float, 3>(0.0f, 0.0f, 2.0f),
+    };
+
+    std::vector<uint32_t>         idx(4 * GROUP_SIZE, 0u);
+    std::vector<float>            weight(4 * GROUP_SIZE, 0.0f);
+    std::vector<float>            nTarget(GROUP_SIZE, 0.0f);
+    std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
+    std::vector<Vector<float, 3>> lambda(GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<Vector<float, 3>> grad(4 * GROUP_SIZE, Vector<float, 3>(0.0f));
+    std::vector<float>            hessScalar(4 * GROUP_SIZE, 0.0f);
+
+    // c0 — λ=0 backward compat case
+    for (int r = 0; r < 4; ++r) idx[4*0 + r] = uint32_t(r);
+    weight[0]=1.0f; weight[1]=1.0f; weight[2]=-1.0f; weight[3]=-1.0f;
+    nTarget[0] = 1.0f;  stiffness[0] = 1.0f;
+    // lambda[0] stays zero
+
+    // c1 — λ≠0 case
+    for (int r = 0; r < 4; ++r) idx[4*1 + r] = uint32_t(r);
+    weight[4]=1.0f; weight[5]=1.0f; weight[6]=-1.0f; weight[7]=-1.0f;
+    nTarget[1] = 1.0f;  stiffness[1] = 1.0f;
+    lambda[1] = Vector<float, 3>(2.0f, 3.0f, 5.0f);
+
+    GlobalParams_0 gp{};
+    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
+    gp.idx_0.data        = idx.data();        gp.idx_0.count        = idx.size();
+    gp.weight_0.data     = weight.data();     gp.weight_0.count     = weight.size();
+    gp.nTarget_0.data    = nTarget.data();    gp.nTarget_0.count    = nTarget.size();
+    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
+    gp.lambda_0.data     = lambda.data();     gp.lambda_0.count     = lambda.size();
+    gp.grad_0.data       = grad.data();       gp.grad_0.count       = grad.size();
+    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    const float expected_grad[N_BEND][4][3] = {
+        // c0 λ=0: matches triangle_bending_force
+        { {0.0f, 0.0f, -1.0f},
+          {0.0f, 0.0f, -1.0f},
+          {0.0f, 0.0f,  1.0f},
+          {0.0f, 0.0f,  1.0f} },
+        // c1 λ=(2,3,5)
+        { { 2.0f,  3.0f,  4.0f},
+          { 2.0f,  3.0f,  4.0f},
+          {-2.0f, -3.0f, -4.0f},
+          {-2.0f, -3.0f, -4.0f} },
+    };
+    const float expected_hess[N_BEND][4] = {
+        {1.0f, 1.0f, 1.0f, 1.0f},
+        {1.0f, 1.0f, 1.0f, 1.0f},
+    };
+
+    int fails = 0;
+    float max_abs_diff = 0.0f;
+    auto check = [&](float got, float ref, const char* label, uint32_t c, int r, int axis) {
+        const float d = std::fabs(got - ref);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d > 1e-5f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "%s mismatch c=%u r=%d axis=%d: got %g, expected %g\n",
+                    label, c, r, axis, got, ref);
+            }
+            ++fails;
+        }
+    };
+    for (uint32_t c = 0; c < N_BEND; ++c) {
+        for (int r = 0; r < 4; ++r) {
+            for (int axis = 0; axis < 3; ++axis) {
+                check(grad[4*c + r][axis], expected_grad[c][r][axis], "grad", c, r, axis);
+            }
+            check(hessScalar[4*c + r], expected_hess[c][r], "hess", c, r, 0);
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "triangle_bending_force_al: TIMEOUT\n");
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("triangle_bending_force_al: %u/%u OK (max_abs_diff=%g, %.1fms)\n",
+                    N_BEND, N_BEND, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "triangle_bending_force_al: %d FAIL\n", fails);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Sixth and final AL kernel of PR-F. Companion to \`triangle_bending_dual_update\` (#80). Same per-constraint bending force + GN Hessian as \`triangle_bending_force\` (#46), with the weighted dual multiplier added to each per-vertex gradient.

\`\`\`
grad[4c+r]       = k · w_r · resid  +  w_r · λ      (= w_r · (k·resid + λ))
hessScalar[4c+r] = k · w_r²                          -- unchanged
\`\`\`

Constraint Jacobian for bending is \`∂C/∂p_r = w_r · I\`, so the AL contribution on vertex r is \`w_r · λ\`. Degenerate stencils gate both \`k_eff = 0\` AND \`λ_eff = 0\`, matching the early-out in the original kernel.

## Verification
\`\`\`
triangle_bending_force_al: 2/2 OK (max_abs_diff=0, 0.0ms)
\`\`\`

Fixture covers backward-compat (λ=0) and AL-active cases. Bit-exact.

## 🎉 PR-F AL kernel set is COMPLETE

| Kernel | PR | Status |
|---|---|---|
| \`attachment_dual_update\` | #74 | ✅ |
| \`attachment_force_al\` | #75 | ✅ |
| \`triangle_membrane_dual_update\` | #78 | ✅ |
| \`triangle_membrane_force_al\` | #79 | ✅ |
| \`triangle_bending_dual_update\` | #80 | ✅ |
| **\`triangle_bending_force_al\`** | **this PR** | ✅ |

**All 6 AL kernels bit-exact at the kernel level.**

## Remaining work for PR-F

- AvbdSolver wiring: swap force kernels to \`_al\` variants, allocate λ buffers, expose \`stepDualMembrane()\` and \`stepDualBending()\` (parallel to \`stepDualAttachments\` from #76).
- Simulation.cpp: dispatch all three dual updates in the iter loop each step.
- Re-run convergence probe on dress — expect \`conv_max\` from #73's 0.7 → ~1e-3 range.

## Test plan
- [x] \`lake build\` — \`native_decide\` proof green
- [x] cpp validator: bit-exact on backward-compat + AL fixtures
- [ ] CI lean-slang validate