### PR TITLE
PR-G bricks 4-6: backward kernels for vbd_gather_{spring,attach,bending}

### DIFF
--- a/lean/Cloth/SlangCodegen.lean
+++ b/lean/Cloth/SlangCodegen.lean
@@ -32,6 +32,9 @@ import Cloth.SlangCodegen.SelfCollisionScan
 import Cloth.SlangCodegen.VbdSolveApplyBackward
 import Cloth.SlangCodegen.VbdInitBackward
 import Cloth.SlangCodegen.VbdGatherTriangleBackward
+import Cloth.SlangCodegen.VbdGatherAttachmentBackward
+import Cloth.SlangCodegen.VbdGatherBendingBackward
+import Cloth.SlangCodegen.VbdGatherSpringBackward
 
 /-!
 # `Cloth.SlangCodegen` — Slang shader codegen umbrella

--- a/lean/Cloth/SlangCodegen/VbdGatherAttachmentBackward.lean
+++ b/lean/Cloth/SlangCodegen/VbdGatherAttachmentBackward.lean
@@ -1,0 +1,108 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdGatherAttachmentBackward` — adjoint of vbd_gather_attachment (PR-G continued)
+
+Backward kernel for `vbd_gather_attachment`. The forward gathers
+per-attachment outputs into per-vertex scratch:
+
+  for v in verts:
+    for c in vertAttach-CSR[v]:
+      g_v        += attachGradV[c]
+      H_v_diag   += attachHessScalar[c]      (added to all 3 diagonals)
+
+Attachments have K=1 vertex per constraint and no role flip, so the
+adjoint is a straight fan-out keyed by the constraint side:
+
+  per c:
+    v = attachVertIdx[c]
+    v_attachGradV[c]      = v_g[v]
+    v_attachHessScalar[c] = v_H_xx[v] + v_H_yy[v] + v_H_zz[v]
+
+Off-diagonal entries of v_H do not flow back — the forward only
+touches diagonals.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<uint>     attachVertIdx         length = N_attach
+  1  StructuredBuffer<float3>   v_g                   length = N_verts (cotangent)
+  2  StructuredBuffer<float>    v_H                   length = 6·N_verts (cotangent, sym 3x3)
+  3  RWStructuredBuffer<float3> v_attachGradV         length = N_attach (output)
+  4  RWStructuredBuffer<float>  v_attachHessScalar    length = N_attach (output)
+-/
+
+namespace Cloth.SlangCodegen.VbdGatherAttachmentBackward
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"    (.member (.var "tid") "x")
+  , .declInit u  "v"    (.index (.var "attachVertIdx") (.var "c"))
+  , .declInit u  "hb"   (.bin "*" (.litUint 6) (.var "v"))
+  , .declInit f3 "vg"   (.index (.var "v_g") (.var "v"))
+  , .declInit f  "vHxx" (.index (.var "v_H") (.var "hb"))
+  , .declInit f  "vHyy" (.index (.var "v_H") (.bin "+" (.var "hb") (.litUint 3)))
+  , .declInit f  "vHzz" (.index (.var "v_H") (.bin "+" (.var "hb") (.litUint 5)))
+  , .assign (.index (.var "v_attachGradV") (.var "c"))
+      (.call "float3"
+        [ .member (.var "vg") "x"
+        , .member (.var "vg") "y"
+        , .member (.var "vg") "z" ])
+  , .assign (.index (.var "v_attachHessScalar") (.var "c"))
+      (.bin "+" (.bin "+" (.var "vHxx") (.var "vHyy")) (.var "vHzz"))
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "attachVertIdx"      (.roBuf u)
+      , bnd 1 "v_g"                (.roBuf f3)
+      , bnd 2 "v_H"                (.roBuf f)
+      , bnd 3 "v_attachGradV"      (.rwBuf f3)
+      , bnd 4 "v_attachHessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<uint> attachVertIdx;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float3> v_g;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> v_H;
+[[vk::binding(3, 0)]]
+RWStructuredBuffer<float3> v_attachGradV;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float> v_attachHessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint v = attachVertIdx[c];
+  uint hb = (6u * v);
+  float3 vg = v_g[v];
+  float vHxx = v_H[hb];
+  float vHyy = v_H[(hb + 3u)];
+  float vHzz = v_H[(hb + 5u)];
+  v_attachGradV[c] = float3(vg.x, vg.y, vg.z);
+  v_attachHessScalar[c] = ((vHxx + vHyy) + vHzz);
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdGatherAttachmentBackward

--- a/lean/Cloth/SlangCodegen/VbdGatherBendingBackward.lean
+++ b/lean/Cloth/SlangCodegen/VbdGatherBendingBackward.lean
@@ -1,0 +1,109 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdGatherBendingBackward` — adjoint of vbd_gather_bending (PR-G continued)
+
+Backward kernel for `vbd_gather_bending`. The forward gathers
+per-(constraint, role) outputs into per-vertex scratch:
+
+  for v in verts:
+    for (c, r) in vertBend-CSR[v]:
+      g_v        += bendGrad[4c+r]
+      H_v_diag   += bendHessScalar[4c+r]
+
+Bending has K=4 (the dihedral stencil), so the slot index is
+`4·c + r` with role ∈ {0,1,2,3}. Adjoint dispatches one thread per
+(c, r) slot:
+
+  per slot s = 4c+r:
+    v = bendIdx[s]
+    v_bendGrad[s]       = v_g[v]
+    v_bendHessScalar[s] = v_H_xx[v] + v_H_yy[v] + v_H_zz[v]
+
+Off-diagonal entries of v_H don't flow back through the gather —
+the forward only touches diagonals.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<uint>     bendIdx             length = 4·N_bend
+  1  StructuredBuffer<float3>   v_g                 length = N_verts (cotangent)
+  2  StructuredBuffer<float>    v_H                 length = 6·N_verts (cotangent, sym 3x3)
+  3  RWStructuredBuffer<float3> v_bendGrad          length = 4·N_bend (output)
+  4  RWStructuredBuffer<float>  v_bendHessScalar    length = 4·N_bend (output)
+-/
+
+namespace Cloth.SlangCodegen.VbdGatherBendingBackward
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "slot" (.member (.var "tid") "x")
+  , .declInit u  "v"    (.index (.var "bendIdx") (.var "slot"))
+  , .declInit u  "hb"   (.bin "*" (.litUint 6) (.var "v"))
+  , .declInit f3 "vg"   (.index (.var "v_g") (.var "v"))
+  , .declInit f  "vHxx" (.index (.var "v_H") (.var "hb"))
+  , .declInit f  "vHyy" (.index (.var "v_H") (.bin "+" (.var "hb") (.litUint 3)))
+  , .declInit f  "vHzz" (.index (.var "v_H") (.bin "+" (.var "hb") (.litUint 5)))
+  , .assign (.index (.var "v_bendGrad") (.var "slot"))
+      (.call "float3"
+        [ .member (.var "vg") "x"
+        , .member (.var "vg") "y"
+        , .member (.var "vg") "z" ])
+  , .assign (.index (.var "v_bendHessScalar") (.var "slot"))
+      (.bin "+" (.bin "+" (.var "vHxx") (.var "vHyy")) (.var "vHzz"))
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "bendIdx"          (.roBuf u)
+      , bnd 1 "v_g"              (.roBuf f3)
+      , bnd 2 "v_H"              (.roBuf f)
+      , bnd 3 "v_bendGrad"       (.rwBuf f3)
+      , bnd 4 "v_bendHessScalar" (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<uint> bendIdx;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float3> v_g;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float> v_H;
+[[vk::binding(3, 0)]]
+RWStructuredBuffer<float3> v_bendGrad;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float> v_bendHessScalar;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint slot = tid.x;
+  uint v = bendIdx[slot];
+  uint hb = (6u * v);
+  float3 vg = v_g[v];
+  float vHxx = v_H[hb];
+  float vHyy = v_H[(hb + 3u)];
+  float vHzz = v_H[(hb + 5u)];
+  v_bendGrad[slot] = float3(vg.x, vg.y, vg.z);
+  v_bendHessScalar[slot] = ((vHxx + vHyy) + vHzz);
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdGatherBendingBackward

--- a/lean/Cloth/SlangCodegen/VbdGatherSpringBackward.lean
+++ b/lean/Cloth/SlangCodegen/VbdGatherSpringBackward.lean
@@ -1,0 +1,136 @@
+import LeanSlang
+
+/-!
+# `Cloth.SlangCodegen.VbdGatherSpringBackward` — adjoint of vbd_gather_spring (PR-G continued)
+
+Backward kernel for `vbd_gather_spring`. The forward gathers
+per-spring outputs into per-vertex scratch with a sign flip on
+endpoint b:
+
+  for v in verts:
+    for (c, r) in vertSpring-CSR[v]:
+      sign = 1 − 2·r                            -- +1 (p1) or −1 (p2)
+      g_v        += sign · springGradA[c]
+      H_v_diag   += springHessScalar[c]         -- no sign flip
+
+Springs have K=2 with sign flip on b. The adjoint dispatches one
+thread per spring c. Each thread reads both endpoint cotangents and
+fans them out with the correct signs:
+
+  per c:
+    p1 = springP1Idx[c],  p2 = springP2Idx[c]
+    vg_p1 = v_g[p1],      vg_p2 = v_g[p2]
+    v_springGradA[c] = vg_p1 − vg_p2           -- +1·p1  +  (−1)·p2
+
+  Hessian fan-out: the forward writes springHessScalar[c] into the
+  three diagonal entries of BOTH endpoints (no sign flip on the
+  Hessian), so the adjoint sums the trace contributions from both:
+
+    v_springHess[c] = (v_H_xx[p1] + v_H_yy[p1] + v_H_zz[p1])
+                    + (v_H_xx[p2] + v_H_yy[p2] + v_H_zz[p2])
+
+Off-diagonal entries of v_H don't flow back through the gather —
+the forward only touches diagonals.
+
+Bindings (set 0):
+
+  0  StructuredBuffer<uint>     springP1Idx       length = N_springs
+  1  StructuredBuffer<uint>     springP2Idx       length = N_springs
+  2  StructuredBuffer<float3>   v_g               length = N_verts (cotangent)
+  3  StructuredBuffer<float>    v_H               length = 6·N_verts (cotangent, sym 3x3)
+  4  RWStructuredBuffer<float3> v_springGradA     length = N_springs (output)
+  5  RWStructuredBuffer<float>  v_springHess      length = N_springs (output)
+-/
+
+namespace Cloth.SlangCodegen.VbdGatherSpringBackward
+
+open LeanSlang
+
+private def f3 : SlangType := .vec .float 3
+private def u  : SlangType := .scalar .uint
+private def f  : SlangType := .scalar .float
+
+private def bnd (n : Nat) (name : String) (t : SlangType) : SlangBinding :=
+  { name := name, type := t, semantic := Semantic.none
+  , binding := some n, space := some 0 }
+
+private def body : List SlangStmt :=
+  [ .declInit u  "c"      (.member (.var "tid") "x")
+  , .declInit u  "p1"     (.index (.var "springP1Idx") (.var "c"))
+  , .declInit u  "p2"     (.index (.var "springP2Idx") (.var "c"))
+  , .declInit u  "hb1"    (.bin "*" (.litUint 6) (.var "p1"))
+  , .declInit u  "hb2"    (.bin "*" (.litUint 6) (.var "p2"))
+  , .declInit f3 "vg1"    (.index (.var "v_g") (.var "p1"))
+  , .declInit f3 "vg2"    (.index (.var "v_g") (.var "p2"))
+  , .declInit f  "vH1xx"  (.index (.var "v_H") (.var "hb1"))
+  , .declInit f  "vH1yy"  (.index (.var "v_H") (.bin "+" (.var "hb1") (.litUint 3)))
+  , .declInit f  "vH1zz"  (.index (.var "v_H") (.bin "+" (.var "hb1") (.litUint 5)))
+  , .declInit f  "vH2xx"  (.index (.var "v_H") (.var "hb2"))
+  , .declInit f  "vH2yy"  (.index (.var "v_H") (.bin "+" (.var "hb2") (.litUint 3)))
+  , .declInit f  "vH2zz"  (.index (.var "v_H") (.bin "+" (.var "hb2") (.litUint 5)))
+  , .assign (.index (.var "v_springGradA") (.var "c"))
+      (.call "float3"
+        [ .bin "-" (.member (.var "vg1") "x") (.member (.var "vg2") "x")
+        , .bin "-" (.member (.var "vg1") "y") (.member (.var "vg2") "y")
+        , .bin "-" (.member (.var "vg1") "z") (.member (.var "vg2") "z") ])
+  , .assign (.index (.var "v_springHess") (.var "c"))
+      (.bin "+"
+        (.bin "+" (.bin "+" (.var "vH1xx") (.var "vH1yy")) (.var "vH1zz"))
+        (.bin "+" (.bin "+" (.var "vH2xx") (.var "vH2yy")) (.var "vH2zz")))
+  ]
+
+def shader : SlangShaderModule :=
+  { globals :=
+      [ bnd 0 "springP1Idx"   (.roBuf u)
+      , bnd 1 "springP2Idx"   (.roBuf u)
+      , bnd 2 "v_g"           (.roBuf f3)
+      , bnd 3 "v_H"           (.roBuf f)
+      , bnd 4 "v_springGradA" (.rwBuf f3)
+      , bnd 5 "v_springHess"  (.rwBuf f)
+      ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [{ name := "tid", type := .vec .uint 3
+                 , semantic := Semantic.svDispatchThreadId
+                 , binding := none, space := none }]
+      body   := body
+    }] }
+
+def expected : String :=
+"[[vk::binding(0, 0)]]
+StructuredBuffer<uint> springP1Idx;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> springP2Idx;
+[[vk::binding(2, 0)]]
+StructuredBuffer<float3> v_g;
+[[vk::binding(3, 0)]]
+StructuredBuffer<float> v_H;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<float3> v_springGradA;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<float> v_springHess;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint c = tid.x;
+  uint p1 = springP1Idx[c];
+  uint p2 = springP2Idx[c];
+  uint hb1 = (6u * p1);
+  uint hb2 = (6u * p2);
+  float3 vg1 = v_g[p1];
+  float3 vg2 = v_g[p2];
+  float vH1xx = v_H[hb1];
+  float vH1yy = v_H[(hb1 + 3u)];
+  float vH1zz = v_H[(hb1 + 5u)];
+  float vH2xx = v_H[hb2];
+  float vH2yy = v_H[(hb2 + 3u)];
+  float vH2zz = v_H[(hb2 + 5u)];
+  v_springGradA[c] = float3((vg1.x - vg2.x), (vg1.y - vg2.y), (vg1.z - vg2.z));
+  v_springHess[c] = (((vH1xx + vH1yy) + vH1zz) + ((vH2xx + vH2yy) + vH2zz));
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Cloth.SlangCodegen.VbdGatherSpringBackward

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -52,6 +52,9 @@ private def kernels : List (String × SlangShaderModule) :=
   , ("vbd_solve_apply_backward", VbdSolveApplyBackward.shader)
   , ("vbd_init_backward", VbdInitBackward.shader)
   , ("vbd_gather_triangle_backward", VbdGatherTriangleBackward.shader)
