### PR TITLE
CHI-118: AVBD resting-contact friction on relative velocity

### DIFF
--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -1942,6 +1942,7 @@ void Simulation::step() {
 		const bool s_avbdNoContact = (std::getenv("AVBD_NO_CONTACT") != nullptr);
 		if (!s_avbdNoContact) {
 			size_t projHits = 0;
+			size_t frictionHits = 0;
 			for (size_t i = 0; i < particles.size(); ++i) {
 				for (Primitive* p : primitives) {
 					if (!p) continue;
@@ -1949,27 +1950,46 @@ void Simulation::step() {
 					if (!p->isInContact(p->center, particles[i].pos,
 					                    particles[i].velocity, normal, dist, v_out))
 						continue;
-					if (dist >= 0.0) continue;  // surface or outside
-					particles[i].pos -= dist * normal;
-					const double vn = particles[i].velocity.dot(normal);
-					if (vn < 0) {
-						particles[i].velocity -= vn * normal;
-						// CHI-112: tangential friction damping. μ ∈ [0,1] —
-						// 0 = perfect slip, 1 = full stick. Approximation
-						// of Coulomb friction: scales tangent velocity by
-						// (1 − μ) instead of clamping to a force cone.
-						// Good enough for sphere demo's inverse design;
-						// gives a non-zero ∂trajectory/∂μ that LBFGS-B can
-						// optimise.
-						if (p->mu > 0.0) {
-							Vec3d v_tan = particles[i].velocity;
-							const double clip = std::min(1.0, p->mu);
-							particles[i].velocity = (1.0 - clip) * v_tan;
-						}
+					const bool penetrating = (dist < 0.0);
+					if (penetrating) {
+						particles[i].pos -= dist * normal;
 					}
-					++projHits;
+					// CHI-112 + CHI-118: contact response on RELATIVE
+					// velocity (cloth − primitive's surface velocity at
+					// contact, including rotation tangent). Single
+					// update that:
+					//   1. Zeros inward normal velocity of cloth (no
+					//      bounce off primitive).
+					//   2. Scales relative tangential velocity by (1 − μ)
+					//      for Coulomb-like friction.
+					// Applied at BOTH penetrating AND resting contacts
+					// (latter dominates the sphere demo — cloth drapes
+					// and stays at `dist ≈ 0`). The old `dist >= 0.0`
+					// skip meant friction never triggered for sphere;
+					// trajectory was invariant to μ.
+					//
+					// `v_out` from isInContact is the primitive's
+					// velocity at the contact point. For the rotating
+					// sphere, this carries the tangential rotation speed
+					// — friction has to act on cloth_velocity − v_out,
+					// not cloth_velocity alone, or the cloth gets pinned
+					// to a stationary surface instead of being carried
+					// by the rotation.
+					const Vec3d v_rel = particles[i].velocity - v_out;
+					const double vn = v_rel.dot(normal);
+					const Vec3d v_tan_rel = v_rel - vn * normal;
+					const double clip = std::min(1.0, std::max(0.0, p->mu));
+					const double vn_after = (vn < 0.0) ? 0.0 : vn;
+					const Vec3d v_rel_after =
+							(1.0 - clip) * v_tan_rel + vn_after * normal;
+					particles[i].velocity = v_rel_after + v_out;
+					if (p->mu > 0.0) ++frictionHits;
+					if (penetrating) ++projHits;
 				}
 			}
+			if (frictionHits > 0)
+				std::printf("[avbd-friction] step %zu applied %zu vert/primitive friction events\n",
+				            forwardRecords.size(), frictionHits);
 			if (projHits > 0)
 				std::printf("[avbd-contact] step %zu projected %zu vert/primitive penetrations\n",
 				            forwardRecords.size(), projHits);


### PR DESCRIPTION
Closes [CHI-118](https://linear.app/chibifire/issue/CHI-118). Two-part fix to AVBD's primitive-contact block:

1. **Drop `dist >= 0.0` skip** so resting contacts trigger friction. Before this PR, sphere demo recorded 0 friction events because all contacts were resting (cloth draped on sphere surface at `dist ≈ 0`); now it records 672/run.

2. **Operate on relative velocity** \`(cloth − primitive's v_out)\`. For the rotating sphere, v_out carries the tangential rotation speed — friction must act on relative motion, not absolute cloth velocity, or the cloth gets pinned to a stationary surface instead of being carried by rotation.

## Limitation (sphere demo still doesn't optimize μ)

Sphere loss stays at 0 across all seeds even with friction triggering. Reason: AVBD's velocity damping is applied AFTER the implicit solve, so it doesn't enter the per-vertex Hessian during constraint resolution. The cloth-vs-sphere force balance during the solve is insensitive to μ; only post-solve velocity is damped, which has weak influence on the next step's drape geometry.

For sphere inverse design to actually optimize μ, friction would need to be a constraint INSIDE the AVBD solve (a new force kernel) — a separate, larger piece of work. This PR is the structural fix (resting contacts now trigger, relative velocity is correct) that the follow-up would build on.

## Verification

| Check | Result |
|---|---|
| Standalone adjoint tests (4) | all pass |
| CHI-111 hat seed=7 (regression) | best 15.87 in 32 iters (unchanged) |
| Sphere `[avbd-friction]` events | 0 → **672/run** |
| Sphere loss | still 0 (post-solve damping insufficient) |

## Also

CHI-100 (AVBD velocity damping) verified already-implemented as `AVBD_DAMP` env-gate (Simulation.cpp:1245). Closing that issue too — no code change needed.