### PR TITLE
CHI-14 Brick E: USE_AVBD_BWD env gate — closes the AVBD inverse-design path

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -4875,6 +4875,20 @@ std::vector<Simulation::BackwardInformation> Simulation::runBackwardTask(
 				forwardRecords.size()); // FORWARD_STEPS = forwardRecords.size()) - 1
 	}
 
+	// CHI-14 Brick E: env-gate to swap PD adjoint for AVBD adjoint.
+	// USE_AVBD_BWD=1 routes per-step gradient through
+	// `stepBackwardAvbd` (Brick D) instead of `stepBackward`. Param
+	// gradients are accumulated across steps host-side here since the
+	// AVBD shim is stateless (does not take a `gradient_new`
+	// accumulator like the PD path does). Requires that the forward
+	// was driven by AVBD (`sysMat[0].avbd` set up).
+	const bool useAvbdBwd = (std::getenv("USE_AVBD_BWD") != nullptr) &&
+			!sysMat.empty() && sysMat[0].avbd && sysMat[0].avbd->ok();
+	if (useAvbdBwd) {
+		std::printf("[avbd-bwd] USE_AVBD_BWD=1 — routing backward through "
+					"Simulation::stepBackwardAvbd\n");
+	}
+
 	std::printf("backward started...");
 	for (int idx = FORWARD_STEPS; idx >= 1; idx--) {
 		if (idx % 50 == 0) {
@@ -4889,9 +4903,33 @@ std::vector<Simulation::BackwardInformation> Simulation::runBackwardTask(
 
 		calculateLossAndGradient(lossType, lossInfo, dL_dxinit, dL_dvinit, idx - 1,
 				false);
-		// backward from [x,v]_{idx} --> [x,v]_{idx-1}, calculate dL/dx_{idx-1}
-		derivative = stepBackward(taskConfiguration, derivative, record,
-				(idx - 1) == 0, dL_dxinit, dL_dvinit);
+
+		if (useAvbdBwd) {
+			// Upstream cotangent for this step = accumulated dL/dx
+			// from later steps + any per-step loss-grad contribution.
+			VecXd dL_dx_in = derivative.dL_dx + dL_dxinit;
+			BackwardInformation avbdRet =
+					stepBackwardAvbd(taskConfiguration, dL_dx_in);
+			// Accumulate per-type stiffness, density, anchor cotangents.
+			for (int t = 0; t < Constraint::CONSTRAINT_NUM && t < 4; ++t) {
+				avbdRet.dL_dk_pertype[t] += derivative.dL_dk_pertype[t];
+			}
+			avbdRet.dL_ddensity += derivative.dL_ddensity;
+			if (avbdRet.dL_dxfixed_accum.rows() ==
+					derivative.dL_dxfixed_accum.rows()) {
+				avbdRet.dL_dxfixed_accum =
+						avbdRet.dL_dxfixed + derivative.dL_dxfixed_accum;
+			}
+			avbdRet.loss = derivative.loss;
+			// AVBD doesn't compute dL_dv (velocity cotangent); set to
+			// zero so downstream consumers see a defined value.
+			avbdRet.dL_dv = VecXd::Zero(3 * particles.size());
+			derivative = avbdRet;
+		} else {
+			// backward from [x,v]_{idx} --> [x,v]_{idx-1}, calculate dL/dx_{idx-1}
+			derivative = stepBackward(taskConfiguration, derivative, record,
+					(idx - 1) == 0, dL_dxinit, dL_dvinit);
+		}
 		fullBackwardRecords.emplace_back(derivative);
 	}
 	std::printf("finished...\n");


### PR DESCRIPTION
Final brick of [CHI-14](https://linear.app/chibifire/issue/CHI-14). Env-gate at the per-step adjoint dispatch inside \`Simulation::runBackwardTask\`. \`USE_AVBD_BWD=1\` swaps PD's \`stepBackward\` for \`stepBackwardAvbd\` (Brick D), letting inverse-design loops drive optimisation through AVBD's analytic adjoint end-to-end.

## What lands

Per-step accumulation is host-side: the AVBD shim is stateless (no \`gradient_new\` accumulator like PD's path), so this loop manually accumulates per-type stiffness, density, and anchor cotangents across steps. Loss carried forward; \`dL_dv\` set to zero (AVBD doesn't compute velocity cotangent yet).

Gating conditions: \`USE_AVBD_BWD\` set AND \`sysMat[0].avbd\` is constructed AND \`ok()\`. Falls back silently to PD if any condition fails.

## End-to-end smoke

```
$ USE_AVBD_BWD=1 ./tool_cloth_dynamics 1 -demo sphere -mode optimize -seed 0
AvbdSolver: 17 forward kernels + 10/10 backward kernels loaded ...
forward started...0..[avbd-shadow] step 1 ... drift_max=3.00e-04 ...
finished...init
[avbd-bwd] USE_AVBD_BWD=1 -- routing backward through Simulation::stepBackwardAvbd
backward started...340..320..300..280..260..240..220..200..180..160..140..120..100..80..60..40..20..finished
Optimization progress is saved to: rotating_sphere-randseed-0-...
```

All 350 backward steps complete on sphere demo, no NaN. LBFGS-B proceeds to iter 1.

## CHI-14 Bricks A–E summary (all on main)

| Brick | PR | What |
|---|---|---|
| A | #113 | Standalone stiffness inverse-design MVP via LBFGSpp |
| B | #114 | Density / mass cotangent via \`vbd_init_backward\` |
| C | #115 | \`AvbdBackwardShim\` per-constraint → per-type aggregator |
| D | #116 | \`Simulation::stepBackwardAvbd\` DiffCloth-side hook |
| E | this | \`USE_AVBD_BWD=1\` env gate in \`runBackwardTask\` |

CHI-14 is now fully wired. DiffCloth's L-BFGS-B inverse-design loop can drive parameter optimisation entirely through AVBD's analytic adjoint instead of PD's.

## Follow-ups (out of CHI-14 scope, candidate new issues)

- Multi-iter chaining if a single AVBD step isn't enough convergence per DiffCloth timestep (Chen 2024's per-iter Jacobian).
- Velocity cotangent \`dL_dv\` (CHI-100 covers the forward damping; backward would mirror).
- \`DEMO_DRESS_TWIRL\` parity validation against PD baseline.