### PR TITLE
CHI-14 follow-up: spline gradient + BPTT clipping in stepBackwardAvbd (partial)

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -2432,7 +2432,8 @@ Simulation::stepBackward(Simulation::BackwardTaskInformation &taskInfo,
 //   dL_dconstantForceField, dL_dsplines, dL_dmu.
 Simulation::BackwardInformation Simulation::stepBackwardAvbd(
 		const Simulation::BackwardTaskInformation &taskInfo,
-		const VecXd &dL_dx_new) {
+		const VecXd &dL_dx_new,
+		const ForwardInformation &forwardInfo_new) {
 	Simulation::BackwardInformation ret = backwardInfoDefault;
 	const uint32_t nV = static_cast<uint32_t>(particles.size());
 
@@ -2503,6 +2504,40 @@ Simulation::BackwardInformation Simulation::stepBackwardAvbd(
 		for (size_t i = 0; i < g.dL_dxfixed.size(); ++i) {
 			ret.dL_dxfixed[static_cast<Eigen::Index>(i)] = g.dL_dxfixed[i];
 			ret.dL_dxfixed_accum[static_cast<Eigen::Index>(i)] = g.dL_dxfixed[i];
+		}
+	}
+
+	// CHI-14 Brick A1: spline control-point gradient.
+	// Each spline pins one fixed point; this step's ∂L/∂xfixed_pFixed
+	// chains through dxfixed_dcontrolPoints(t) to give the per-spline
+	// parameter gradient. Accumulated host-side across steps in the
+	// runBackwardTask loop.
+	if (taskInfo.dL_dcontrolPoints && !ret.dL_dsplines.empty()) {
+		for (size_t sysMatId = 0; sysMatId < sysMat.size() &&
+								   sysMatId < ret.dL_dsplines.size();
+				++sysMatId) {
+			std::vector<Spline> &splines =
+					sysMat[sysMatId].controlPointSplines;
+			for (size_t splineId = 0;
+					splineId < splines.size() &&
+					splineId < ret.dL_dsplines[sysMatId].size();
+					++splineId) {
+				Spline &s = splines[splineId];
+				const int pFixed = s.pFixed;
+				const size_t base = static_cast<size_t>(3 * pFixed);
+				if (base + 2 >= g.dL_dxfixed.size()) continue;
+				Vec3d slice;
+				slice << g.dL_dxfixed[base + 0],
+						 g.dL_dxfixed[base + 1],
+						 g.dL_dxfixed[base + 2];
+				MatXd dxfixed_dspline =
+						s.dxfixed_dcontrolPoints(forwardInfo_new.simDurartionFraction);
+				VecXd deltaGrad = dxfixed_dspline.transpose() * slice;
+				if (deltaGrad.rows() ==
+						ret.dL_dsplines[sysMatId][splineId].rows()) {
+					ret.dL_dsplines[sysMatId][splineId] += deltaGrad;
+				}
+			}
 		}
 	}
 
@@ -4908,8 +4943,23 @@ std::vector<Simulation::BackwardInformation> Simulation::runBackwardTask(
 			// Upstream cotangent for this step = accumulated dL/dx
 			// from later steps + any per-step loss-grad contribution.
 			VecXd dL_dx_in = derivative.dL_dx + dL_dxinit;
+			// Apply the same gradient clipping PD uses (Simulation.h:
+			// `gradientClippingThreshold` per vertex). Without this, the
+			// AVBD adjoint chain can amplify exponentially through long
+			// horizons (we saw ~2× per step on the hat demo's 400-step
+			// trajectory). Clamping the cotangent norm here is the
+			// canonical truncated-BPTT fix and matches what PD does
+			// at the top of `stepBackward`.
+			if (gradientClipping) {
+				const double maxNorm =
+						gradientClippingThreshold * particles.size();
+				const double n = dL_dx_in.norm();
+				if (n > maxNorm) {
+					dL_dx_in *= maxNorm / n;
+				}
+			}
 			BackwardInformation avbdRet =
-					stepBackwardAvbd(taskConfiguration, dL_dx_in);
+					stepBackwardAvbd(taskConfiguration, dL_dx_in, record);
 			// Accumulate per-type stiffness, density, anchor cotangents.
 			for (int t = 0; t < Constraint::CONSTRAINT_NUM && t < 4; ++t) {
 				avbdRet.dL_dk_pertype[t] += derivative.dL_dk_pertype[t];
@@ -4919,6 +4969,21 @@ std::vector<Simulation::BackwardInformation> Simulation::runBackwardTask(
 					derivative.dL_dxfixed_accum.rows()) {
 				avbdRet.dL_dxfixed_accum =
 						avbdRet.dL_dxfixed + derivative.dL_dxfixed_accum;
+			}
+			// Accumulate per-spline gradients across steps (the AVBD
+			// shim writes this step's contribution into avbdRet; sum
+			// with the carryover from later steps in `derivative`).
+			if (avbdRet.dL_dsplines.size() == derivative.dL_dsplines.size()) {
+				for (size_t s = 0; s < avbdRet.dL_dsplines.size(); ++s) {
+					for (size_t i = 0; i < avbdRet.dL_dsplines[s].size() &&
+									   i < derivative.dL_dsplines[s].size(); ++i) {
+						if (avbdRet.dL_dsplines[s][i].rows() ==
+								derivative.dL_dsplines[s][i].rows()) {
+							avbdRet.dL_dsplines[s][i] +=
+									derivative.dL_dsplines[s][i];
+						}
+					}
+				}
 			}
 			avbdRet.loss = derivative.loss;
 			// AVBD doesn't compute dL_dv (velocity cotangent); set to

--- a/src/code/simulation/Simulation.h
+++ b/src/code/simulation/Simulation.h
@@ -631,7 +631,8 @@ public:
 	// default values — AVBD doesn't currently parameterise these.
 	BackwardInformation stepBackwardAvbd(
 			const Simulation::BackwardTaskInformation &taskInfo,
-			const VecXd &dL_dx_new);
+			const VecXd &dL_dx_new,
+			const ForwardInformation &forwardInfo_new);
 
 	void resetForwardRecordsFromFolder(std::string subFolder) {
 		std::vector<Vec3d> modelPoints;


### PR DESCRIPTION
Partial-progress PR from sweeping all 5 demos under \`USE_AVBD_BWD=1\` and discovering 4 of 5 weren't actually exercising the AVBD adjoint path. Adds the missing spline-control-points gradient (hat/sock) and the gradient-clipping pass PD already has. **Does NOT close the demo-validation gap on its own** — the underlying single-iter-per-step AVBD adjoint is BPTT-unstable across the demos' 100–400-step horizons.

## What lands

1. \`Simulation::stepBackwardAvbd\` now takes \`ForwardInformation&\` (needed for \`simDurartionFraction\`) and emits the per-step spline-control-point gradient via \`Spline::dxfixed_dcontrolPoints(t).transpose() · dL_dxfixed.segment(3·pFixed, 3)\`. Matches PD's formulation.

2. \`runBackwardTask\` under \`USE_AVBD_BWD=1\` accumulates \`dL_dsplines\` across timesteps host-side (same pattern already used for \`dL_dk_pertype\` / \`dL_ddensity\`).

3. **Gradient clipping** on \`dL_dx_in\` before the adjoint call, matching PD's threshold (\`gradientClippingThreshold * particles.size()\`). Without this, the chain amplifies ~2× per step and overflows; we measured 0.68 → 205 in 18 backward steps on hat.

## Why this isn't enough

The per-step Jacobian of one AVBD outer iter has spectral radius ~√2 in some modes. 400 steps of backprop-through-time → 2^200× amplification. Clipping caps the magnitude but distorts the direction enough that LBFGS-B's line search can't find descent. The spline gradient math IS correct; the long-horizon chain is the problem.

Honest demo status with \`USE_AVBD_BWD=1\` after this PR:

| Demo | Optimized params | Outcome |
|---|---|---|
| sphere | \`dL_dmu\` (friction) | False pass — shim doesn't emit friction grad, LBFGS sees ‖∇‖≈0, quits at iter 1 |
| tshirt | \`dL_dfwind\` + stiffness + density | False pass — shim doesn't emit wind grad; stiffness/density grad alone insufficient |
| hat | splines (this PR adds this) | Line search fails — BPTT-clipped gradient direction not descent |
| sock | splines (this PR adds this) | Line search fails — same |
| dress | density + bending-k | Still NaNs at iter 2 — same BPTT |

## Standalone tests

All slang-solver-side tests still pass (\`test-backward-shim\`, \`test-inverse-design\`, \`test-inverse-design-mass\`, \`test-avbd\`). The bricks A–E foundation is intact.

## Follow-ups needed (will file as separate Linear issues)

- **Long-horizon adjoint stabilisation**: truncated BPTT (limit chain to ~10-20 steps) or IFT-based steady-state adjoint (one solve, no chaining). Either unlocks the demos.
- **Friction adjoint kernel** (sphere): new \`primitive_friction_backward\` slang kernel.
- **Wind cotangent**: expose \`bufVPredictedJunk\` → \`readPredictedGrad\`, chain through \`dpredicted/dwind\`.