### PR TITLE
AVBD cloth-vs-sphere position projection (minimal contact path)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1814,6 +1814,38 @@ void Simulation::step() {
 		}
 		std::printf("[avbd-drive] step %zu wrote AVBD output to Particle.pos\n",
 		            forwardRecords.size());
+
+		// AVBD-side cloth-vs-sphere position projection. After AVBD's
+		// converged positions are committed, push every cloth vertex
+		// outside any sphere primitive whose interior it landed in.
+		// Inward-normal velocity component is zeroed (sticky / no-bounce
+		// contact). Default-on when DRIVE is set; AVBD_NO_CONTACT=1
+		// disables for ablation. Lets hat/sphere/big-sphere demos run
+		// AVBD-only without PD's contact handling. Self-collision and
+		// capsule/plane/bowl projection are follow-ups.
+		const bool s_avbdNoContact = (std::getenv("AVBD_NO_CONTACT") != nullptr);
+		if (!s_avbdNoContact) {
+			size_t projHits = 0;
+			for (size_t i = 0; i < particles.size(); ++i) {
+				for (Primitive* p : primitives) {
+					Sphere* sp = dynamic_cast<Sphere*>(p);
+					if (!sp) continue;
+					const Vec3d delta = particles[i].pos - sp->center;
+					const double dist = delta.norm();
+					if (dist < sp->radius && dist > 1e-10) {
+						const Vec3d normal = delta / dist;
+						particles[i].pos = sp->center + normal * sp->radius;
+						const double vn = particles[i].velocity.dot(normal);
+						if (vn < 0)
+							particles[i].velocity -= vn * normal;
+						++projHits;
+					}
+				}
+			}
+			if (projHits > 0)
+				std::printf("[avbd-contact] step %zu projected %zu verts out of sphere primitives\n",
+				            forwardRecords.size(), projHits);
+		}
 	}
 #endif
 


### PR DESCRIPTION
## Summary

Post-step cloth-vs-sphere projection so AVBD can drive demos with sphere primitives (hat, sphere, big-sphere) without depending on PD's contact handling. After AVBD's converged positions are committed, walk every cloth vertex and project it outside any \`Sphere\` primitive whose interior it landed in. Zero the inward-normal velocity component (sticky/no-bounce).

Default-on when \`AVBD_DRIVE=1\`. \`AVBD_NO_CONTACT=1\` disables for ablation.

## Smoke tests

- \`hat\` (sphere_head primitive): runs through step 10, no projection hits — AVBD's drape lands clear.
- \`sphere\` (PLANE_AND_SPHERE): runs through step 20, no projection hits.

In both, AVBD's chosen drape naturally avoids the spheres, so projection is a no-op. Code activates when needed (intentional intersections, dynamic motion, self-collision later).

## Why this slice

Step 1 toward "drop PD entirely" per the user's roadmap. Sphere contact is the simplest primitive type and covers 3 of the 5 contact-having demos. Capsule (Foot/sockLeg), Plane (slope/ground), and Bowl are follow-up slices, as is self-collision.

## Test plan

- [x] Hat demo runs AVBD-only through step 10, no NaN.
- [x] Sphere demo runs AVBD-only through step 20, no NaN.
- [x] No-op when no sphere primitive (dress, tshirt) — projection loop is fast even with no spheres.