### PR TITLE
AVBD drape OBJ dump for visual validation

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1795,8 +1795,9 @@ void Simulation::step() {
 	// the PD pass computed (potentially inconsistent — that's why
 	// this is opt-in).
 	static const bool s_avbdDrive = (std::getenv("AVBD_DRIVE") != nullptr);
-	if (s_avbdDrive && g_useAvbd && currentSysmatId == 0 &&
-	    sysMat[0].avbd && sysMat[0].avbd->ok()) {
+	const bool s_avbdDriveActive = s_avbdDrive && g_useAvbd && currentSysmatId == 0 &&
+	    sysMat[0].avbd && sysMat[0].avbd->ok();
+	if (s_avbdDriveActive) {
 		std::vector<float> avbdPosFinal;
 		sysMat[0].avbd->readPositions(avbdPosFinal);
 		const double invH = 1.0 / sceneConfig.timeStep;
@@ -1814,6 +1815,32 @@ void Simulation::step() {
 		}
 		std::printf("[avbd-drive] step %zu wrote AVBD output to Particle.pos\n",
 		            forwardRecords.size());
+	}
+
+	// AVBD_DUMP_STEP=<N> writes /tmp/{avbd,pd}_drape_step_<N>.obj at
+	// step N. Naming reflects whether AVBD or PD's output drove that
+	// step — switch by running with and without AVBD_DRIVE=1. Lets you
+	// eyeball the drape in any OBJ viewer (Blender, gltf-viewer, etc.)
+	// to confirm the shape is physically plausible (gravity-aligned,
+	// attached at pinned vertices, no inside-out triangles, geometry
+	// resembling what PD produces).
+	if (const char* dumpStr = std::getenv("AVBD_DUMP_STEP")) {
+		const size_t dumpStep = size_t(std::atoll(dumpStr));
+		if (forwardRecords.size() == dumpStep) {
+			VecXd positions(3 * particles.size());
+			for (size_t i = 0; i < particles.size(); ++i)
+				positions.segment(3 * i, 3) = particles[i].pos;
+			std::vector<Vec3i> triList(mesh.size());
+			for (size_t i = 0; i < mesh.size(); ++i)
+				triList[i] = Vec3i(mesh[i].p0_idx, mesh[i].p1_idx, mesh[i].p2_idx);
+			const std::string label = s_avbdDriveActive ? "avbd" : "pd";
+			const std::string outPath =
+				"/tmp/" + label + "_drape_step_" + std::to_string(dumpStep);
+			MeshFileHandler::saveOBJFile(outPath, positions, triList);
+			std::printf("[drape-dump] wrote %s.obj (%zu verts, %zu tris) — %s path\n",
+			            outPath.c_str(), particles.size(), mesh.size(),
+			            label.c_str());
+		}
 	}
 #endif
 


### PR DESCRIPTION
## Summary

\`AVBD_DUMP_STEP=<N>\` env writes \`/tmp/<label>_drape_step_<N>.obj\` at step N, with \`<label>\` reflecting whether AVBD or PD drove that step. Open in any OBJ viewer (Blender, gltf-viewer, macOS Quick Look).

## Dress comparison @ step 40

| metric | avbd | pd | Δ |
|---|---:|---:|---:|
| x_spread (m) | 12.54 | 12.30 | +0.23 |
| y_spread (m) | 13.00 | 13.34 | -0.34 |
| z_spread (m) | 11.39 | 11.31 | +0.08 |
| centroid_y | -0.90 | -1.07 | +0.17 |
| top_y | 5.09 | 4.95 | +0.15 |
| bottom_y | -5.83 | -6.00 | +0.18 |
| per-vert L2 | mean=0.71, median=0.46, max=2.24 |

Same dress shape, gravity-pulled, attached at +5.1m, hem at -5.8m. AVBD_DRIVE produces a physically sensible drape on dress. No NaN, no inside-out triangles.

## Test plan

- [x] AVBD: \`USE_AVBD=1 AVBD_COLORS=1 AVBD_DRIVE=1 AVBD_DUMP_STEP=40 ./tool_cloth_dynamics -demo dress -seed 0\` writes the AVBD drape.
- [x] PD: \`AVBD_DUMP_STEP=40 ./tool_cloth_dynamics -demo dress -seed 0\` (no USE_AVBD) writes the PD drape.
- [x] OBJ opens cleanly in any viewer; vertex count + triangle count match the dress mesh (3634 + 7026).