### PR TITLE
AVBD_AL_GAMMA env + γ sweep — finding: AL is NOT the dress's convergence fix (PR-F)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -3366,6 +3366,15 @@ void Simulation::initializePrefactoredMatrices() {
 				avbd->uploadBendings(nB, bendIdx.data(), bendWeight.data(),
 				                     bendNTarget.data(), bendK.data());
 
+				// AVBD_AL_GAMMA scales the AL γ down from its default
+				// (= stiffness, ~1e4 on dress, way too aggressive per
+				// PR #83 finding). Reasonable values: 0.001 to 0.1.
+				if (const char* gstr = std::getenv("AVBD_AL_GAMMA")) {
+					const float gscale = float(std::atof(gstr));
+					avbd->setGammaScale(gscale);
+					std::printf("[avbd] γ scaled by %g (AVBD_AL_GAMMA env)\n", gscale);
+				}
+
 				sysMat[sysMatId].avbd = avbd;
 				std::printf("[avbd] AvbdSolver loaded + uploaded "
 				            "(nVerts=%u, nSprings=%u, nTri=%u, nAttach=%u, nBend=%u, h=%g, invH²=%g)\n",

--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -137,6 +137,15 @@ public:
     // where s = Σ w·p_r is the 4-vertex weighted sum.
     int stepDualBending();
 
+    // Multiply all γ values across attachment / membrane / bending by
+    // `scale`. Default γ on upload = constraint stiffness, which is
+    // typically ~1e3-1e4 for the dress (membrane k_stiff). PR #83
+    // showed this is too aggressive — λ over-ramps and diverges.
+    // Call this AFTER uploadAttachments / uploadTriangles /
+    // uploadBendings to scale γ down to a stable range. Calling
+    // again multiplies on top of the previous scale.
+    void setGammaScale(float scale);
+
     // Per-step state refresh: re-upload positions + predicted into the
     // existing GPU buffers (no realloc). Cheap when called every step
     // from the simulation. Caller is responsible for keeping nVerts

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -715,6 +715,18 @@ int AvbdSolver::stepDualMembrane() {
     return 0;
 }
 
+void AvbdSolver::setGammaScale(float scale) {
+    if (!ok()) return;
+    auto scaleBuf = [scale](id<MTLBuffer> buf, uint32_t n) {
+        if (!buf || n == 0) return;
+        float* p = static_cast<float*>(buf.contents);
+        for (uint32_t i = 0; i < n; ++i) p[i] *= scale;
+    };
+    scaleBuf(impl_->bufAttachGamma, impl_->nAttach);
+    scaleBuf(impl_->bufTriGamma,    impl_->nTri);
+    scaleBuf(impl_->bufBendGamma,   impl_->nBend);
+}
+
 int AvbdSolver::stepDualBending() {
     if (!ok() || !impl_->meshReady) return -1;
     if (impl_->nBend == 0) return 0;


### PR DESCRIPTION
## Summary
Adds \`setGammaScale(scale)\` method that scales all γ buffers (attachment, membrane, bending) in-place after upload. \`Simulation.cpp\` reads \`AVBD_AL_GAMMA\` env to apply the scale at scene init.

## γ sweep on dress (USE_AVBD=1 AVBD_AL=1 AVBD_ITERS=16, step 1)

| γ_scale | \`|Δx|_max\` | \`conv_max\` | |
|---:|---:|---:|---|
| 1.0 | 2.92 | **1.50** | ← diverges (over-aggressive) |
| 0.1 | 1.748 | 0.702 | |
| 0.01 | 1.472 | 0.718 | |
| 0.001 | 1.435 | 0.713 | ← effectively no AL |
| 0.0001 | 1.431 | 0.713 | ← AL is no-op |
| AL=0 baseline | 1.431 | 0.713 | |

## ⚠️ Finding: there is NO γ sweet spot for the dress

- Small γ → λ doesn't ramp → AL inactive
- Large γ → λ over-ramps → simulation diverges
- Medium γ → \`conv_max\` stays at the same ~0.71 as no-AL

**The dress's \`conv_max ≈ 0.71\` is NOT an AL-fixable failure mode.** AL is the right tool for hard constraints (infinite-stiffness contact, rigid joints) where λ → λ* enforces C=0. For SOFT cloth constraints — ARAP membrane and dihedral bending — there's no true equality constraint to enforce; the cloth bounces around its rest shape as kinetic energy accumulates from gravity + spinning skirt dynamics.

The proper fixes for cloth-bounce oscillation are:
- Velocity damping (multiply v_n by 0.99 each step)
- Sub-stepping (smaller h)
- Chebyshev acceleration on the inner solver
- Higher iter count (paid with linear wall scaling)

## What PR-F accomplished

- 6 AL kernels bit-exact (#74, #75, #78, #79, #80, #81)
- AvbdSolver wires 16 kernels with backward-compat at λ=0 (#76, #82)
- Simulation.cpp dispatches all 3 dual updates (#83)
- **\`AVBD_AL_GAMMA\` env + setGammaScale()** — this PR
- γ sweep empirically falsifies "AL fixes dress convergence" hypothesis

The AL machinery is correctly implemented and ready to use on scenes with actual hard constraints (sock, hat). For the dress specifically, the right next move is damping / sub-stepping — orthogonal to AL.

## Roadmap (#42)

- ✅ PR-A four force kernels (#43-46)
- ✅ PR-B vertex CSR adjacency (#47, #48)
- ✅ PR-C vertex graph coloring (#49)
- ✅ PR-D six vertex-block-update kernels (#50-55)
- ✅ PR-E AvbdSolver + Simulation + 10-kernel pipeline live on dress
- ✅ PR-F full AL machinery + empirical sweep — **AL not the dress's fix**
- PR-G differentiable adjoint
- PR-H dress demo validation (likely needs damping additions)

## Test plan
- [x] \`AVBD_AL_GAMMA\` env scales γ in-place across all 3 constraint types
- [x] Sweep at 5 γ values documents the divergence-vs-no-op tradeoff
- [ ] CI lean-slang validate