### PR TITLE
Wire per-triangle inv_deltaUV into AVBD membrane kernels

### DIFF
--- a/lean/Cloth/SlangCodegen/TriangleMembraneForce.lean
+++ b/lean/Cloth/SlangCodegen/TriangleMembraneForce.lean
@@ -4,14 +4,17 @@ import LeanSlang
 # `Cloth.SlangCodegen.TriangleMembraneForce` — AVBD triangle in-plane stretch
 
 Third constraint-force kernel for the AVBD port (todo.md PR-A). For
-each triangle `c` with vertex indices `(i0, i1, i2)` and stiffness `k`,
-computes the ARAP-style in-plane stretch force on each of the three
-vertices, plus the Gauss-Newton diagonal Hessian scalar for each.
+each triangle `c` with vertex indices `(i0, i1, i2)`, per-triangle
+inverse rest-material matrix `inv_deltaUV` (the 2x2 from DiffCloth's
+`Triangle::inv_deltaUV`), and stiffness `k`, computes the ARAP-style
+in-plane stretch force on each of the three vertices, plus the
+Gauss-Newton diagonal Hessian scalar for each.
 
 The energy is the standard 2D-ARAP / corotated stretch:
 
 ```
-F   = [p1 − p0 | p2 − p0]                 -- 3×2 deformation gradient
+P   = [p1 − p0 | p2 − p0]                 -- 3x2 raw current edges
+F   = P · inv_deltaUV                     -- 3x2 deformation gradient
 R   = newdeltaUV · R_2D                   -- closest-rotation projection
                                               (same math as TriangleProject)
 E   = (k/2) · |F − R|²_F
@@ -19,33 +22,33 @@ E   = (k/2) · |F − R|²_F
 
 Holding `R` fixed (the standard Gauss-Newton approximation for
 rotation-invariant elastic energies — exactly the trick PD's local
-step uses), the gradients are:
+step uses), define residuals
+`e0 = F.col(0) − R.col(0)`, `e1r = F.col(1) − R.col(1)`. The gradient
+with respect to a vertex chases through `∂F/∂pv`:
 
 ```
-e0 = F.col(0) − R.col(0)     -- 3-vector
-e1 = F.col(1) − R.col(1)     -- 3-vector
-
-grad[3c+0] = −k · (e0 + e1)       (vertex 0 of the triangle)
-grad[3c+1] = +k · e0              (vertex 1)
-grad[3c+2] = +k · e1              (vertex 2)
+grad[3c+0] = −k · (e0·(m00+m10) + e1r·(m01+m11))   -- vertex 0
+grad[3c+1] = +k · (e0·m00 + e1r·m01)               -- vertex 1
+grad[3c+2] = +k · (e0·m10 + e1r·m11)               -- vertex 2
 ```
 
-And the diagonal Hessian blocks ∇²_v E are scalar multiples of `I₃`:
+where `mij = inv_deltaUV(i,j)`. With `inv_deltaUV = I` (m00=m11=1,
+m01=m10=0), this reduces to the canonical-rest form:
+`grad[3c+0] = −k·(e0+e1r)`, `grad[3c+1] = k·e0`, `grad[3c+2] = k·e1r`.
+
+The diagonal Hessian blocks ∇²_v E are scalar multiples of `I₃`:
 
 ```
