### PR TITLE
CHI-14 Brick B: density/mass cotangent + LBFGSpp mass-fit MVP

### DIFF
--- a/src/code/slang_solver/AvbdSolver.h
+++ b/src/code/slang_solver/AvbdSolver.h
@@ -235,6 +235,11 @@ public:
     // Each accessor is safe to call after stepBackward() succeeds; the
     // corresponding constraint type must have been uploaded.
     void readPositionsGrad(std::vector<float>& out) const;
+    // Per-vertex ∂L/∂mass — emitted by `vbd_init_backward` (PR-G Brick B,
+    // CHI-14). The inertial term is the only place mass appears in the
+    // forward, so this is the full density / mass gradient. Vector of
+    // length `nVerts`. Empty if backward not run.
+    void readMassGrad(std::vector<float>& mass_grad) const;
     void readSpringGrad(std::vector<float>& restLen_grad,
                         std::vector<float>& stiff_grad) const;
     void readAttachGrad(std::vector<float>& fixedPos_grad,

--- a/src/code/slang_solver/AvbdSolver.mm
+++ b/src/code/slang_solver/AvbdSolver.mm
@@ -44,6 +44,13 @@ struct VbdSolveApplyParams {
     uint32_t colorOffset;
 };
 
+// Matches the VbdInitBackwardParams struct emitted by
+// Cloth.SlangCodegen.VbdInitBackward (the adjoint of vbd_init's
+// inertial seed; needs invHSquared to scale w = m_v · invHSq).
+struct VbdInitBackwardParams {
+    float invHSquared;
+};
+
 struct AvbdSolver::Impl {
     id<MTLDevice>               device   = nil;
     id<MTLCommandQueue>         queue    = nil;
@@ -204,6 +211,22 @@ struct AvbdSolver::Impl {
     // after — having a dedicated buffer avoids racing with
     // solve_apply_backward which reads bufHScratch.)
     id<MTLBuffer> bufHScratchJunk     = nil; // 6 floats per vert
+
+    // PR-G Brick B (CHI-14): per-vertex cotangents from vbd_init_backward.
+    // The init kernel writes the inertial seed g_v = w·(x_v − y_v),
+    // H_v = w·I where w = m_v · invHSquared, so the inertial path is the
+    // only place where density / mass flows. Outputs:
+    //   v_x_init   — cotangent on x via the init g term (3-vec per vert).
+    //                Added to bufVPositionsGrad on the CPU after dispatch.
+    //   v_y_init   — cotangent on predicted (3-vec per vert). Unused for
+    //                single-step inverse design; allocated as a junk
+    //                write target.
+    //   v_mass     — ∂L/∂m_v (scalar per vert). Read via readMassGrad.
+    id<MTLBuffer> bufVPositionsInit   = nil;
+    id<MTLBuffer> bufVPredictedJunk   = nil;
+    id<MTLBuffer> bufVMass            = nil;
+    // VbdInitBackwardParams { invHSquared }; one float, packed via setBytes.
+    // No buffer needed since setBytes can carry small constant buffers.
 
     // Per-constraint backward cotangents.
     id<MTLBuffer> bufVSpringGradA     = nil; // padded float3 per spring   (input from gather bwd)
@@ -1183,6 +1206,9 @@ void ensureBackwardBuffers_impl(Impl* impl) {
     impl->bufDeltaX         = [impl->device newBufferWithLength:bytesVec3Padded_v options:opts];
     impl->bufVPositionsGrad = [impl->device newBufferWithLength:bytesVec3Padded_v options:opts];
     impl->bufHScratchJunk   = [impl->device newBufferWithLength:bytesHess_v       options:opts];
+    impl->bufVPositionsInit = [impl->device newBufferWithLength:bytesVec3Padded_v options:opts];
+    impl->bufVPredictedJunk = [impl->device newBufferWithLength:bytesVec3Padded_v options:opts];
+    impl->bufVMass          = [impl->device newBufferWithLength:nV * sizeof(float) options:opts];
 
     if (impl->nSprings > 0) {
         const uint32_t n = impl->nSprings;
@@ -1393,6 +1419,26 @@ int AvbdSolver::stepBackward(const float* v_positions_loss) {
        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
     }
 
+    // ---- 6b. vbd_init_backward — inertial path. Writes per-vertex
+    //          cotangents on positions (v_x_init), predicted (v_y, junk),
+    //          and mass (v_mass). Reads bufVG / bufVH from solve_apply_bwd.
+    //          PR-G Brick B (CHI-14) — density gradient flows only here.
+    if (impl_->psoInitBwd) {
+        [enc setComputePipelineState:impl_->psoInitBwd];
+        [enc setBuffer:impl_->bufPositionsPreStep offset:0 atIndex:0];
+        [enc setBuffer:impl_->bufPredicted        offset:0 atIndex:1];
+        [enc setBuffer:impl_->bufMass             offset:0 atIndex:2];
+        [enc setBuffer:impl_->bufVG               offset:0 atIndex:3];
+        [enc setBuffer:impl_->bufVH               offset:0 atIndex:4];
+        [enc setBuffer:impl_->bufVPositionsInit   offset:0 atIndex:5];
+        [enc setBuffer:impl_->bufVPredictedJunk   offset:0 atIndex:6];
+        [enc setBuffer:impl_->bufVMass            offset:0 atIndex:7];
+        VbdInitBackwardParams ibp{impl_->invHSqCached};
+        [enc setBytes:&ibp length:sizeof(ibp) atIndex:8];
+        [enc dispatchThreads:MTLSizeMake(nV, 1, 1)
+       threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+    }
+
     // ---- 7. Accumulate per-constraint position cotangents into v_positions
     //         by RE-USING the forward gather kernels. They additively
     //         scatter springGradA / triGrad / bendGrad into the per-vertex
@@ -1460,6 +1506,19 @@ int AvbdSolver::stepBackward(const float* v_positions_loss) {
     [cb commit];
     [cb waitUntilCompleted];
 
+    // PR-G Brick B (CHI-14): add the inertial path's position cotangent
+    // to bufVPositionsGrad. CPU saxpby is fine — nV·3 float adds, fully
+    // bandwidth-bound, dwarfed by the GPU dispatches we just waited on.
+    if (impl_->psoInitBwd) {
+        float* pg       = static_cast<float*>(impl_->bufVPositionsGrad.contents);
+        const float* pi = static_cast<const float*>(impl_->bufVPositionsInit.contents);
+        for (uint32_t v = 0; v < nV; ++v) {
+            pg[4*v + 0] += pi[4*v + 0];
+            pg[4*v + 1] += pi[4*v + 1];
+            pg[4*v + 2] += pi[4*v + 2];
+        }
+    }
+
     return 0;
 }
 
@@ -1469,6 +1528,17 @@ void AvbdSolver::readPositionsGrad(std::vector<float>& out) const {
         return;
     }
     readVec3Padded(out, impl_->bufVPositionsGrad, impl_->nVerts);
+}
+
+void AvbdSolver::readMassGrad(std::vector<float>& mass_grad) const {
+    if (!ok() || !impl_->meshReady || !impl_->backwardReady ||
+        !impl_->bufVMass) {
+        mass_grad.clear();
+        return;
+    }
+    const uint32_t n = impl_->nVerts;
+    mass_grad.assign(n, 0.0f);
+    std::memcpy(mass_grad.data(), impl_->bufVMass.contents, n * sizeof(float));
 }
 
 void AvbdSolver::readSpringGrad(std::vector<float>& restLen_grad,

--- a/src/code/slang_solver/Makefile
+++ b/src/code/slang_solver/Makefile
@@ -19,7 +19,7 @@ INCLUDES   := -I.
 EIGEN_INC := $(REPO_ROOT)/external/eigen
 LBFGSPP_INC := $(REPO_ROOT)/external/LBFGSpp/include
 
-.PHONY: test test-avbd test-inverse-design clean
+.PHONY: test test-avbd test-inverse-design test-inverse-design-mass clean
 
 test: $(BUILD)/test_metal_cg_solver
 	@echo "=== Smoke test of the wrapper (no Eigen, no DiffCloth)."
@@ -32,6 +32,10 @@ test-avbd: $(BUILD)/test_avbd_solver
 test-inverse-design: $(BUILD)/test_avbd_inverse_design
 	@echo "=== Inverse-design MVP (CHI-14 Brick A): LBFGSpp fits k via AVBD adjoint."
 	$(BUILD)/test_avbd_inverse_design $(METALLIB_DIR)
+
+test-inverse-design-mass: $(BUILD)/test_avbd_inverse_design_mass
+	@echo "=== Inverse-design (CHI-14 Brick B): LBFGSpp fits mass via vbd_init_backward."
+	$(BUILD)/test_avbd_inverse_design_mass $(METALLIB_DIR)
 
 $(BUILD)/test_metal_cg_solver: test_metal_cg_solver.cpp \
                                 $(BUILD)/MetalCGSolver.o
@@ -47,6 +51,12 @@ $(BUILD)/test_avbd_solver: test_avbd_solver.cpp $(BUILD)/AvbdSolver.o
 	  -o $@ $^
 
 $(BUILD)/test_avbd_inverse_design: test_avbd_inverse_design.cpp $(BUILD)/AvbdSolver.o
+	@mkdir -p $(BUILD)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -I$(EIGEN_INC) -I$(LBFGSPP_INC) \
+	  -framework Metal -framework Foundation \
+	  -o $@ $^
+
+$(BUILD)/test_avbd_inverse_design_mass: test_avbd_inverse_design_mass.cpp $(BUILD)/AvbdSolver.o
 	@mkdir -p $(BUILD)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -I$(EIGEN_INC) -I$(LBFGSPP_INC) \
 	  -framework Metal -framework Foundation \

--- a/src/code/slang_solver/test_avbd_inverse_design_mass.cpp
+++ b/src/code/slang_solver/test_avbd_inverse_design_mass.cpp
@@ -1,0 +1,175 @@
+// Density / mass inverse-design MVP (CHI-14 Brick B).
+//
+// Sibling of test_avbd_inverse_design.cpp (which fits k_spring). This
+// one fits a per-vertex MASS to match a target post-step position,
+// using the v_mass cotangent emitted by `vbd_init_backward` and routed
+// through `AvbdSolver::stepBackward` + `readMassGrad`.
+//
+// Setup. Same 2-vert / 1-spring / 1-attach fixture as the stiffness
+// MVP. Vertex v1 is the free DoF; varying its mass m_v1 changes the
+// inertial weight w = m·invHSq → changes the per-vertex Hessian
+// → changes Δx → changes final position. Spring stiffness held fixed
+// at k = 4.0 (no longer the optimized variable).
+//
+// LBFGSpp drives a SCALAR x = m_v1, starting at 0.5 with bounds
+// [0.05, 10]. Ground truth m_v1 = 2.0. Expected: convergence within
+// 1e-3 relative error in <10 fn evals.
+
+#include "AvbdSolver.h"
+
+#include <Eigen/Core>
+#include <LBFGSB.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using VecXd = Eigen::VectorXd;
+
+namespace {
+
+struct Mesh {
+    static constexpr uint32_t N = 2;
+    static constexpr float L  = 1.0f;
+    static constexpr float K_SPRING = 4.0f;
+    static constexpr float K_ATTACH = 1000.0f;
+    static constexpr float INV_HSQ  = 100.0f;
+    static constexpr float M_V0     = 1.0f;   // v0 is pinned; mass is irrelevant
+    static constexpr float V1_PRED_X = 1.9f;
+
+    std::vector<float> positions = {0.0f, 0.0f, 0.0f,  2.0f, 0.0f, 0.0f};
+    std::vector<float> predicted = {0.0f, 0.0f, 0.0f,  V1_PRED_X, 0.0f, 0.0f};
+
+    std::vector<uint32_t> spP1 = {1u};
+    std::vector<uint32_t> spP2 = {0u};
+    std::vector<float>    spLen= {L};
+    std::vector<float>    spK  = {K_SPRING};
+
+    std::vector<uint32_t> atVert  = {0u};
+    std::vector<float>    atFixed = {0.0f, 0.0f, 0.0f};
+    std::vector<float>    atK     = {K_ATTACH};
+};
+
+void run_forward(cloth::AvbdSolver& solver, const Mesh& m, float m_v1,
+                 std::vector<float>& positions_out) {
+    const float mass[Mesh::N] = {Mesh::M_V0, m_v1};
+    solver.setupMesh(Mesh::N, m.positions.data(), m.predicted.data(), mass,
+                     Mesh::INV_HSQ);
+    solver.uploadSprings(1u, m.spP1.data(), m.spP2.data(), m.spLen.data(),
+                         m.spK.data());
+    solver.uploadAttachments(1u, m.atVert.data(), m.atFixed.data(), m.atK.data());
+    if (solver.step() != 0) {
+        std::fprintf(stderr, "test_avbd_inverse_design_mass: forward failed\n");
+        std::exit(1);
+    }
+    solver.readPositions(positions_out);
+}
+
+class MassProblem {
+public:
+    MassProblem(cloth::AvbdSolver& solver, const Mesh& mesh,
+                const std::vector<float>& target)
+        : solver_(solver), mesh_(mesh), target_(target) {}
+
+    int iters = 0;
+
+    double operator()(const VecXd& x, VecXd& grad) {
+        ++iters;
+        const float m_v1 = static_cast<float>(x[0]);
+
+        std::vector<float> pos;
+        run_forward(solver_, mesh_, m_v1, pos);
+
+        double loss = 0.0;
+        std::vector<float> v_loss(3 * Mesh::N, 0.0f);
+        for (uint32_t v = 0; v < Mesh::N; ++v) {
+            for (int c = 0; c < 3; ++c) {
+                const double diff = double(pos[3*v+c]) - double(target_[3*v+c]);
+                loss += 0.5 * diff * diff;
+                v_loss[3*v+c] = static_cast<float>(diff);
+            }
+        }
+
+        if (solver_.stepBackward(v_loss.data()) != 0) {
+            std::fprintf(stderr, "stepBackward failed\n");
+            std::exit(1);
+        }
+        std::vector<float> dMass;
+        solver_.readMassGrad(dMass);
+        // ∂L/∂m_v1 — gradient of loss w.r.t. v1's mass.
+        grad[0] = double(dMass[1]);
+
+        std::printf("  iter %2d:  m=%.6f  loss=%.6g  ∂L/∂m=%.6g\n",
+                    iters, x[0], loss, grad[0]);
+        return loss;
+    }
+
+private:
+    cloth::AvbdSolver& solver_;
+    const Mesh& mesh_;
+    const std::vector<float>& target_;
+};
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <metallib_dir>\n", argv[0]);
+        return 2;
+    }
+    cloth::AvbdSolver solver(argv[1]);
+    if (!solver.ok()) {
+        std::fprintf(stderr, "construction failed\n");
+        return 1;
+    }
+
+    const Mesh mesh;
+    constexpr double M_GT      = 2.0;
+    constexpr double M_INITIAL = 0.5;
+    constexpr double M_LO = 0.05, M_HI = 10.0;
+
+    std::vector<float> target;
+    run_forward(solver, mesh, static_cast<float>(M_GT), target);
+    std::printf("Ground truth: m_v1 = %.4f → x_v1 = (%.6f, %.6f, %.6f)\n",
+                M_GT, target[3], target[4], target[5]);
+
+    LBFGSpp::LBFGSBParam<double> param;
+    param.epsilon = 1e-8;
+    param.epsilon_rel = 1e-8;
+    param.delta = 1e-12;
+    param.past = 1;
+    param.max_iterations = 50;
+    param.max_linesearch = 40;
+    LBFGSpp::LBFGSBSolver<double> lbfgs(param);
+
+    MassProblem fn(solver, mesh, target);
+    VecXd x(1);  x[0] = M_INITIAL;
+    VecXd lb(1); lb[0] = M_LO;
+    VecXd ub(1); ub[0] = M_HI;
+
+    double fx = 0.0;
+    int niter = 0;
+    try {
+        niter = lbfgs.minimize(fn, x, fx, lb, ub);
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "L-BFGS-B threw: %s\n", e.what());
+        return 1;
+    }
+
+    std::printf("L-BFGS-B converged in %d iters (%d fn evals)\n", niter, fn.iters);
+    std::printf("  m_recovered = %.6f   (ground truth %.6f)\n", x[0], M_GT);
+    std::printf("  final loss  = %.6g\n", fx);
+
+    const double m_err = std::fabs(x[0] - M_GT) / M_GT;
+    constexpr double M_TOL = 1e-3;
+    if (m_err > M_TOL) {
+        std::fprintf(stderr,
+            "test_avbd_inverse_design_mass: FAIL — m %.6f vs gt %.6f, "
+            "rel err %.4g > tol %.4g\n", x[0], M_GT, m_err, M_TOL);
+        return 1;
+    }
+    std::printf("test_avbd_inverse_design_mass: OK (rel err %.3g < tol %.3g)\n",
+                m_err, M_TOL);
+    return 0;
+}


### PR DESCRIPTION
Second brick of [CHI-14](https://linear.app/chibifire/issue/CHI-14). Wires `vbd_init_backward` into `AvbdSolver::stepBackward` so the inertial path emits both the position cotangent on x (additively folded into the per-constraint contributions) and the per-vertex mass cotangent. The forward's inertial term \\(g_v = w(x-y),\\ H_v = wI\\) with \\(w = m_v \\cdot \\text{invHSq}\\) is the only place density flows, so this closes the density gradient.

## Changes

`AvbdSolver.{h,mm}`:
- New `Impl` buffers: `bufVPositionsInit`, `bufVPredictedJunk`, `bufVMass`.
- `VbdInitBackwardParams { invHSquared }` setBytes payload.
- `stepBackward` dispatches `psoInitBwd` after the gather backwards, reading `bufVG`/`bufVH` (from `solve_apply_backward`) and writing `v_x_init` / `v_y_junk` / `v_mass`.
- After encoder completion, a CPU saxpby folds `v_x_init` into `bufVPositionsGrad`.
- New `readMassGrad` accessor.

New inverse-design test: `src/code/slang_solver/test_avbd_inverse_design_mass.cpp` — sibling of the stiffness MVP, fits a SCALAR `m_v1` via LBFGSpp using only the `v_mass` cotangent.

## Result

```
Ground truth: m_v1 = 2.0  ->  x_v1 = (1.882353, 0, 0)
  iter  1: m=0.500  loss=1.20e-3   dL/dm=-6.05e-3
  iter  2: m=1.500  loss=1.64e-5   dL/dm=-8.70e-5
  iter  8: m=1.994  loss=1.21e-9   dL/dm=-4.28e-7
  iter  9: m=1.999  loss=2.84e-12  dL/dm=-2.06e-8
  iter 10: m=2.000  loss=0         dL/dm=0      <-- converged

L-BFGS-B converged in 8 iters (10 fn evals)
  m_recovered = 1.999999   (ground truth 2.000000)
  final loss  = 0
test_avbd_inverse_design_mass: OK (rel err 6.31e-07 < tol 0.001)
```

LBFGSpp converges in 8 iters / 10 fn evals; m recovered to **6.3e-7 relative error** with final loss exactly 0.

Stiffness MVP (`test_avbd_inverse_design` from #113) still passes unchanged.

## Build / run

```
make -C src/code/slang_solver test-inverse-design       # stiffness fit
make -C src/code/slang_solver test-inverse-design-mass  # mass fit
```

## Next CHI-14 bricks

- **C**: `Simulation::stepBackwardAvbd` shim — translates per-constraint AVBD cotangents into DiffCloth's `BackwardInformation`.
- **D**: AVBD-backed `runBackwardTask` (env gate `USE_AVBD_BWD=1`).
- **E**: dress drape inverse-design validation.