### PR TITLE
Drift-vertex + inv_deltaUV-range diagnostics for AVBD shadow

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1302,6 +1302,11 @@ void Simulation::step() {
 		// accumulating). If drift dominates: AVBD is "snapping to
 		// equilibrium" rather than tracking the implicit-Euler step.
 		float predMax = 0.0f, driftMax = 0.0f;
+		// Track which vertex hosts the largest drift — picking
+		// between "attachment-adjacent", "free-edge", or "interior"
+		// helps narrow the per-vertex GS divergence story.
+		uint32_t driftMaxVert = 0;
+		int driftMaxAxis = 0;
 		int nanCount = 0;
 		for (uint32_t i = 0; i < nV; ++i) {
 			for (int axis = 0; axis < 3; ++axis) {
@@ -1312,7 +1317,11 @@ void Simulation::step() {
 				if (!std::isfinite(ax)) ++nanCount;
 				if (dx > dxMax) dxMax = dx;
 				if (dp > predMax) predMax = dp;
-				if (dd > driftMax) driftMax = dd;
+				if (dd > driftMax) {
+					driftMax = dd;
+					driftMaxVert = i;
+					driftMaxAxis = axis;
+				}
 				dxMean += dx;
 				if (!avbdPosHalf.empty()) {
 					const float dconv = std::fabs(ax - avbdPosHalf[3*i + axis]);
@@ -1329,9 +1338,10 @@ void Simulation::step() {
 		// needed.
 		std::printf("[avbd-shadow] step %zu  dof=%u  iters=%d  rc=%d  wall=%lld us"
 		            "  |Δx|_max=%g  |Δx|_mean=%g  pred_max=%g  drift_max=%g"
-		            "  conv_max=%g  conv_mean=%g  nan=%d\n",
+		            "  drift@v%u.%c  conv_max=%g  conv_mean=%g  nan=%d\n",
 		            forwardRecords.size(), nV * 3u, s_avbdIters, rc, us,
 		            dxMax, dxMean, predMax, driftMax,
+		            driftMaxVert, "xyz"[driftMaxAxis],
 		            convergeMax, convergeMean, nanCount);
 	}
 #endif
@@ -3412,6 +3422,8 @@ void Simulation::initializePrefactoredMatrices() {
 				std::vector<uint32_t> triIdx(3 * nT);
 				std::vector<float>    triInvUV(4 * nT);
 				std::vector<float>    triK(nT, float(Triangle::k_stiff));
+				float maxAbsInvUV = 0.0f;
+				uint32_t maxTri = 0;
 				for (uint32_t i = 0; i < nT; ++i) {
 					triIdx[3*i + 0] = uint32_t(mesh[i].p0_idx);
 					triIdx[3*i + 1] = uint32_t(mesh[i].p1_idx);
@@ -3421,7 +3433,17 @@ void Simulation::initializePrefactoredMatrices() {
 					triInvUV[4*i + 1] = float(mesh[i].inv_deltaUV(0, 1));
 					triInvUV[4*i + 2] = float(mesh[i].inv_deltaUV(1, 0));
 					triInvUV[4*i + 3] = float(mesh[i].inv_deltaUV(1, 1));
+					for (int j = 0; j < 4; ++j) {
+						const float a = std::fabs(triInvUV[4*i + j]);
+						if (a > maxAbsInvUV) { maxAbsInvUV = a; maxTri = i; }
+					}
 				}
+				std::printf("[avbd] inv_deltaUV range over %u tris: max |M|=%g "
+				            "at tri %u (verts %u,%u,%u; M=[%g,%g; %g,%g])\n",
+				            nT, maxAbsInvUV, maxTri,
+				            triIdx[3*maxTri+0], triIdx[3*maxTri+1], triIdx[3*maxTri+2],
+				            triInvUV[4*maxTri+0], triInvUV[4*maxTri+1],
+				            triInvUV[4*maxTri+2], triInvUV[4*maxTri+3]);
 				avbd->uploadTriangles(nT, triIdx.data(), triInvUV.data(),
 				                     triK.data());
 


### PR DESCRIPTION
## Summary

Stacks on #88. Two diagnostics that turn the PR #88 pd-vs-avbd gap into a localized story:

- `[avbd]` at scene init: max `|inv_deltaUV_ij|` and which triangle / vertices host it. Identifies the most anisotropic rest shape in the mesh.
- `[avbd-shadow]` per-step: `drift@vN.axis` — the (vertex, axis) hosting the worst `|avbd − s_n|`. Lets you cross-reference against the dress's attachment list (loop points, already dumped at init) and classify the offender.

## Dress finding (USE_AVBD=1, AVBD_ITERS=16)

```
[avbd] inv_deltaUV range over 7026 tris: max |M|=38.58 at tri 14
       (verts 40,38,37; M=[1.29,-22.44; ~0, 38.58])
[avbd-shadow] step 2..11: drift@v1333.z   (same vertex every step)
drift_max grows: 0.09 → 0.42 m linearly in step
```

`v1333` is NOT in the dress's attachment list — interior or free-edge vertex. **A single vertex** is consistently divergent while ~3,000 others stay close to PD. Per-vertex Gauss-Seidel can't equilibrate one vertex when its local 3×3 system is dominated by constraints and neighbor positions disagree.

## Likely fixes (next PR)

- Chebyshev acceleration on the position update
- Sub-stepping (smaller h ⇒ inertial term wins)
- Modified inertial weight `m_eff/h² = m/h² + ε · Σ_c k_c`

## Test plan

- [x] `USE_AVBD=1 ./tool_cloth_dynamics -demo dress -seed 0` prints both new lines.
- [x] No effect when USE_AVBD unset.