### PR TITLE
Simulation.cpp: dispatch all 3 AL duals — finding: γ=stiffness over-aggressive (PR-F)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1252,14 +1252,22 @@ void Simulation::step() {
 		for (int it = 0; it < firstHalf; ++it) {
 			rc = sysMat[0].avbd->step();
 			if (rc != 0) break;
-			if (s_avbdAl) sysMat[0].avbd->stepDualAttachments();
+			if (s_avbdAl) {
+				sysMat[0].avbd->stepDualAttachments();
+				sysMat[0].avbd->stepDualMembrane();
+				sysMat[0].avbd->stepDualBending();
+			}
 		}
 		std::vector<float> avbdPosHalf;
 		if (rc == 0 && firstHalf > 0)
 			sysMat[0].avbd->readPositions(avbdPosHalf);
 		for (int it = firstHalf; it < s_avbdIters && rc == 0; ++it) {
 			rc = sysMat[0].avbd->step();
-			if (rc == 0 && s_avbdAl) sysMat[0].avbd->stepDualAttachments();
+			if (rc == 0 && s_avbdAl) {
+				sysMat[0].avbd->stepDualAttachments();
+				sysMat[0].avbd->stepDualMembrane();
+				sysMat[0].avbd->stepDualBending();
+			}
 		}
 		auto _avbd_t1 = std::chrono::steady_clock::now();
 		const long long us =


### PR DESCRIPTION
## Summary
Wires \`stepDualMembrane()\` and \`stepDualBending()\` into the iter loop alongside \`stepDualAttachments()\`, so all three AVBD constraint types ramp λ per outer iter when \`AVBD_AL=1\`.

## ⚠️ A/B finding: AL=1 with default γ DIVERGES on dress

\`\`\`
AL=0 baseline (steady state):
  |Δx|_max=1.43054   |Δx|_mean=0.29   conv_max=0.7125
AL=1 (all 3 dual ramps active):
  step 1: |Δx|_max=2.92  |Δx|_mean=0.50  conv_max=1.50  ← growing!
  step 5: |Δx|_max=4.78  |Δx|_mean=0.83  conv_max=2.08
\`\`\`

|Δx|_max climbs from 2.9 to 4.8 over 5 steps; conv_max doubles. The cloth is explosively over-corrected.

## Diagnosis
Default \`γ_c = stiffness[c]\` is too aggressive for the dress's high constraint stiffness. Membrane \`k_stiff\` in DiffCloth is ~1e4; bending similarly stiff. With γ matching k, the dual ramp adds \`γ·residual\` to λ each iter — over 16 iters λ grows ~1000× the initial residual, applying a runaway "AL force" that overshoots the constraint.

## Next step (planned)
The AVBD paper notes γ should start small and adapt upward only if constraint violation persists. Right fix:
1. Default γ to a modest value (e.g. 1.0 or \`m/h²\`) — **not** stiffness.
2. Add adaptive γ ramping (\`γ ← clamp(β·γ, γ_max)\`) per iter only when constraint violation isn't dropping fast enough.

This PR ships the wiring + the empirical finding. γ tuning is the next slice — likely env-controllable \`AVBD_AL_GAMMA\` scale factor, then full adaptive ramping.

## Roadmap (#42) — PR-F

- ✅ 6 AL kernels (#74-#81)
- ✅ AvbdSolver AL wiring across all 3 constraint types (#76, #82)
- 🟡 **Simulation dispatch all 3 duals + finding** — this PR
- PR-F next: γ tuning (env scale factor + adaptive ramp)
- PR-F: re-run conv probe at safe γ — target conv_max → ~1e-3
- PR-G differentiable adjoint
- PR-H dress demo validation

## Test plan
- [x] Wiring runs without crash; AVBD_AL=1 dispatches all 3 dual kernels per iter
- [x] Documented empirical finding: γ=stiffness too aggressive; need scale control
- [ ] CI lean-slang validate