### PR TITLE
Per-step PD displacement diagnostic for AVBD comparison

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1666,6 +1666,26 @@ void Simulation::step() {
 	returnRecord.v = v_new;
 	returnRecord.f = f;
 	returnRecord.r = r;
+
+#ifdef __APPLE__
+	// Per-step PD displacement |x_new − x_n| for direct comparison
+	// with avbd-shadow's dxMax/dxMean (which measures |avbd − x_n|).
+	// If pd_dx_max and avbd_dx_max diverge much, the AVBD solve
+	// disagrees with PD on what implicit Euler "should" produce.
+	if (g_useAvbd && currentSysmatId == 0 && sysMat[0].avbd && sysMat[0].avbd->ok()) {
+		double pdMax = 0.0, pdMean = 0.0;
+		const size_t nDof = size_t(x_new.size());
+		for (size_t i = 0; i < nDof; ++i) {
+			const double dx = std::fabs(x_new[i] - x_n[i]);
+			if (dx > pdMax) pdMax = dx;
+			pdMean += dx;
+		}
+		pdMean /= double(nDof);
+		std::printf("[pd-step]     step %zu  dof=%zu  pd|Δx|_max=%g  pd|Δx|_mean=%g\n",
+		            forwardRecords.size(), nDof, pdMax, pdMean);
+	}
+#endif
+
 	returnRecord.timer = timeSteptimer.getReportMicroseconds();
 	returnRecord.accumTimer =
 			Timer::addTimer(returnRecord.timer.timeMicroseconds,


### PR DESCRIPTION
## Summary

Adds a `[pd-step]` log line printing DiffCloth's converged `|x_new − x_n|` alongside `[avbd-shadow]`'s own. Same metric, side-by-side, so divergence localizes AVBD's residual error.

Stacks on top of #87 (`inv-deltauv` branch).

## Dress finding (post-#87)

| step | pd \|Δx\|_max | avbd \|Δx\|_max | avbd \|Δx\|_mean | pd \|Δx\|_mean |
|---|---:|---:|---:|---:|
| 1 | 0.051 | 0.00066 | 3.8e-5 | 0.00088 |
| 5 | 0.071 | 0.150 | 0.00104 | 0.00351 |
| 12 | 0.084 | 0.399 | 0.00263 | 0.00699 |

PD's max stays bounded ~0.05–0.10 m. **AVBD's max grows ~6× past PD by step 12, while AVBD's mean stays smaller than PD's.** Classic per-vertex Gauss-Seidel divergence on boundary / high-tension vertices that the local 3×3 update can't equilibrate without neighbor coupling.

Likely fixes (separate PRs):
- Chebyshev acceleration on the position update
- Sub-stepping (smaller h ⇒ inertial term wins on stiff verts)
- Modified mass `m_eff = m + h² · Σ_c k_c` for the inertial weight

## Test plan

- [x] `USE_AVBD=1 AVBD_ITERS=16 ./tool_cloth_dynamics -demo dress -seed 0` prints the new line.
- [x] No effect when `USE_AVBD` is unset (guard on `g_useAvbd`).