-hessScalar[3c+0] = 2 · k     (vertex 0 contributes to both columns)
-hessScalar[3c+1] = k
-hessScalar[3c+2] = k
+hessScalar[3c+0] = k · ((m00+m10)² + (m01+m11)²)
+hessScalar[3c+1] = k · (m00² + m01²)
+hessScalar[3c+2] = k · (m10² + m11²)
 ```
+
+Again reducing to `2k, k, k` when `inv_deltaUV = I`.
 
 The per-vertex AVBD gather (PR-D) for an incident triangle `c` on a
 vertex of role `r` reads `grad[3c+r]` and adds `hessScalar[3c+r]` to
 each diagonal entry of the local 3x3 `H`.
-
-This kernel inherits the no-UV-mapping restriction from
-`TriangleProject` — `inv_deltaUV = I`, so `F` equals the raw edges.
-Restoring UV mapping is a follow-up that pre-multiplies `F` per
-triangle.
 
 Bindings (set 0):
 
@@ -54,6 +57,9 @@ Bindings (set 0):
   2  StructuredBuffer<float>    stiffness   length = N_tri
   3  RWStructuredBuffer<float3> grad        length = 3 · N_tri
   4  RWStructuredBuffer<float>  hessScalar  length = 3 · N_tri
+  5  StructuredBuffer<float>    inv_deltaUV length = 4 · N_tri
+                                            (row-major 2x2 per tri:
+                                             [m00, m01, m10, m11])
 -/
 
 namespace Cloth.SlangCodegen.TriangleMembraneForce
@@ -86,12 +92,32 @@ private def body : List SlangStmt :=
   , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
   , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
   , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
-  , .declInit f "f0x" (.bin "-" (pmv "p1" "x") (pmv "p0" "x"))
-  , .declInit f "f0y" (.bin "-" (pmv "p1" "y") (pmv "p0" "y"))
-  , .declInit f "f0z" (.bin "-" (pmv "p1" "z") (pmv "p0" "z"))
-  , .declInit f "f1x" (.bin "-" (pmv "p2" "x") (pmv "p0" "x"))
-  , .declInit f "f1y" (.bin "-" (pmv "p2" "y") (pmv "p0" "y"))
-  , .declInit f "f1z" (.bin "-" (pmv "p2" "z") (pmv "p0" "z"))
+  -- Read inv_deltaUV (row-major: m00, m01, m10, m11)
+  , .declInit u "iub"   (.bin "*" (.var "c") (.litUint 4))
+  , .declInit f "m00"   (.index (.var "inv_deltaUV") (.var "iub"))
+  , .declInit f "m01"   (.index (.var "inv_deltaUV") (.bin "+" (.var "iub") (.litUint 1)))
+  , .declInit f "m10"   (.index (.var "inv_deltaUV") (.bin "+" (.var "iub") (.litUint 2)))
+  , .declInit f "m11"   (.index (.var "inv_deltaUV") (.bin "+" (.var "iub") (.litUint 3)))
+  -- Raw edges in 3D
+  , .declInit f "ex0" (.bin "-" (pmv "p1" "x") (pmv "p0" "x"))
+  , .declInit f "ey0" (.bin "-" (pmv "p1" "y") (pmv "p0" "y"))
+  , .declInit f "ez0" (.bin "-" (pmv "p1" "z") (pmv "p0" "z"))
+  , .declInit f "ex1" (.bin "-" (pmv "p2" "x") (pmv "p0" "x"))
+  , .declInit f "ey1" (.bin "-" (pmv "p2" "y") (pmv "p0" "y"))
+  , .declInit f "ez1" (.bin "-" (pmv "p2" "z") (pmv "p0" "z"))
+  -- F.col(0) = ex0*m00 + ex1*m10, F.col(1) = ex0*m01 + ex1*m11
+  , .declInit f "f0x" (.bin "+" (.bin "*" (.var "ex0") (.var "m00"))
+                                (.bin "*" (.var "ex1") (.var "m10")))
+  , .declInit f "f0y" (.bin "+" (.bin "*" (.var "ey0") (.var "m00"))
+                                (.bin "*" (.var "ey1") (.var "m10")))
+  , .declInit f "f0z" (.bin "+" (.bin "*" (.var "ez0") (.var "m00"))
+                                (.bin "*" (.var "ez1") (.var "m10")))
+  , .declInit f "f1x" (.bin "+" (.bin "*" (.var "ex0") (.var "m01"))
+                                (.bin "*" (.var "ex1") (.var "m11")))
+  , .declInit f "f1y" (.bin "+" (.bin "*" (.var "ey0") (.var "m01"))
+                                (.bin "*" (.var "ey1") (.var "m11")))
+  , .declInit f "f1z" (.bin "+" (.bin "*" (.var "ez0") (.var "m01"))
+                                (.bin "*" (.var "ez1") (.var "m11")))
   , .declInit f "a"   (len3 (.var "f0x") (.var "f0y") (.var "f0z"))
   , .declInit f "e1x" (.bin "/" (.var "f0x") (.var "a"))
   , .declInit f "e1y" (.bin "/" (.var "f0y") (.var "a"))
@@ -128,6 +154,7 @@ private def body : List SlangStmt :=
                                 (.bin "*" (.var "e2y") (.var "r11")))
   , .declInit f "n1z" (.bin "+" (.bin "*" (.var "e1z") (.var "r01"))
                                 (.bin "*" (.var "e2z") (.var "r11")))
+  -- Residuals: e0 = F.col(0) - newF.col(0), e1r = F.col(1) - newF.col(1)
   , .declInit f "e0x" (.bin "-" (.var "f0x") (.var "n0x"))
   , .declInit f "e0y" (.bin "-" (.var "f0y") (.var "n0y"))
   , .declInit f "e0z" (.bin "-" (.var "f0z") (.var "n0z"))
@@ -135,40 +162,69 @@ private def body : List SlangStmt :=
   , .declInit f "e1ry" (.bin "-" (.var "f1y") (.var "n1y"))
   , .declInit f "e1rz" (.bin "-" (.var "f1z") (.var "n1z"))
   , .declInit f "k"   (.index (.var "stiffness") (.var "c"))
+  -- Helper weights for vertex 0: (m00+m10) and (m01+m11)
+  , .declInit f "w0a" (.bin "+" (.var "m00") (.var "m10"))
+  , .declInit f "w0b" (.bin "+" (.var "m01") (.var "m11"))
   , .declInit u "gb"  (.bin "*" (.var "c") (.litUint 3))
+  -- grad_p0 = -k * (e0 * w0a + e1r * w0b)
   , .assign (.index (.var "grad") (.var "gb"))
       (.call "float3"
         [ .bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
-            (.bin "+" (.var "e0x") (.var "e1rx"))
+            (.bin "+" (.bin "*" (.var "e0x") (.var "w0a"))
+                      (.bin "*" (.var "e1rx") (.var "w0b")))
         , .bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
-            (.bin "+" (.var "e0y") (.var "e1ry"))
+            (.bin "+" (.bin "*" (.var "e0y") (.var "w0a"))
+                      (.bin "*" (.var "e1ry") (.var "w0b")))
         , .bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
-            (.bin "+" (.var "e0z") (.var "e1rz")) ])
+            (.bin "+" (.bin "*" (.var "e0z") (.var "w0a"))
+                      (.bin "*" (.var "e1rz") (.var "w0b"))) ])
+  -- grad_p1 = k * (e0 * m00 + e1r * m01)
   , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 1)))
       (.call "float3"
-        [ .bin "*" (.var "k") (.var "e0x")
-        , .bin "*" (.var "k") (.var "e0y")
-        , .bin "*" (.var "k") (.var "e0z") ])
+        [ .bin "*" (.var "k")
+            (.bin "+" (.bin "*" (.var "e0x") (.var "m00"))
+                      (.bin "*" (.var "e1rx") (.var "m01")))
+        , .bin "*" (.var "k")
+            (.bin "+" (.bin "*" (.var "e0y") (.var "m00"))
+                      (.bin "*" (.var "e1ry") (.var "m01")))
+        , .bin "*" (.var "k")
+            (.bin "+" (.bin "*" (.var "e0z") (.var "m00"))
+                      (.bin "*" (.var "e1rz") (.var "m01"))) ])
+  -- grad_p2 = k * (e0 * m10 + e1r * m11)
   , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 2)))
       (.call "float3"
-        [ .bin "*" (.var "k") (.var "e1rx")
-        , .bin "*" (.var "k") (.var "e1ry")
-        , .bin "*" (.var "k") (.var "e1rz") ])
+        [ .bin "*" (.var "k")
+            (.bin "+" (.bin "*" (.var "e0x") (.var "m10"))
+                      (.bin "*" (.var "e1rx") (.var "m11")))
+        , .bin "*" (.var "k")
+            (.bin "+" (.bin "*" (.var "e0y") (.var "m10"))
+                      (.bin "*" (.var "e1ry") (.var "m11")))
+        , .bin "*" (.var "k")
+            (.bin "+" (.bin "*" (.var "e0z") (.var "m10"))
+                      (.bin "*" (.var "e1rz") (.var "m11"))) ])
+  -- Hessians: k*(w0a² + w0b²), k*(m00² + m01²), k*(m10² + m11²)
   , .assign (.index (.var "hessScalar") (.var "gb"))
-      (.bin "*" (.litFloat 2.0) (.var "k"))
+      (.bin "*" (.var "k")
+        (.bin "+" (.bin "*" (.var "w0a") (.var "w0a"))
+                  (.bin "*" (.var "w0b") (.var "w0b"))))
   , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 1)))
-      (.var "k")
+      (.bin "*" (.var "k")
+        (.bin "+" (.bin "*" (.var "m00") (.var "m00"))
+                  (.bin "*" (.var "m01") (.var "m01"))))
   , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 2)))
-      (.var "k")
+      (.bin "*" (.var "k")
+        (.bin "+" (.bin "*" (.var "m10") (.var "m10"))
+                  (.bin "*" (.var "m11") (.var "m11"))))
   ]
 
 def shader : SlangShaderModule :=
   { globals :=
-      [ bnd 0 "positions"  (.roBuf f3)
-      , bnd 1 "idx"        (.roBuf u)
-      , bnd 2 "stiffness"  (.roBuf f)
-      , bnd 3 "grad"       (.rwBuf f3)
-      , bnd 4 "hessScalar" (.rwBuf f)
+      [ bnd 0 "positions"   (.roBuf f3)
+      , bnd 1 "idx"         (.roBuf u)
+      , bnd 2 "stiffness"   (.roBuf f)
+      , bnd 3 "grad"        (.rwBuf f3)
+      , bnd 4 "hessScalar"  (.rwBuf f)
+      , bnd 5 "inv_deltaUV" (.roBuf f)
       ]
   , functions := [{
       attrs  := [.shaderCompute, .numthreads 64 1 1]
@@ -190,6 +246,8 @@ StructuredBuffer<float> stiffness;
 RWStructuredBuffer<float3> grad;
 [[vk::binding(4, 0)]]
 RWStructuredBuffer<float> hessScalar;
+[[vk::binding(5, 0)]]
+StructuredBuffer<float> inv_deltaUV;
 
 [shader(\"compute\")] [numthreads(64, 1, 1)]
 void main(uint3 tid : SV_DispatchThreadID) {
@@ -201,12 +259,23 @@ void main(uint3 tid : SV_DispatchThreadID) {
   float3 p0 = positions[i0];
   float3 p1 = positions[i1];
   float3 p2 = positions[i2];
-  float f0x = (p1.x - p0.x);
-  float f0y = (p1.y - p0.y);
-  float f0z = (p1.z - p0.z);
-  float f1x = (p2.x - p0.x);
-  float f1y = (p2.y - p0.y);
-  float f1z = (p2.z - p0.z);
+  uint iub = (c * 4u);
+  float m00 = inv_deltaUV[iub];
+  float m01 = inv_deltaUV[(iub + 1u)];
+  float m10 = inv_deltaUV[(iub + 2u)];
+  float m11 = inv_deltaUV[(iub + 3u)];
+  float ex0 = (p1.x - p0.x);
+  float ey0 = (p1.y - p0.y);
+  float ez0 = (p1.z - p0.z);
+  float ex1 = (p2.x - p0.x);
+  float ey1 = (p2.y - p0.y);
+  float ez1 = (p2.z - p0.z);
+  float f0x = ((ex0 * m00) + (ex1 * m10));
+  float f0y = ((ey0 * m00) + (ey1 * m10));
+  float f0z = ((ez0 * m00) + (ez1 * m10));
+  float f1x = ((ex0 * m01) + (ex1 * m11));
+  float f1y = ((ey0 * m01) + (ey1 * m11));
+  float f1z = ((ez0 * m01) + (ez1 * m11));
   float a = sqrt((((f0x * f0x) + (f0y * f0y)) + (f0z * f0z)));
   float e1x = (f0x / a);
   float e1y = (f0y / a);
@@ -239,13 +308,15 @@ void main(uint3 tid : SV_DispatchThreadID) {
   float e1ry = (f1y - n1y);
   float e1rz = (f1z - n1z);
   float k = stiffness[c];
+  float w0a = (m00 + m10);
+  float w0b = (m01 + m11);
   uint gb = (c * 3u);
-  grad[gb] = float3(((0.000000 - k) * (e0x + e1rx)), ((0.000000 - k) * (e0y + e1ry)), ((0.000000 - k) * (e0z + e1rz)));
-  grad[(gb + 1u)] = float3((k * e0x), (k * e0y), (k * e0z));
-  grad[(gb + 2u)] = float3((k * e1rx), (k * e1ry), (k * e1rz));
-  hessScalar[gb] = (2.000000 * k);
-  hessScalar[(gb + 1u)] = k;
-  hessScalar[(gb + 2u)] = k;
+  grad[gb] = float3(((0.000000 - k) * ((e0x * w0a) + (e1rx * w0b))), ((0.000000 - k) * ((e0y * w0a) + (e1ry * w0b))), ((0.000000 - k) * ((e0z * w0a) + (e1rz * w0b))));
+  grad[(gb + 1u)] = float3((k * ((e0x * m00) + (e1rx * m01))), (k * ((e0y * m00) + (e1ry * m01))), (k * ((e0z * m00) + (e1rz * m01))));
+  grad[(gb + 2u)] = float3((k * ((e0x * m10) + (e1rx * m11))), (k * ((e0y * m10) + (e1ry * m11))), (k * ((e0z * m10) + (e1rz * m11))));
+  hessScalar[gb] = (k * ((w0a * w0a) + (w0b * w0b)));
+  hessScalar[(gb + 1u)] = (k * ((m00 * m00) + (m01 * m01)));
+  hessScalar[(gb + 2u)] = (k * ((m10 * m10) + (m11 * m11)));
 }"
 
 example : LeanSlang.emit shader = expected := by native_decide

--- a/lean/Cloth/SlangCodegen/TriangleMembraneForceAl.lean
+++ b/lean/Cloth/SlangCodegen/TriangleMembraneForceAl.lean
@@ -5,23 +5,28 @@ import LeanSlang
 
 Companion to `TriangleMembraneDualUpdate` (#78). Same per-triangle
 force + GN Hessian as `triangle_membrane_force` (#45) but with two
-extra `lambda` input columns folded into the per-vertex gradient:
+`lambda` input columns folded into the per-vertex gradient. With
+per-triangle `inv_deltaUV` (rest material matrix), the residual
+columns `e0 = F.col(0) − R.col(0)`, `e1 = F.col(1) − R.col(1)` and
+the λ columns share the same `∂F/∂p` chain through `inv_deltaUV`.
+Define `te0 = k·e0 + λ0`, `te1 = k·e1 + λ1`, then:
 
 ```
