### PR TITLE
AVBD generic cloth-vs-primitive projection (sphere + capsule + plane + bowl)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1814,6 +1814,39 @@ void Simulation::step() {
 		}
 		std::printf("[avbd-drive] step %zu wrote AVBD output to Particle.pos\n",
 		            forwardRecords.size());
+
+		// AVBD-side cloth-vs-primitive position projection. After
+		// AVBD's positions are committed, push every cloth vertex
+		// outside any primitive (Sphere, Capsule, LowerLeg, Bowl,
+		// Plane, Foot) it penetrated. Generic via Primitive's
+		// virtual `isInContact`: returns signed `dist` (negative =
+		// inside) and outward `normal`; we translate the vertex by
+		// `-dist * normal` to land on the surface and zero the
+		// inward-normal velocity component (sticky / no-bounce).
+		// Default-on when DRIVE is set; AVBD_NO_CONTACT=1 disables.
+		// Self-collision (cloth-cloth) is a follow-up.
+		const bool s_avbdNoContact = (std::getenv("AVBD_NO_CONTACT") != nullptr);
+		if (!s_avbdNoContact) {
+			size_t projHits = 0;
+			for (size_t i = 0; i < particles.size(); ++i) {
+				for (Primitive* p : primitives) {
+					if (!p) continue;
+					Vec3d normal; double dist = 0; Vec3d v_out;
+					if (!p->isInContact(p->center, particles[i].pos,
+					                    particles[i].velocity, normal, dist, v_out))
+						continue;
+					if (dist >= 0.0) continue;  // surface or outside
+					particles[i].pos -= dist * normal;
+					const double vn = particles[i].velocity.dot(normal);
+					if (vn < 0)
+						particles[i].velocity -= vn * normal;
+					++projHits;
+				}
+			}
+			if (projHits > 0)
+				std::printf("[avbd-contact] step %zu projected %zu vert/primitive penetrations\n",
+				            forwardRecords.size(), projHits);
+		}
 	}
 #endif
 


### PR DESCRIPTION
## Summary

Generalizes PR #97's Sphere-specific projection to every \`Primitive\` subclass via the virtual \`isInContact\` API. Covers \`Sphere\`, \`Capsule\`, \`LowerLeg\` (sockLeg), \`Foot\`, \`Bowl\`, \`Plane\`. Single loop, no per-primitive code paths.

Per cloth vertex per primitive: call \`p->isInContact(p->center, pos, vel, &normal, &dist, &v_out)\` — if \`dist < 0\` (inside), translate by \`-dist · normal\` to the surface; zero inward-normal velocity component.

## Smoke tests

| demo | primitive | result |
|---|---|---|
| hat | sphere_head | runs AVBD-only, no NaN, drape clears sphere |
| sphere | PLANE_AND_SPHERE | runs AVBD-only, no NaN, drape clears sphere |
| sock | LowerLeg | runs AVBD-only through step 15, no NaN |

In all three demos AVBD's drape lands clear of the primitive, so projection is a no-op. Activates when intersection occurs.

## Relationship to #97

Supersedes — the generic isInContact-based loop covers Sphere AND adds the other primitive types. Either PR can merge first; the second will need a trivial conflict resolution (take the generic version).

## Test plan

- [x] Hat / sphere / sock demos run AVBD-only without NaN.
- [x] No-op when no primitives (dress, tshirt) — projection loop iterates the empty \`primitives\` vector.