+  , ("vbd_gather_attachment_backward", VbdGatherAttachmentBackward.shader)
+  , ("vbd_gather_bending_backward", VbdGatherBendingBackward.shader)
+  , ("vbd_gather_spring_backward", VbdGatherSpringBackward.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,7 @@ LEAN_DIR   := $(REPO_ROOT)/lean
 
 # Metal kernels we benchmark on real GPU (Tier-3 perf). The full slang →
 # air → metallib pipeline runs once per kernel listed here.
-METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force vbd_init vbd_solve_apply vbd_gather_spring vbd_gather_attachment vbd_gather_triangle vbd_gather_bending attachment_force_al attachment_dual_update triangle_membrane_force_al triangle_membrane_dual_update triangle_bending_force_al triangle_bending_dual_update self_collision_scan vbd_solve_apply_backward vbd_init_backward vbd_gather_triangle_backward
+METAL_KERNELS := spring_project saxpby spmv dot_reduce_serial dot_reduce assemble_b cg_alpha cg_beta saxpby_indirect spmv_df32 saxpby_indirect_df32 spring_force vbd_init vbd_solve_apply vbd_gather_spring vbd_gather_attachment vbd_gather_triangle vbd_gather_bending attachment_force_al attachment_dual_update triangle_membrane_force_al triangle_membrane_dual_update triangle_bending_force_al triangle_bending_dual_update self_collision_scan vbd_solve_apply_backward vbd_init_backward vbd_gather_triangle_backward vbd_gather_attachment_backward vbd_gather_bending_backward vbd_gather_spring_backward
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 CXX        ?= clang++


### PR DESCRIPTION
## Summary

Three scatter-of-cotangent backward kernels for the AVBD gather set, completing the gather-backward portion of PR-G. Adds to the chain after #106 (solve_apply), #107 (init), #108 (gather_triangle).

| kernel | dispatch | arity | output |
|---|---|---|---|
| \`VbdGatherAttachmentBackward\` | per-attachment | K=1 | v_attachGradV, v_attachHessScalar |
| \`VbdGatherBendingBackward\` | per-slot (4·nBend) | K=4 | v_bendGrad, v_bendHessScalar |
| \`VbdGatherSpringBackward\` | per-spring | K=2 (with sign flip) | v_springGradA, v_springHess |

Spring is the most interesting: forward applies +1/−1 to the two endpoints' gradient contributions, so the backward gradient is \`v_g[p1] − v_g[p2]\`. Hessian fans out additively to both endpoints with no sign.

## Adjoint chain status

- ✓ vbd_solve_apply (#106)
- ✓ vbd_init (#107)
- ✓ vbd_gather_triangle (#108)
- ✓ vbd_gather_attachment (this PR)
- ✓ vbd_gather_bending (this PR)
- ✓ vbd_gather_spring (this PR)
- ◯ spring_force backward
- ◯ attachment_force_al backward
- ◯ triangle_bending_force_al backward
- ◯ triangle_membrane_force_al backward — the polar-decomposition SVD adjoint, the genuinely hard one

## Test plan

- [x] All three Lean modules build with native_decide green first-try.
- [x] \`lake exe emit_shaders\` writes the three new \`.slang\` files.
- [x] slangc → metal → metallib pipeline clean for all three.