-e0 = F.col(0) − R.col(0)                  -- physics residual col 0
-e1 = F.col(1) − R.col(1)                  -- physics residual col 1
+grad[3c+0] = -(te0·(m00+m10) + te1·(m01+m11))   -- vertex 0
+grad[3c+1] = +(te0·m00 + te1·m01)               -- vertex 1
+grad[3c+2] = +(te0·m10 + te1·m11)               -- vertex 2
 
-grad[3c+0] = -k · (e0 + e1)   - (λ0 + λ1)  -- vertex 0 (sits on both cols)
-grad[3c+1] = +k · e0          + λ0         -- vertex 1
-grad[3c+2] = +k · e1          + λ1         -- vertex 2
-
-hessScalar[3c+0] = 2k                      -- unchanged
-hessScalar[3c+1] = k
-hessScalar[3c+2] = k
+hessScalar[3c+0] = k · ((m00+m10)² + (m01+m11)²)
+hessScalar[3c+1] = k · (m00² + m01²)
+hessScalar[3c+2] = k · (m10² + m11²)
 ```
+
+With `inv_deltaUV = I`, this reduces to the canonical AL form:
+`grad[3c+0] = -k·(e0+e1) - (λ0+λ1)`, `hessScalar = 2k, k, k`.
 
 `k` here is the effective stiffness `k_phys + γ_al`. The Hessian
-shape is unchanged — AL augmentation only shifts the gradient.
+shape is identical to the non-AL kernel — AL augmentation only
+shifts the gradient by `λ·(∂F/∂p)`.
 
 Bindings (set 0):
 
@@ -32,6 +37,8 @@ Bindings (set 0):
   4  StructuredBuffer<float3>   lambda1     length = N_tri
   5  RWStructuredBuffer<float3> grad        length = 3 · N_tri
   6  RWStructuredBuffer<float>  hessScalar  length = 3 · N_tri
+  7  StructuredBuffer<float>    inv_deltaUV length = 4 · N_tri
+                                            (row-major 2x2 per tri)
 -/
 
 namespace Cloth.SlangCodegen.TriangleMembraneForceAl
@@ -64,12 +71,29 @@ private def body : List SlangStmt :=
   , .declInit f3 "p0"   (.index (.var "positions") (.var "i0"))
   , .declInit f3 "p1"   (.index (.var "positions") (.var "i1"))
   , .declInit f3 "p2"   (.index (.var "positions") (.var "i2"))
-  , .declInit f "f0x" (.bin "-" (pmv "p1" "x") (pmv "p0" "x"))
-  , .declInit f "f0y" (.bin "-" (pmv "p1" "y") (pmv "p0" "y"))
-  , .declInit f "f0z" (.bin "-" (pmv "p1" "z") (pmv "p0" "z"))
-  , .declInit f "f1x" (.bin "-" (pmv "p2" "x") (pmv "p0" "x"))
-  , .declInit f "f1y" (.bin "-" (pmv "p2" "y") (pmv "p0" "y"))
-  , .declInit f "f1z" (.bin "-" (pmv "p2" "z") (pmv "p0" "z"))
+  , .declInit u "iub"   (.bin "*" (.var "c") (.litUint 4))
+  , .declInit f "m00"   (.index (.var "inv_deltaUV") (.var "iub"))
+  , .declInit f "m01"   (.index (.var "inv_deltaUV") (.bin "+" (.var "iub") (.litUint 1)))
+  , .declInit f "m10"   (.index (.var "inv_deltaUV") (.bin "+" (.var "iub") (.litUint 2)))
+  , .declInit f "m11"   (.index (.var "inv_deltaUV") (.bin "+" (.var "iub") (.litUint 3)))
+  , .declInit f "ex0" (.bin "-" (pmv "p1" "x") (pmv "p0" "x"))
+  , .declInit f "ey0" (.bin "-" (pmv "p1" "y") (pmv "p0" "y"))
+  , .declInit f "ez0" (.bin "-" (pmv "p1" "z") (pmv "p0" "z"))
+  , .declInit f "ex1" (.bin "-" (pmv "p2" "x") (pmv "p0" "x"))
+  , .declInit f "ey1" (.bin "-" (pmv "p2" "y") (pmv "p0" "y"))
+  , .declInit f "ez1" (.bin "-" (pmv "p2" "z") (pmv "p0" "z"))
+  , .declInit f "f0x" (.bin "+" (.bin "*" (.var "ex0") (.var "m00"))
+                                (.bin "*" (.var "ex1") (.var "m10")))
+  , .declInit f "f0y" (.bin "+" (.bin "*" (.var "ey0") (.var "m00"))
+                                (.bin "*" (.var "ey1") (.var "m10")))
+  , .declInit f "f0z" (.bin "+" (.bin "*" (.var "ez0") (.var "m00"))
+                                (.bin "*" (.var "ez1") (.var "m10")))
+  , .declInit f "f1x" (.bin "+" (.bin "*" (.var "ex0") (.var "m01"))
+                                (.bin "*" (.var "ex1") (.var "m11")))
+  , .declInit f "f1y" (.bin "+" (.bin "*" (.var "ey0") (.var "m01"))
+                                (.bin "*" (.var "ey1") (.var "m11")))
+  , .declInit f "f1z" (.bin "+" (.bin "*" (.var "ez0") (.var "m01"))
+                                (.bin "*" (.var "ez1") (.var "m11")))
   , .declInit f "a"   (len3 (.var "f0x") (.var "f0y") (.var "f0z"))
   , .declInit f "e1x" (.bin "/" (.var "f0x") (.var "a"))
   , .declInit f "e1y" (.bin "/" (.var "f0y") (.var "a"))
@@ -115,48 +139,70 @@ private def body : List SlangStmt :=
   , .declInit f  "k"   (.index (.var "stiffness") (.var "c"))
   , .declInit f3 "l0"  (.index (.var "lambda0")   (.var "c"))
   , .declInit f3 "l1"  (.index (.var "lambda1")   (.var "c"))
+  -- te0 = k·e0 + λ0, te1 = k·e1r + λ1 (3-vector, combined physics+AL)
+  , .declInit f "te0x" (.bin "+" (.bin "*" (.var "k") (.var "e0x"))  (pmv "l0" "x"))
+  , .declInit f "te0y" (.bin "+" (.bin "*" (.var "k") (.var "e0y"))  (pmv "l0" "y"))
+  , .declInit f "te0z" (.bin "+" (.bin "*" (.var "k") (.var "e0z"))  (pmv "l0" "z"))
+  , .declInit f "te1x" (.bin "+" (.bin "*" (.var "k") (.var "e1rx")) (pmv "l1" "x"))
+  , .declInit f "te1y" (.bin "+" (.bin "*" (.var "k") (.var "e1ry")) (pmv "l1" "y"))
+  , .declInit f "te1z" (.bin "+" (.bin "*" (.var "k") (.var "e1rz")) (pmv "l1" "z"))
+  , .declInit f "w0a" (.bin "+" (.var "m00") (.var "m10"))
+  , .declInit f "w0b" (.bin "+" (.var "m01") (.var "m11"))
   , .declInit u "gb"  (.bin "*" (.var "c") (.litUint 3))
+  -- grad_p0 = -(te0 * w0a + te1 * w0b)
   , .assign (.index (.var "grad") (.var "gb"))
       (.call "float3"
-        [ .bin "-"
-            (.bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
-              (.bin "+" (.var "e0x") (.var "e1rx")))
-            (.bin "+" (pmv "l0" "x") (pmv "l1" "x"))
-        , .bin "-"
-            (.bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
-              (.bin "+" (.var "e0y") (.var "e1ry")))
-            (.bin "+" (pmv "l0" "y") (pmv "l1" "y"))
-        , .bin "-"
-            (.bin "*" (.bin "-" (.litFloat 0.0) (.var "k"))
-              (.bin "+" (.var "e0z") (.var "e1rz")))
-            (.bin "+" (pmv "l0" "z") (pmv "l1" "z")) ])
+        [ .bin "-" (.litFloat 0.0)
+            (.bin "+" (.bin "*" (.var "te0x") (.var "w0a"))
+                      (.bin "*" (.var "te1x") (.var "w0b")))
+        , .bin "-" (.litFloat 0.0)
+            (.bin "+" (.bin "*" (.var "te0y") (.var "w0a"))
+                      (.bin "*" (.var "te1y") (.var "w0b")))
+        , .bin "-" (.litFloat 0.0)
+            (.bin "+" (.bin "*" (.var "te0z") (.var "w0a"))
+                      (.bin "*" (.var "te1z") (.var "w0b"))) ])
+  -- grad_p1 = te0 * m00 + te1 * m01
   , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 1)))
       (.call "float3"
-        [ .bin "+" (.bin "*" (.var "k") (.var "e0x")) (pmv "l0" "x")
-        , .bin "+" (.bin "*" (.var "k") (.var "e0y")) (pmv "l0" "y")
-        , .bin "+" (.bin "*" (.var "k") (.var "e0z")) (pmv "l0" "z") ])
+        [ .bin "+" (.bin "*" (.var "te0x") (.var "m00"))
+                   (.bin "*" (.var "te1x") (.var "m01"))
+        , .bin "+" (.bin "*" (.var "te0y") (.var "m00"))
+                   (.bin "*" (.var "te1y") (.var "m01"))
+        , .bin "+" (.bin "*" (.var "te0z") (.var "m00"))
+                   (.bin "*" (.var "te1z") (.var "m01")) ])
+  -- grad_p2 = te0 * m10 + te1 * m11
   , .assign (.index (.var "grad") (.bin "+" (.var "gb") (.litUint 2)))
       (.call "float3"
-        [ .bin "+" (.bin "*" (.var "k") (.var "e1rx")) (pmv "l1" "x")
-        , .bin "+" (.bin "*" (.var "k") (.var "e1ry")) (pmv "l1" "y")
-        , .bin "+" (.bin "*" (.var "k") (.var "e1rz")) (pmv "l1" "z") ])
+        [ .bin "+" (.bin "*" (.var "te0x") (.var "m10"))
+                   (.bin "*" (.var "te1x") (.var "m11"))
+        , .bin "+" (.bin "*" (.var "te0y") (.var "m10"))
+                   (.bin "*" (.var "te1y") (.var "m11"))
+        , .bin "+" (.bin "*" (.var "te0z") (.var "m10"))
+                   (.bin "*" (.var "te1z") (.var "m11")) ])
   , .assign (.index (.var "hessScalar") (.var "gb"))
-      (.bin "*" (.litFloat 2.0) (.var "k"))
+      (.bin "*" (.var "k")
+        (.bin "+" (.bin "*" (.var "w0a") (.var "w0a"))
+                  (.bin "*" (.var "w0b") (.var "w0b"))))
   , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 1)))
-      (.var "k")
+      (.bin "*" (.var "k")
+        (.bin "+" (.bin "*" (.var "m00") (.var "m00"))
+                  (.bin "*" (.var "m01") (.var "m01"))))
   , .assign (.index (.var "hessScalar") (.bin "+" (.var "gb") (.litUint 2)))
-      (.var "k")
+      (.bin "*" (.var "k")
+        (.bin "+" (.bin "*" (.var "m10") (.var "m10"))
+                  (.bin "*" (.var "m11") (.var "m11"))))
   ]
 
 def shader : SlangShaderModule :=
   { globals :=
-      [ bnd 0 "positions"  (.roBuf f3)
-      , bnd 1 "idx"        (.roBuf u)
-      , bnd 2 "stiffness"  (.roBuf f)
-      , bnd 3 "lambda0"    (.roBuf f3)
-      , bnd 4 "lambda1"    (.roBuf f3)
-      , bnd 5 "grad"       (.rwBuf f3)
-      , bnd 6 "hessScalar" (.rwBuf f)
+      [ bnd 0 "positions"   (.roBuf f3)
+      , bnd 1 "idx"         (.roBuf u)
+      , bnd 2 "stiffness"   (.roBuf f)
+      , bnd 3 "lambda0"     (.roBuf f3)
+      , bnd 4 "lambda1"     (.roBuf f3)
+      , bnd 5 "grad"        (.rwBuf f3)
+      , bnd 6 "hessScalar"  (.rwBuf f)
+      , bnd 7 "inv_deltaUV" (.roBuf f)
       ]
   , functions := [{
       attrs  := [.shaderCompute, .numthreads 64 1 1]
@@ -182,6 +228,8 @@ StructuredBuffer<float3> lambda1;
 RWStructuredBuffer<float3> grad;
 [[vk::binding(6, 0)]]
 RWStructuredBuffer<float> hessScalar;
+[[vk::binding(7, 0)]]
+StructuredBuffer<float> inv_deltaUV;
 
 [shader(\"compute\")] [numthreads(64, 1, 1)]
 void main(uint3 tid : SV_DispatchThreadID) {
@@ -193,12 +241,23 @@ void main(uint3 tid : SV_DispatchThreadID) {
   float3 p0 = positions[i0];
   float3 p1 = positions[i1];
   float3 p2 = positions[i2];
-  float f0x = (p1.x - p0.x);
-  float f0y = (p1.y - p0.y);
-  float f0z = (p1.z - p0.z);
-  float f1x = (p2.x - p0.x);
-  float f1y = (p2.y - p0.y);
-  float f1z = (p2.z - p0.z);
+  uint iub = (c * 4u);
+  float m00 = inv_deltaUV[iub];
+  float m01 = inv_deltaUV[(iub + 1u)];
+  float m10 = inv_deltaUV[(iub + 2u)];
+  float m11 = inv_deltaUV[(iub + 3u)];
+  float ex0 = (p1.x - p0.x);
+  float ey0 = (p1.y - p0.y);
+  float ez0 = (p1.z - p0.z);
+  float ex1 = (p2.x - p0.x);
+  float ey1 = (p2.y - p0.y);
+  float ez1 = (p2.z - p0.z);
+  float f0x = ((ex0 * m00) + (ex1 * m10));
+  float f0y = ((ey0 * m00) + (ey1 * m10));
+  float f0z = ((ez0 * m00) + (ez1 * m10));
+  float f1x = ((ex0 * m01) + (ex1 * m11));
+  float f1y = ((ey0 * m01) + (ey1 * m11));
+  float f1z = ((ez0 * m01) + (ez1 * m11));
   float a = sqrt((((f0x * f0x) + (f0y * f0y)) + (f0z * f0z)));
   float e1x = (f0x / a);
   float e1y = (f0y / a);
@@ -233,13 +292,21 @@ void main(uint3 tid : SV_DispatchThreadID) {
   float k = stiffness[c];
   float3 l0 = lambda0[c];
   float3 l1 = lambda1[c];
+  float te0x = ((k * e0x) + l0.x);
+  float te0y = ((k * e0y) + l0.y);
+  float te0z = ((k * e0z) + l0.z);
+  float te1x = ((k * e1rx) + l1.x);
+  float te1y = ((k * e1ry) + l1.y);
+  float te1z = ((k * e1rz) + l1.z);
+  float w0a = (m00 + m10);
+  float w0b = (m01 + m11);
   uint gb = (c * 3u);
-  grad[gb] = float3((((0.000000 - k) * (e0x + e1rx)) - (l0.x + l1.x)), (((0.000000 - k) * (e0y + e1ry)) - (l0.y + l1.y)), (((0.000000 - k) * (e0z + e1rz)) - (l0.z + l1.z)));
-  grad[(gb + 1u)] = float3(((k * e0x) + l0.x), ((k * e0y) + l0.y), ((k * e0z) + l0.z));
-  grad[(gb + 2u)] = float3(((k * e1rx) + l1.x), ((k * e1ry) + l1.y), ((k * e1rz) + l1.z));
-  hessScalar[gb] = (2.000000 * k);
-  hessScalar[(gb + 1u)] = k;
-  hessScalar[(gb + 2u)] = k;
+  grad[gb] = float3((0.000000 - ((te0x * w0a) + (te1x * w0b))), (0.000000 - ((te0y * w0a) + (te1y * w0b))), (0.000000 - ((te0z * w0a) + (te1z * w0b))));
+  grad[(gb + 1u)] = float3(((te0x * m00) + (te1x * m01)), ((te0y * m00) + (te1y * m01)), ((te0z * m00) + (te1z * m01)));
+  grad[(gb + 2u)] = float3(((te0x * m10) + (te1x * m11)), ((te0y * m10) + (te1y * m11)), ((te0z * m10) + (te1z * m11)));
+  hessScalar[gb] = (k * ((w0a * w0a) + (w0b * w0b)));
+  hessScalar[(gb + 1u)] = (k * ((m00 * m00) + (m01 * m01)));
+  hessScalar[(gb + 2u)] = (k * ((m10 * m10) + (m11 * m11)));
 }"
 
 example : LeanSlang.emit shader = expected := by native_decide

--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1296,13 +1296,23 @@ void Simulation::step() {
 		sysMat[0].avbd->readPositions(avbdPos);
 		float dxMax = 0.0f, dxMean = 0.0f;
 		float convergeMax = 0.0f, convergeMean = 0.0f;
+		// Decompose |Δx| = |avbd − x_n| into predictor contribution
+		// |s_n − x_n| (velocity + h²g) and AVBD's drift |avbd − s_n|.
+		// If predictor dominates: dxMax is real physics (velocity
+		// accumulating). If drift dominates: AVBD is "snapping to
+		// equilibrium" rather than tracking the implicit-Euler step.
+		float predMax = 0.0f, driftMax = 0.0f;
 		int nanCount = 0;
 		for (uint32_t i = 0; i < nV; ++i) {
 			for (int axis = 0; axis < 3; ++axis) {
 				const float ax = avbdPos[3*i + axis];
 				const float dx = std::fabs(ax - posF[3*i + axis]);
+				const float dp = std::fabs(predF[3*i + axis] - posF[3*i + axis]);
+				const float dd = std::fabs(ax - predF[3*i + axis]);
 				if (!std::isfinite(ax)) ++nanCount;
 				if (dx > dxMax) dxMax = dx;
+				if (dp > predMax) predMax = dp;
+				if (dd > driftMax) driftMax = dd;
 				dxMean += dx;
 				if (!avbdPosHalf.empty()) {
 					const float dconv = std::fabs(ax - avbdPosHalf[3*i + axis]);
@@ -1318,9 +1328,11 @@ void Simulation::step() {
 		// iters would have been enough. Large values mean more iters
 		// needed.
 		std::printf("[avbd-shadow] step %zu  dof=%u  iters=%d  rc=%d  wall=%lld us"
-		            "  |Δx|_max=%g  |Δx|_mean=%g  conv_max=%g  conv_mean=%g  nan=%d\n",
+		            "  |Δx|_max=%g  |Δx|_mean=%g  pred_max=%g  drift_max=%g"
+		            "  conv_max=%g  conv_mean=%g  nan=%d\n",
 		            forwardRecords.size(), nV * 3u, s_avbdIters, rc, us,
-		            dxMax, dxMean, convergeMax, convergeMean, nanCount);
+		            dxMax, dxMean, predMax, driftMax,
+		            convergeMax, convergeMean, nanCount);
 	}
 #endif
 	returnRecord.windFactor = windFactor;
@@ -1709,6 +1721,43 @@ void Simulation::step() {
 			static_cast<size_t>(particles.size() * 3),
 			static_cast<long long>(_bench_us));
 	}
+
+#ifdef __APPLE__
+	// AVBD_DRIVE=1 commits AVBD's shadow output as the simulation
+	// outcome — overrides PD's converged Particle.pos and recomputes
+	// velocity from the AVBD delta. Use ONLY when you've verified
+	// AVBD converges to a sensible state on this scene (per #86 the
+	// dress's "conv_max" is slow linear convergence, not divergence,
+	// so this should be safe).
+	//
+	// The shadow shuttle already read AVBD positions into `avbdPos`
+	// earlier in step(); we re-read here to get the latest copy
+	// after the iter loop completed. Particle.pos and Particle.velocity
+	// are updated; collision / contact / fixed points stay whatever
+	// the PD pass computed (potentially inconsistent — that's why
+	// this is opt-in).
+	static const bool s_avbdDrive = (std::getenv("AVBD_DRIVE") != nullptr);
+	if (s_avbdDrive && g_useAvbd && currentSysmatId == 0 &&
+	    sysMat[0].avbd && sysMat[0].avbd->ok()) {
+		std::vector<float> avbdPosFinal;
+		sysMat[0].avbd->readPositions(avbdPosFinal);
+		const double invH = 1.0 / sceneConfig.timeStep;
+		for (size_t i = 0; i < particles.size(); ++i) {
+			const double nx = double(avbdPosFinal[3*i+0]);
+			const double ny = double(avbdPosFinal[3*i+1]);
+			const double nz = double(avbdPosFinal[3*i+2]);
+			Vec3d newPos(nx, ny, nz);
+			// v = (x_avbd − x_n) / h (x_n is start-of-step position;
+			// `particles[i].pos` was already overwritten by PD's
+			// x_new earlier in step()).
+			Vec3d startPos = x_n.segment(3*i, 3);
+			particles[i].velocity = (newPos - startPos) * invH;
+			particles[i].pos = newPos;
+		}
+		std::printf("[avbd-drive] step %zu wrote AVBD output to Particle.pos\n",
+		            forwardRecords.size());
+	}
+#endif
 
 	// [bench] one-shot phase breakdown on a chosen step number (default 20).
 	// Set BENCH_PHASE_AT=<step_number> to pick which step to dump. Useful
@@ -3333,15 +3382,28 @@ void Simulation::initializePrefactoredMatrices() {
 				// DiffCloth's `mesh` vector holds Triangle constraints
 				// with (p0, p1, p2). Stiffness is Triangle::k_stiff
 				// (shared static; per-triangle override is uncommon).
+				// Each Triangle stores `inv_deltaUV` (2x2 rest material
+				// matrix inverse) used to map raw 3D edges into the 2D
+				// material plane: F = [p1-p0 | p2-p0] · inv_deltaUV.
+				// AVBD's membrane kernel needs this — without it every
+				// triangle is treated as canonical/equilateral rest,
+				// pulling the mesh toward an unphysical equilibrium.
 				const uint32_t nT = uint32_t(mesh.size());
 				std::vector<uint32_t> triIdx(3 * nT);
+				std::vector<float>    triInvUV(4 * nT);
 				std::vector<float>    triK(nT, float(Triangle::k_stiff));
 				for (uint32_t i = 0; i < nT; ++i) {
 					triIdx[3*i + 0] = uint32_t(mesh[i].p0_idx);
 					triIdx[3*i + 1] = uint32_t(mesh[i].p1_idx);
 					triIdx[3*i + 2] = uint32_t(mesh[i].p2_idx);
+					// Row-major 2x2: [m00, m01, m10, m11].
+					triInvUV[4*i + 0] = float(mesh[i].inv_deltaUV(0, 0));
+					triInvUV[4*i + 1] = float(mesh[i].inv_deltaUV(0, 1));
+					triInvUV[4*i + 2] = float(mesh[i].inv_deltaUV(1, 0));
+					triInvUV[4*i + 3] = float(mesh[i].inv_deltaUV(1, 1));
 				}
-				avbd->uploadTriangles(nT, triIdx.data(), triK.data());
+				avbd->uploadTriangles(nT, triIdx.data(), triInvUV.data(),
+				                     triK.data());
 
 				// Upload attachment (point-pin) constraints from this
 				// sysMat's `attachments` vector. Each AttachmentSpring

--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -82,11 +82,15 @@ public:
 
     // Upload triangle membrane (in-plane stretch) constraints.
     // `nTri` triangles with corner vertex indices `triIdx` (length
-    // 3*nTri, interleaved (i0,i1,i2) per triangle) and stiffness
-    // `stiffness[c]`. Allocates output buffers for
-    // triangle_membrane_force (grad, hessScalar at slot 3*c+r).
+    // 3*nTri, interleaved (i0,i1,i2) per triangle), per-triangle
+    // rest material inverse `invUV` (length 4*nTri, row-major 2x2
+    // per triangle: [m00, m01, m10, m11] from DiffCloth's
+    // `Triangle::inv_deltaUV`), and stiffness `stiffness[c]`.
+    // Allocates output buffers for triangle_membrane_force
+    // (grad, hessScalar at slot 3*c+r).
     void uploadTriangles(uint32_t nTri,
                          const uint32_t* triIdx,
+                         const float* invUV,
                          const float* stiffness);
 
     // Upload dihedral bending constraints. `nBend` bending stencils

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -91,6 +91,7 @@ struct AvbdSolver::Impl {
     // Triangle membrane constraint buffers (allocated by uploadTriangles).
     id<MTLBuffer> bufTriIdx            = nil; // uint per (3 * nTri) — corners
     id<MTLBuffer> bufTriStiffness      = nil; // float per nTri
+    id<MTLBuffer> bufTriInvUV          = nil; // float per (4 * nTri) — rest material inv (2x2 per tri)
     id<MTLBuffer> bufTriGrad           = nil; // padded float3 per (3 * nTri)
     id<MTLBuffer> bufTriHessScalar     = nil; // float per (3 * nTri)
 
@@ -395,16 +396,19 @@ void AvbdSolver::uploadAttachments(uint32_t nAttach,
 
 void AvbdSolver::uploadTriangles(uint32_t nTri,
                                   const uint32_t* triIdx,
+                                  const float* invUV,
                                   const float* stiffness) {
     if (!ok()) return;
     impl_->nTri = nTri;
     const NSUInteger bytesTriIdx = 3 * nTri * sizeof(uint32_t);
+    const NSUInteger bytesInvUV  = 4 * nTri * sizeof(float);
     const NSUInteger bytesF      = nTri * sizeof(float);
     const NSUInteger bytesGradPadded   = 4 * 3 * nTri * sizeof(float);
     const NSUInteger bytesHessScalar   = 3 * nTri * sizeof(float);
     const MTLResourceOptions opts = MTLResourceStorageModeShared;
 
     impl_->bufTriIdx        = [impl_->device newBufferWithBytes:triIdx    length:bytesTriIdx options:opts];
+    impl_->bufTriInvUV      = [impl_->device newBufferWithBytes:invUV     length:bytesInvUV  options:opts];
     impl_->bufTriStiffness  = [impl_->device newBufferWithBytes:stiffness length:bytesF      options:opts];
     impl_->bufTriGrad       = [impl_->device newBufferWithLength:bytesGradPadded options:opts];
     impl_->bufTriHessScalar = [impl_->device newBufferWithLength:bytesHessScalar options:opts];
@@ -602,6 +606,7 @@ int AvbdSolver::step() {
         [enc setBuffer:impl_->bufTriLambda1     offset:0 atIndex:4];
         [enc setBuffer:impl_->bufTriGrad        offset:0 atIndex:5];
         [enc setBuffer:impl_->bufTriHessScalar  offset:0 atIndex:6];
+        [enc setBuffer:impl_->bufTriInvUV       offset:0 atIndex:7];
         [enc dispatchThreads:MTLSizeMake(impl_->nTri, 1, 1)
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
 

--- a/src/code/slang_solver/test_avbd_solver.cpp
+++ b/src/code/slang_solver/test_avbd_solver.cpp
@@ -90,8 +90,10 @@ int main(int argc, char** argv) {
 
     constexpr uint32_t N_T = 1;
     const uint32_t triIdx[3 * N_T] = {0u, 1u, 2u};
+    // Identity inv_deltaUV — canonical rest, same as pre-PR-G behavior.
+    const float triInvUV[4 * N_T]  = {1.0f, 0.0f, 0.0f, 1.0f};
     const float triK[N_T]          = {1.0f};
-    solver.uploadTriangles(N_T, triIdx, triK);
+    solver.uploadTriangles(N_T, triIdx, triInvUV, triK);
 
     constexpr uint32_t N_B = 1;
     const uint32_t bendIdx[4 * N_B]    = {0u, 1u, 2u, 3u};

--- a/tests/slang_validate/triangle_membrane_force_al_test.cpp
+++ b/tests/slang_validate/triangle_membrane_force_al_test.cpp
@@ -1,26 +1,39 @@
 // Real-input validator for Cloth.SlangCodegen.TriangleMembraneForceAl —
-// AL-augmented ARAP membrane force.
+// AL-augmented ARAP membrane force with per-triangle inv_deltaUV.
 //
-// Same as triangle_membrane_force but with λ_col0 and λ_col1 added to
-// the per-vertex gradients with the corotational sign pattern:
-//   grad[3c+0] = -k·(e0+e1) - (λ0 + λ1)
-//   grad[3c+1] = +k·e0      + λ0
-//   grad[3c+2] = +k·e1      + λ1
+// Define te0 = k·e0 + λ0, te1 = k·e1r + λ1 (3-vectors). Per triangle:
+//   grad[3c+0] = -(te0·(m00+m10) + te1·(m01+m11))
+//   grad[3c+1] = +(te0·m00       + te1·m01)
+//   grad[3c+2] = +(te0·m10       + te1·m11)
+//   hessScalar[3c+0] = k · ((m00+m10)² + (m01+m11)²)
+//   hessScalar[3c+1] = k · (m00² + m01²)
+//   hessScalar[3c+2] = k · (m10² + m11²)
 //
-// Test fixture (3 verts, 1 triangle, 2× stretched both axes, k=1):
+// Test fixture (3 verts, 3 triangles, 2× stretched both axes):
 //   v0=(0,0,0), v1=(2,0,0), v2=(0,2,0)
-//   F=[(2,0,0)|(0,2,0)]; closest 2D rot = I → R=[(1,0,0)|(0,1,0)]
-//   e0=(1,0,0), e1=(0,1,0)
 //
-//   Test 1 (λ=0):  matches triangle_membrane_force output exactly.
-//     grad[0]=(-1,-1,0), grad[1]=(1,0,0), grad[2]=(0,1,0)
-//     hess=[2, 1, 1]
+// T0 (M=I, λ=0, k=1): bit-exact pre-IUV result.
+//   F=[(2,0,0)|(0,2,0)], R=[(1,0,0)|(0,1,0)]
+//   e0=(1,0,0), e1=(0,1,0); te0=e0, te1=e1
+//   grad[0]=(-1,-1,0), grad[1]=(1,0,0), grad[2]=(0,1,0)
+//   hess=[2, 1, 1]
 //
-//   Test 2 (λ0=(1,2,3), λ1=(4,5,6)):
-//     grad[0] = (-1,-1,0) - (5,7,9) = (-6,-8,-9)
-//     grad[1] = (1,0,0)   + (1,2,3) = (2,2,3)
-//     grad[2] = (0,1,0)   + (4,5,6) = (4,6,6)
-//     hess unchanged: [2, 1, 1]
+// T1 (M=I, λ0=(1,2,3), λ1=(4,5,6), k=1):
+//   te0 = (1,0,0)+(1,2,3) = (2,2,3)
+//   te1 = (0,1,0)+(4,5,6) = (4,6,6)
+//   grad[0] = -(te0+te1)         = (-6,-8,-9)
+//   grad[1] = te0                = (2,2,3)
+//   grad[2] = te1                = (4,6,6)
+//   hess=[2, 1, 1]
+//
+// T2 (M=2·I, λ0=(1,0,0), λ1=(0,1,0), k=1):
+//   F = P · 2I = [(4,0,0)|(0,4,0)], R=[(1,0,0)|(0,1,0)]
+//   e0=(3,0,0), e1=(0,3,0); te0=(4,0,0), te1=(0,4,0)
+//   (m00+m10)=2, (m01+m11)=2
+//   grad[0] = -((4,0,0)·2 + (0,4,0)·2) = (-8,-8,0)
+//   grad[1] = (4,0,0)·2 + (0,4,0)·0    = (8,0,0)
+//   grad[2] = (4,0,0)·0 + (0,4,0)·2    = (0,8,0)
+//   hess=[8, 4, 4]
 
 #include <chrono>
 #include <cmath>
@@ -35,7 +48,7 @@ static constexpr double kBudgetSeconds = 5.0;
 int main() {
     const auto t0 = std::chrono::steady_clock::now();
 
-    constexpr uint32_t N_TRI = 2;  // T0=λ-zero, T1=λ-nonzero
+    constexpr uint32_t N_TRI = 3;
     constexpr uint32_t GROUP_SIZE = 64;
 
     std::vector<Vector<float, 3>> positions = {
@@ -50,23 +63,36 @@ int main() {
     std::vector<Vector<float, 3>> lambda1(GROUP_SIZE, Vector<float, 3>(0.0f));
     std::vector<Vector<float, 3>> grad(3 * GROUP_SIZE, Vector<float, 3>(0.0f));
     std::vector<float>            hessScalar(3 * GROUP_SIZE, 0.0f);
+    std::vector<float>            inv_deltaUV(4 * GROUP_SIZE, 0.0f);
+    for (uint32_t c = 0; c < GROUP_SIZE; ++c) {
+        inv_deltaUV[4*c + 0] = 1.0f; // m00
+        inv_deltaUV[4*c + 1] = 0.0f; // m01
+        inv_deltaUV[4*c + 2] = 0.0f; // m10
+        inv_deltaUV[4*c + 3] = 1.0f; // m11
+    }
 
     for (uint32_t c = 0; c < GROUP_SIZE; ++c) {
         idx[3*c+0] = 0u; idx[3*c+1] = 1u; idx[3*c+2] = 2u;
     }
-    stiffness[0] = 1.0f;  // λ=0 case
-    stiffness[1] = 1.0f;  // λ≠0 case
+    stiffness[0] = 1.0f;  // T0: λ=0, M=I
+    stiffness[1] = 1.0f;  // T1: λ≠0, M=I
+    stiffness[2] = 1.0f;  // T2: λ≠0, M=2I
     lambda0[1] = Vector<float, 3>(1.0f, 2.0f, 3.0f);
     lambda1[1] = Vector<float, 3>(4.0f, 5.0f, 6.0f);
+    lambda0[2] = Vector<float, 3>(1.0f, 0.0f, 0.0f);
+    lambda1[2] = Vector<float, 3>(0.0f, 1.0f, 0.0f);
+    inv_deltaUV[4*2 + 0] = 2.0f;
+    inv_deltaUV[4*2 + 3] = 2.0f;
 
     GlobalParams_0 gp{};
-    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
-    gp.idx_0.data        = idx.data();        gp.idx_0.count        = idx.size();
-    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
-    gp.lambda0_0.data    = lambda0.data();    gp.lambda0_0.count    = lambda0.size();
-    gp.lambda1_0.data    = lambda1.data();    gp.lambda1_0.count    = lambda1.size();
-    gp.grad_0.data       = grad.data();       gp.grad_0.count       = grad.size();
-    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+    gp.positions_0.data    = positions.data();    gp.positions_0.count    = positions.size();
+    gp.idx_0.data          = idx.data();          gp.idx_0.count          = idx.size();
+    gp.stiffness_0.data    = stiffness.data();    gp.stiffness_0.count    = stiffness.size();
+    gp.lambda0_0.data      = lambda0.data();      gp.lambda0_0.count      = lambda0.size();
+    gp.lambda1_0.data      = lambda1.data();      gp.lambda1_0.count      = lambda1.size();
+    gp.grad_0.data         = grad.data();         gp.grad_0.count         = grad.size();
+    gp.hessScalar_0.data   = hessScalar.data();   gp.hessScalar_0.count   = hessScalar.size();
+    gp.inv_deltaUV_0.data  = inv_deltaUV.data();  gp.inv_deltaUV_0.count  = inv_deltaUV.size();
 
     ComputeVaryingInput vi{};
     vi.startGroupID = uint3(0, 0, 0);
@@ -74,14 +100,14 @@ int main() {
     main_0(&vi, nullptr, &gp);
 
     const float expected_grad[N_TRI][3][3] = {
-        // T0 with λ=0: matches triangle_membrane_force
-        { {-1.0f, -1.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f} },
-        // T1 with λ0=(1,2,3), λ1=(4,5,6)
+        { {-1.0f, -1.0f,  0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f} },
         { {-6.0f, -8.0f, -9.0f}, {2.0f, 2.0f, 3.0f}, {4.0f, 6.0f, 6.0f} },
+        { {-8.0f, -8.0f,  0.0f}, {8.0f, 0.0f, 0.0f}, {0.0f, 8.0f, 0.0f} },
     };
     const float expected_hess[N_TRI][3] = {
         {2.0f, 1.0f, 1.0f},
         {2.0f, 1.0f, 1.0f},
+        {8.0f, 4.0f, 4.0f},
     };
 
     int fails = 0;

--- a/tests/slang_validate/triangle_membrane_force_test.cpp
+++ b/tests/slang_validate/triangle_membrane_force_test.cpp
@@ -1,36 +1,45 @@
 // Real-input validator for Cloth.SlangCodegen.TriangleMembraneForce —
 // AVBD per-triangle in-plane stretch force (PR-A of AVBD port).
 //
-// Per triangle c with vertices (i0,i1,i2) and stiffness k:
-//   F = [p1-p0 | p2-p0],  R = closest-rotation-in-image-plane(F)
-//   e0 = F.col(0) − R.col(0)
-//   e1 = F.col(1) − R.col(1)
-//   grad[3c+0] = −k · (e0 + e1)
-//   grad[3c+1] = +k · e0
-//   grad[3c+2] = +k · e1
-//   hessScalar[3c+0] = 2·k
-//   hessScalar[3c+1] = k
-//   hessScalar[3c+2] = k
+// Per triangle c with vertices (i0,i1,i2), inv_deltaUV M (row-major
+// 2x2: m00, m01, m10, m11), and stiffness k:
+//   P = [p1-p0 | p2-p0]
+//   F = P · M = [P*M.col(0) | P*M.col(1)]
+//   R = closest-rotation-in-image-plane(F)
+//   e0  = F.col(0) − R.col(0)
+//   e1  = F.col(1) − R.col(1)
+//   grad[3c+0] = -k · (e0·(m00+m10) + e1·(m01+m11))
+//   grad[3c+1] = +k · (e0·m00       + e1·m01)
+//   grad[3c+2] = +k · (e0·m10       + e1·m11)
+//   hessScalar[3c+0] = k · ((m00+m10)² + (m01+m11)²)
+//   hessScalar[3c+1] = k · (m00² + m01²)
+//   hessScalar[3c+2] = k · (m10² + m11²)
 //
-// Test fixture (2 triangles, 6 verts):
+// Test fixture (3 triangles, 6 verts):
 //
-// Triangle 0 — stretched 2x in x and y, k=1:
+// Triangle 0 — stretched 2x, M = I, k=1 (bit-exact pre-IUV result):
 //   v0=(0,0,0), v1=(2,0,0), v2=(0,2,0)
-//   F = [(2,0,0)|(0,2,0)], 2D form [2,0;0,2], closest rot = I
-//   R = [(1,0,0)|(0,1,0)]
+//   F = [(2,0,0)|(0,2,0)] = P, closest rot R = I
 //   e0=(1,0,0), e1=(0,1,0)
-//   grad[0] = (−1, −1, 0)
-//   grad[1] = (1, 0, 0)
-//   grad[2] = (0, 1, 0)
-//   hess = [2, 1, 1]
+//   grad = (-1,-1,0), (1,0,0), (0,1,0)
+//   hess = 2, 1, 1
 //
-// Triangle 1 — unit rest triangle, k=3:
+// Triangle 1 — unit rest triangle, M = I, k=3:
 //   v3=(10,10,10), v4=(11,10,10), v5=(10,11,10)
-//   F = [(1,0,0)|(0,1,0)] = R, so e0=e1=(0,0,0)
-//   grad = [(0,0,0)] × 3
-//   hess = [6, 3, 3]
+//   F = [(1,0,0)|(0,1,0)] = R, e0=e1=(0,0,0)
+//   grad = (0,0,0) × 3
+//   hess = 6, 3, 3
 //
-// Padding (slots 2..63): idx=(0,1,2), k=0 → safe rotation math + zero grad/hess.
+// Triangle 2 — same positions as triangle 0 but M = 2·I, k=1:
+//   F = P · 2I = [(4,0,0)|(0,4,0)], closest rot R = I (unit columns)
+//   e0=(3,0,0), e1=(0,3,0); (m00+m10)=2, (m01+m11)=2
+//   grad = -(e0·2 + e1·2) = (-6,-6,0)
+//        = (e0·2 + e1·0) = (6,0,0)
+//        = (e0·0 + e1·2) = (0,6,0)
+//   hess = ((2)²+(2)²) = 8; ((2)²+0²) = 4; (0²+(2)²) = 4
+//
+// Padding (slots 3..63): idx=(0,1,2), k=0, M=I → safe rotation math
+// + zero grad/hess.
 
 #include <chrono>
 #include <cmath>
@@ -45,7 +54,7 @@ static constexpr double kBudgetSeconds = 5.0;
 int main() {
     const auto t0 = std::chrono::steady_clock::now();
 
-    constexpr uint32_t N_TRI = 2;
+    constexpr uint32_t N_TRI = 3;
     constexpr uint32_t GROUP_SIZE = 64;
 
     std::vector<Vector<float, 3>> positions = {
@@ -61,6 +70,15 @@ int main() {
     std::vector<float>            stiffness(GROUP_SIZE, 0.0f);
     std::vector<Vector<float, 3>> grad(3 * GROUP_SIZE, Vector<float, 3>(0.0f));
     std::vector<float>            hessScalar(3 * GROUP_SIZE, 0.0f);
+    // M = identity for every triangle (padding default). Test
+    // triangle 2 overrides to 2·I below.
+    std::vector<float>            inv_deltaUV(4 * GROUP_SIZE, 0.0f);
+    for (uint32_t c = 0; c < GROUP_SIZE; ++c) {
+        inv_deltaUV[4*c + 0] = 1.0f; // m00
+        inv_deltaUV[4*c + 1] = 0.0f; // m01
+        inv_deltaUV[4*c + 2] = 0.0f; // m10
+        inv_deltaUV[4*c + 3] = 1.0f; // m11
+    }
 
     // Default padding: idx = (0, 1, 2) (well-defined positions), k = 0
     for (uint32_t c = 0; c < GROUP_SIZE; ++c) {
@@ -69,13 +87,18 @@ int main() {
 
     idx[0] = 0u; idx[1] = 1u; idx[2] = 2u; stiffness[0] = 1.0f;
     idx[3] = 3u; idx[4] = 4u; idx[5] = 5u; stiffness[1] = 3.0f;
+    idx[6] = 0u; idx[7] = 1u; idx[8] = 2u; stiffness[2] = 1.0f;
+    // Triangle 2: M = 2·I
+    inv_deltaUV[4*2 + 0] = 2.0f;
+    inv_deltaUV[4*2 + 3] = 2.0f;
 
     GlobalParams_0 gp{};
-    gp.positions_0.data  = positions.data();  gp.positions_0.count  = positions.size();
-    gp.idx_0.data        = idx.data();        gp.idx_0.count        = idx.size();
-    gp.stiffness_0.data  = stiffness.data();  gp.stiffness_0.count  = stiffness.size();
-    gp.grad_0.data       = grad.data();       gp.grad_0.count       = grad.size();
-    gp.hessScalar_0.data = hessScalar.data(); gp.hessScalar_0.count = hessScalar.size();
+    gp.positions_0.data    = positions.data();    gp.positions_0.count    = positions.size();
+    gp.idx_0.data          = idx.data();          gp.idx_0.count          = idx.size();
+    gp.stiffness_0.data    = stiffness.data();    gp.stiffness_0.count    = stiffness.size();
+    gp.grad_0.data         = grad.data();         gp.grad_0.count         = grad.size();
+    gp.hessScalar_0.data   = hessScalar.data();   gp.hessScalar_0.count   = hessScalar.size();
+    gp.inv_deltaUV_0.data  = inv_deltaUV.data();  gp.inv_deltaUV_0.count  = inv_deltaUV.size();
 
     ComputeVaryingInput vi{};
     vi.startGroupID = uint3(0, 0, 0);
@@ -85,10 +108,12 @@ int main() {
     const float expected_grad[N_TRI][3][3] = {
         { {-1.0f, -1.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f} },
         { { 0.0f,  0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f} },
+        { {-6.0f, -6.0f, 0.0f}, {6.0f, 0.0f, 0.0f}, {0.0f, 6.0f, 0.0f} },
     };
     const float expected_hess[N_TRI][3] = {
         {2.0f, 1.0f, 1.0f},
         {6.0f, 3.0f, 3.0f},
+        {8.0f, 4.0f, 4.0f},
     };
 
     int   fails        = 0;


### PR DESCRIPTION
## Summary

- Fixes the AVBD triangle-membrane force / AL kernels' hardcoded `inv_deltaUV = I`, the root cause of the dress shadow's 1.36 m / step solve-drift (PR #84 finding).
- Drift at step 1 drops from **1.356 m → 0.00127 m** (~1068× reduction); `conv_max` from **0.702 → 0.00066**. AVBD now tracks the implicit-Euler step instead of pulling toward a canonical-rest equilibrium.

## What changed

- `TriangleMembraneForce.lean` / `TriangleMembraneForceAl.lean` — new `inv_deltaUV` binding (4 floats per triangle, row-major 2×2 `[m00, m01, m10, m11]`). `F = [p1−p0 | p2−p0] · M`, gradients/Hessians chain back through `M`. With `M=I` reduces bit-exactly to pre-PR-G form.
- Validators add a 2·I test triangle (alongside the existing identity case).
- `AvbdSolver::uploadTriangles` — new `invUV` parameter, new `bufTriInvUV`, bound at index 7 in the AL membrane dispatch.
- `Simulation.cpp` — packs each `mesh[i].inv_deltaUV` (Mat2x2d) into the upload array.
- Shadow log gains `pred_max` (`|s_n − x_n|` from predictor) and `drift_max` (`|avbd − s_n|`) — the split that made this bug locatable in one rebuild.
- `AVBD_DRIVE=1` env: commits AVBD output to `Particle.pos` + recomputes velocity. Off by default; only sensible now that rest-pose is fixed.

## Known follow-ups

- `TriangleMembraneDualUpdate` (only dispatched when `AVBD_AL=1`) still uses raw edges.
- Per-step `|Δx|` still grows over time (drift = 0.45 m by step 12). Suspected mass/stiffness ratio (`m/h²` ≪ `k`) causing per-vertex GS to ignore inertia — separate PR.

## Test plan

- [x] `lake build Cloth.SlangCodegen.TriangleMembraneForce[Al]` — `native_decide` accepts both new emits.
- [x] `make -C tests/slang_validate test` — `all kernels OK` (3/3 on `triangle_membrane_force`, 3/3 on `_al`).
- [x] `ninja tool_cloth_dynamics` — clean build.
- [x] `USE_AVBD=1 AVBD_ITERS=16 ./tool_cloth_dynamics -demo dress -seed 0` — shadow log shows `drift_max` ~0.001 m at step 1 (was 1.35).