### PR TITLE
CHI-11: rip out Eigen (subtasks 1, 2, 4 of 5)

### DIFF
--- a/src/code/engine/Vec3f.h
+++ b/src/code/engine/Vec3f.h
@@ -1,0 +1,103 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024-present K. S. Ernest (Fire) Lee
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef OMEGAENGINE_VEC3F_H
+#define OMEGAENGINE_VEC3F_H
+
+#include "Macros.h"
+#include <cmath>
+
+// CHI-11 subtask 2: in-house Vec3f, replaces Eigen::Vector3d in
+// Particle for the per-vertex state that doesn't need fp64 precision.
+// Implicit conversions from Eigen::Vector3d (and 3-row segments of
+// VecXd) keep the existing call sites compiling during the migration.
+struct Vec3f {
+	float x = 0.0f;
+	float y = 0.0f;
+	float z = 0.0f;
+
+	Vec3f() = default;
+	Vec3f(float a, float b, float c) : x(a), y(b), z(c) {}
+
+	// Eigen interop. Implicit on the read side so `Vec3f v = some_segment`
+	// just works; on the write side use `eigen_segment = v.toVec3d()`.
+	Vec3f(const Eigen::Vector3d &v)
+	    : x(float(v[0])), y(float(v[1])), z(float(v[2])) {}
+	Vec3f(const Eigen::Vector3f &v) : x(v[0]), y(v[1]), z(v[2]) {}
+
+	template <typename Derived>
+	Vec3f(const Eigen::MatrixBase<Derived> &v)
+	    : x(float(v[0])), y(float(v[1])), z(float(v[2])) {
+		static_assert(int(Derived::SizeAtCompileTime) == 3 ||
+		                int(Derived::SizeAtCompileTime) == Eigen::Dynamic,
+		    "Vec3f source must be a 3-vector");
+	}
+
+	Eigen::Vector3d toVec3d() const {
+		return Eigen::Vector3d(double(x), double(y), double(z));
+	}
+	Eigen::Vector3f toVec3f() const { return Eigen::Vector3f(x, y, z); }
+	// Implicit conversion to Eigen::Vector3d: enables `segment(...) = p.pos`
+	// and `Vec3d v = p.pos - other` to compile during the transition. Cost
+	// is a float -> double promotion, which is exact.
+	operator Eigen::Vector3d() const { return toVec3d(); }
+
+	float &operator[](int i) { return (&x)[i]; }
+	const float &operator[](int i) const { return (&x)[i]; }
+
+	Vec3f &operator+=(const Vec3f &o) { x += o.x; y += o.y; z += o.z; return *this; }
+	Vec3f &operator-=(const Vec3f &o) { x -= o.x; y -= o.y; z -= o.z; return *this; }
+	Vec3f &operator*=(float s) { x *= s; y *= s; z *= s; return *this; }
+	Vec3f &operator/=(float s) { x /= s; y /= s; z /= s; return *this; }
+
+	Vec3f operator+(const Vec3f &o) const { return {x + o.x, y + o.y, z + o.z}; }
+	Vec3f operator-(const Vec3f &o) const { return {x - o.x, y - o.y, z - o.z}; }
+	Vec3f operator-() const { return {-x, -y, -z}; }
+	Vec3f operator*(float s) const { return {x * s, y * s, z * s}; }
+	Vec3f operator/(float s) const { return {x / s, y / s, z / s}; }
+
+	float norm() const { return std::sqrt(x * x + y * y + z * z); }
+	float squaredNorm() const { return x * x + y * y + z * z; }
+	float dot(const Vec3f &o) const { return x * o.x + y * o.y + z * o.z; }
+	Vec3f cross(const Vec3f &o) const {
+		return {y * o.z - z * o.y, z * o.x - x * o.z, x * o.y - y * o.x};
+	}
+	Vec3f normalized() const {
+		const float n = norm();
+		return n > 0.0f ? Vec3f{x / n, y / n, z / n} : Vec3f{};
+	}
+	// In-place normalize, matching Eigen::Vector3d::normalize().
+	void normalize() {
+		const float n = norm();
+		if (n > 0.0f) { x /= n; y /= n; z /= n; }
+	}
+	void setZero() { x = 0.0f; y = 0.0f; z = 0.0f; }
+	bool hasNaN() const {
+		return std::isnan(x) || std::isnan(y) || std::isnan(z);
+	}
+};
+
+inline Vec3f operator*(float s, const Vec3f &v) { return v * s; }
+
+#endif // OMEGAENGINE_VEC3F_H

--- a/src/code/simulation/Particle.h
+++ b/src/code/simulation/Particle.h
@@ -31,29 +31,35 @@
 #define OMEGAENGINE_PARTICLE_H
 
 #include "../engine/Macros.h"
+#include "../engine/Vec3f.h"
 
 class Particle {
 public:
 	double mass;
 	int idx;
-	Vec3d pos_rest; // position where strain will be 0
-	Vec3d pos_init; // starting position
-	Vec3d pos;
+	// CHI-11 subtask 2: per-vertex state moved to in-house Vec3f.
+	// fp32 is plenty for positions / velocities / normals at cloth
+	// scales; the inertial predictor and PD/backward solves still run
+	// in fp64 via implicit promotion at the Eigen boundary.
+	Vec3f pos_rest; // position where strain will be 0
+	Vec3f pos_init; // starting position
+	Vec3f pos;
 	double radii;
 	double area; // the distributed area onto this particle
 
-	Vec3d velocity_init;
-	Vec3d normal;
+	Vec3f velocity_init;
+	Vec3f normal;
 	Vec2i planeCoord; // int coordiant in 2D cloth plane1
-	Vec3d velocity;
+	Vec3f velocity;
 
 	Particle(double mass, const Vec3d &rest_pos, const Vec3d &pos_initial,
 			const Vec3d &velocity, const Vec2i &planeCoord, int idx) :
-			mass(mass), pos_rest(rest_pos), pos_init(pos_initial), pos(pos_initial), velocity(velocity), velocity_init(velocity), planeCoord(planeCoord), normal(0, 0, 0), idx(idx){};
+			mass(mass), pos_rest(rest_pos), pos_init(pos_initial), pos(pos_initial), velocity(velocity), velocity_init(velocity), planeCoord(planeCoord), normal(0.0f, 0.0f, 0.0f), idx(idx){};
 
-	void addNormal(const Vec3d &n) { normal += n; }
+	void addNormal(const Vec3d &n) { normal += Vec3f(n); }
+	void addNormal(const Vec3f &n) { normal += n; }
 
-	void clearNormal() { normal = Vec3d(0.0, 0.0, 0.0); }
+	void clearNormal() { normal.setZero(); }
 
 	void printState() const {
 		std::printf("Paricle %d x=(%.2f,%.2f,%.2f) v=(%.9f,%.9f,%.9f)\n", idx,

--- a/src/code/simulation/Primitive.h
+++ b/src/code/simulation/Primitive.h
@@ -108,7 +108,7 @@ public:
 		VecXd out(points.size() * 3);
 		out.setZero();
 		for (int i = 0; i < points.size(); i++) {
-			out.segment(i * 3, 3) = points[i].pos + center;
+			out.segment(i * 3, 3) = points[i].pos.toVec3d() + center;
 		}
 
 		return out;
@@ -126,7 +126,7 @@ public:
 
 		int posOffset = cumulativePos.rows();
 		for (int i = 0; i < points.size(); i++) {
-			newCumulativePos.segment(posOffset + i * 3, 3) = points[i].pos + center;
+			newCumulativePos.segment(posOffset + i * 3, 3) = points[i].pos.toVec3d() + center;
 		}
 
 		for (int i = 0; i < mesh.size(); i++) {
@@ -189,11 +189,14 @@ public:
 	}
 
 	static std::pair<bool, Vec3d> pointInsideTriangle(Triangle t, Vec3d p_prime) {
-		Vec3d AB = (t.p1()->pos - t.p0()->pos);
-		Vec3d AC = (t.p2()->pos - t.p0()->pos);
+		const Vec3d p0d = t.p0()->pos.toVec3d();
+		const Vec3d p1d = t.p1()->pos.toVec3d();
+		const Vec3d p2d = t.p2()->pos.toVec3d();
+		Vec3d AB = p1d - p0d;
+		Vec3d AC = p2d - p0d;
 		Vec3d n = AB.cross(AC);
 		double n2 = n.squaredNorm();
-		Vec3d AP = p_prime - t.p0()->pos;
+		Vec3d AP = p_prime - p0d;
 		double alpha = AB.cross(AP).dot(n) / n2;
 		double beta = AP.cross(AC).dot(n) / n2;
 		double gamma = 1 - alpha - beta;
@@ -201,7 +204,7 @@ public:
 		bool isInside = (alpha >= 0) && (beta >= 0) && (gamma >= 0) &&
 				(gamma <= 1) && (alpha <= 1) && (beta <= 1);
 
-		Vec3d proj = alpha * t.p1()->pos + beta * t.p2()->pos + gamma * t.p0()->pos;
+		Vec3d proj = alpha * p1d + beta * p2d + gamma * p0d;
 		return std::make_pair(isInside, proj);
 	}
 

--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -59,6 +59,18 @@ namespace {
     bool g_usePD    = (std::getenv("USE_PD") != nullptr);
     bool g_useAvbd  = !g_usePD;
 
+    // CHI-11 subtask 1: when AVBD will drive every step and the PD CG
+    // loop is short-circuited (default on Apple Silicon), the only
+    // per-step PD state that matters is what backward() reads. The
+    // forward-only PD kernels — Msolver factorization, M*s_n,
+    // P*x_n, the b vector — are pure waste. This gate skips them.
+    // AVBD_NO_SKIP_PD=1 re-enables the PD CG loop for shadow
+    // comparison; in that case PD must keep its full forward state.
+    bool pdForwardActive() {
+        if (g_usePD) return true;
+        return std::getenv("AVBD_NO_SKIP_PD") != nullptr;
+    }
+
     // metallib search path. Override with SLANG_METALLIB_DIR=... in env.
     std::string slangMetallibDir() {
         if (const char* env = std::getenv("SLANG_METALLIB_DIR")) return env;
@@ -1587,46 +1599,43 @@ void Simulation::step() {
 
 	{
 		timeSteptimer.tic("PD init");
-		Eigen::VectorXd b(3 * particles.size());
-		b.setZero();
-		double newEnergy = 0;
-		curEnergy = 1000000;
-		double min_xdiff = ((s_n - x_n).norm() * (1.0 / particles.size()));
-		int min_xdiffiter = 0;
 
-		VecXd M_times_sn = M * s_n;
-		VecXd P_times_xn = sysMat[currentSysmatId].P * x_n;
-		VecXd x_new_lastconverging = x_n, v_new_lastconverging = v_n;
-
-		timeSteptimer.toc();
-		PD_TOTAL_ITER = (-std::log10(forwardConvergenceThreshold)) * 150;
-
+		// CHI-11 subtask 1: decide whether PD's CG loop will actually
+		// iterate before allocating its working set. When AVBD drives
+		// every step (default on Apple Silicon), b / M*s_n / P*x_n are
+		// pure waste — the loop runs zero iterations and AVBD_DRIVE
+		// overwrites particles[i].{pos, velocity}. AVBD_NO_SKIP_PD=1
+		// or AVBD_NO_DRIVE=1 keeps PD active for shadow comparison.
 #ifdef __APPLE__
-		// AVBD_SKIP_PD=1 + AVBD_DRIVE=1: short-circuit PD's CG loop
-		// entirely. AVBD provides the per-step positions; PD's
-		// converged x_new would just get overwritten by AVBD_DRIVE
-		// anyway, so iterating it is pure waste. Initialize
-		// x_new / v_new to the inertial predictor so post-loop code
-		// paths have sensible values, then PD_TOTAL_ITER = 0 skips
-		// the loop body. AVBD_DRIVE later overwrites
-		// particles[i].{pos, velocity} with AVBD's solve.
-		// PD's CG loop is short-circuited when AVBD drives the
-		// step. Inverted env: AVBD_NO_SKIP_PD=1 re-enables iteration
-		// (only useful for shadow comparison; the result gets thrown
-		// away by AVBD_DRIVE anyway). AVBD_NO_DRIVE=1 turns off the
-		// writeback so PD's converged x_new is kept.
-		static const bool s_avbdSkipPD =
-		    (std::getenv("AVBD_NO_SKIP_PD") == nullptr);
 		static const bool s_avbdDriveEnv =
 		    (std::getenv("AVBD_NO_DRIVE") == nullptr);
 		const bool avbdWillDrive = s_avbdDriveEnv && g_useAvbd &&
 		    currentSysmatId == 0 && sysMat[0].avbd && sysMat[0].avbd->ok();
-		if (s_avbdSkipPD && avbdWillDrive) {
+		const bool runPDLoop = pdForwardActive() || !avbdWillDrive;
+#else
+		const bool runPDLoop = true;
+#endif
+
+		Eigen::VectorXd b;
+		VecXd M_times_sn, P_times_xn;
+		double newEnergy = 0;
+		curEnergy = 1000000;
+		double min_xdiff = ((s_n - x_n).norm() * (1.0 / particles.size()));
+		int min_xdiffiter = 0;
+		VecXd x_new_lastconverging = x_n, v_new_lastconverging = v_n;
+
+		if (runPDLoop) {
+			b = Eigen::VectorXd::Zero(3 * particles.size());
+			M_times_sn = M * s_n;
+			P_times_xn = sysMat[currentSysmatId].P * x_n;
+			PD_TOTAL_ITER = (-std::log10(forwardConvergenceThreshold)) * 150;
+		} else {
 			x_new = s_n;
 			v_new = (s_n - x_n) / sceneConfig.timeStep;
 			PD_TOTAL_ITER = 0;
 		}
-#endif
+
+		timeSteptimer.toc();
 
 		for (int iterIdx = 0; iterIdx < PD_TOTAL_ITER; iterIdx++) {
 			timeSteptimer.tic("iter init");
@@ -3922,7 +3931,13 @@ void Simulation::updateMassMatrix() {
 		std::printf("\n");
 	}
 
-	factorizeDirectSolverLLT(M, Msolver, "Msolver pre factorization");
+	// Msolver is only consumed by PD's forward CG path. When AVBD
+	// drives the step (default on Apple Silicon), the factorization
+	// is dead state — M is diagonal so LLT(M) is trivial, but the
+	// solver object still allocates symbolic + numerical factors.
+	if (pdForwardActive()) {
+		factorizeDirectSolverLLT(M, Msolver, "Msolver pre factorization");
+	}
 }
 
 void Simulation::initializePrefactoredMatrices() {

--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -157,13 +157,14 @@ double Simulation::calculateMaxTriangleDeformation(VecXd &x_new) {
 	return maxDeformation;
 }
 
-const double Simulation::fillForces(VecXd &f_int, VecXd &f_ext, const VecXd &v,
-		const VecXd &x, double t_now) {
-	// calculate forces
-	f_int.setZero();
-	// Internal forces calculation not needed for PD
-	f_ext.setZero();
-	// externalForces
+const double Simulation::fillForces(std::vector<float> &f_int,
+		std::vector<float> &f_ext, const VecXd &v, const VecXd &x, double t_now) {
+	// CHI-11 subtask 4: per-vertex AoS force buffers. f_int stays in
+	// the signature for symmetry with the old API but is unused — PD
+	// never reads internal forces from this path, it computes them
+	// through the constraint-projection matrix.
+	std::fill(f_int.begin(), f_int.end(), 0.0f);
+	std::fill(f_ext.begin(), f_ext.end(), 0.0f);
 	double windFactor = 1.0;
 
 	switch (sceneConfig.windConfig) {
@@ -188,11 +189,13 @@ const double Simulation::fillForces(VecXd &f_int, VecXd &f_ext, const VecXd &v,
 	}
 
 	if (enableConstantForcefield) {
-		f_ext += external_force_field;
+		const Eigen::Index n = external_force_field.size();
+		for (Eigen::Index i = 0; i < n; ++i) {
+			f_ext[size_t(i)] += float(external_force_field[i]);
+		}
 	}
 
-	//  double windFactor = 1.0;
-	for (int i = 0; i < particles.size(); i++) {
+	for (int i = 0; i < (int)particles.size(); i++) {
 		Particle &p = particles[i];
 		Vec3d f_i(0, 0, 0);
 		if (gravityEnabled)
@@ -207,7 +210,10 @@ const double Simulation::fillForces(VecXd &f_int, VecXd &f_ext, const VecXd &v,
 			f_i += windf_i;
 		}
 
-		f_ext.segment(p.idx * 3, 3) += f_i;
+		const size_t base = size_t(p.idx) * 3;
+		f_ext[base + 0] += float(f_i[0]);
+		f_ext[base + 1] += float(f_i[1]);
+		f_ext[base + 2] += float(f_i[2]);
 	}
 
 	return windFactor;
@@ -1212,7 +1218,12 @@ void Simulation::step() {
 
 	VecXd x_new(3 * particles.size());
 	VecXd v_new(3 * particles.size());
-	VecXd f_int(3 * particles.size()), f_ext(3 * particles.size());
+	// CHI-11 subtask 4: per-vertex external/internal force buffers
+	// switch from VecXd (3*N doubles + Eigen machinery) to a flat
+	// std::vector<float> AoS. f_int is dead code in this path; both
+	// stay zero-initialized by fillForces.
+	std::vector<float> f_int(3 * particles.size(), 0.0f);
+	std::vector<float> f_ext(3 * particles.size(), 0.0f);
 	VecXd f(3 * particles.size()); // this is f in contact force calculation, but
 								   // it's different than f_int + f_ext
 	VecXd r(3 * particles.size());
@@ -1225,8 +1236,22 @@ void Simulation::step() {
 	r.setZero();
 
 	double windFactor = fillForces(f_int, f_ext, v_n, x_n, returnRecord.t);
-	s_n = x_n + sceneConfig.timeStep * v_n +
-			sceneConfig.timeStep * sceneConfig.timeStep * M_inv * f_ext;
+	// Inertial predictor s_n = x_n + h·v_n + h²·M⁻¹·f_ext. M is
+	// diagonal (per-vertex mass), so the matvec reduces to a flat
+	// per-vertex scale — no need to round-trip f_ext through Eigen.
+	{
+		const double h  = sceneConfig.timeStep;
+		const double h2 = h * h;
+		s_n = x_n + h * v_n;
+		const size_t nV = particles.size();
+		for (size_t i = 0; i < nV; ++i) {
+			const double m_inv_i = 1.0 / particles[i].mass;
+			const size_t b = i * 3;
+			s_n[Eigen::Index(b + 0)] += h2 * m_inv_i * double(f_ext[b + 0]);
+			s_n[Eigen::Index(b + 1)] += h2 * m_inv_i * double(f_ext[b + 1]);
+			s_n[Eigen::Index(b + 2)] += h2 * m_inv_i * double(f_ext[b + 2]);
+		}
+	}
 
 	returnRecord.x_prev = x_n;
 	returnRecord.v_prev = v_n;
@@ -1267,9 +1292,24 @@ void Simulation::step() {
 		// velocity: s_n_avbd = x_n + h·damp·v_n + h²·M_inv·f_ext.
 		// At damp=1.0 this is identical to s_n.
 		const double dampFactor = double(s_avbdDamp);
-		VecXd s_n_avbd = (dampFactor == 1.0) ? s_n
-		    : (x_n + sceneConfig.timeStep * dampFactor * v_n +
-		       sceneConfig.timeStep * sceneConfig.timeStep * M_inv * f_ext);
+		VecXd s_n_avbd;
+		if (dampFactor == 1.0) {
+			s_n_avbd = s_n;
+		} else {
+			// Same per-vertex M⁻¹·f_ext rewrite as above, just with
+			// damped velocity.
+			const double h  = sceneConfig.timeStep;
+			const double h2 = h * h;
+			s_n_avbd = x_n + h * dampFactor * v_n;
+			const size_t nV2 = particles.size();
+			for (size_t i = 0; i < nV2; ++i) {
+				const double m_inv_i = 1.0 / particles[i].mass;
+				const size_t b = i * 3;
+				s_n_avbd[Eigen::Index(b + 0)] += h2 * m_inv_i * double(f_ext[b + 0]);
+				s_n_avbd[Eigen::Index(b + 1)] += h2 * m_inv_i * double(f_ext[b + 1]);
+				s_n_avbd[Eigen::Index(b + 2)] += h2 * m_inv_i * double(f_ext[b + 2]);
+			}
+		}
 
 		// CHI-119: friction-as-predictor-blend, TANGENT-ONLY projection.
 		// Per AVBD's penalty formulation: friction is a per-vertex

--- a/src/code/simulation/Simulation.cpp
+++ b/src/code/simulation/Simulation.cpp
@@ -224,8 +224,8 @@ void Simulation::updateCurrentPosVelocityVec() {
 	x_n.setZero();
 
 	for (const Particle &p : particles) {
-		v_n.segment(p.idx * 3, 3) = p.velocity;
-		x_n.segment(p.idx * 3, 3) = p.pos;
+		v_n.segment(p.idx * 3, 3) = p.velocity.toVec3d();
+		x_n.segment(p.idx * 3, 3) = p.pos.toVec3d();
 	}
 }
 
@@ -238,8 +238,8 @@ std::pair<VecXd, VecXd> Simulation::getCurrentPosVelocityVec() const {
 	bool encounteredNAN = false;
 	int nanCount = 0;
 	for (const Particle &p : particles) {
-		velocity.segment(p.idx * 3, 3) = p.velocity;
-		pos.segment(p.idx * 3, 3) = p.pos;
+		velocity.segment(p.idx * 3, 3) = p.velocity.toVec3d();
+		pos.segment(p.idx * 3, 3) = p.pos.toVec3d();
 		if (std::isnan(p.pos.norm())) {
 			encounteredNAN = true;
 			nanCount++;
@@ -2197,7 +2197,7 @@ void Simulation::step() {
 					VecXd v_zero = VecXd::Zero(3 * particles.size());
 					VecXd x_now(3 * particles.size());
 					for (size_t i = 0; i < particles.size(); ++i)
-						x_now.segment(3 * i, 3) = particles[i].pos;
+						x_now.segment(3 * i, 3) = particles[i].pos.toVec3d();
 					auto info = collisionDetection(x_now, v_zero,
 					                                xnew_n_primitives, v_n_primitives);
 					auto _t1 = std::chrono::steady_clock::now();
@@ -2243,7 +2243,7 @@ void Simulation::step() {
 		if (forwardRecords.size() == dumpStep) {
 			VecXd positions(3 * particles.size());
 			for (size_t i = 0; i < particles.size(); ++i)
-				positions.segment(3 * i, 3) = particles[i].pos;
+				positions.segment(3 * i, 3) = particles[i].pos.toVec3d();
 			std::vector<Vec3i> triList(mesh.size());
 			for (size_t i = 0; i < mesh.size(); ++i)
 				triList[i] = Vec3i(mesh[i].p0_idx, mesh[i].p1_idx, mesh[i].p2_idx);
@@ -4355,7 +4355,7 @@ void Simulation::loadWindSim2RealAnimationSequence(
 
 	Vec3d windFocusPoint = Vec3d(0, -1, 0);
 	for (int i = 0; i < particles.size(); i++) {
-		double distSquared = (windFocusPoint - particles[i].pos).norm();
+		double distSquared = (windFocusPoint - particles[i].pos.toVec3d()).norm();
 
 		windFallOff.segment(i * 3, 3) =
 				Vec3d::Ones() * std::min(1.0 / distSquared, 1.0);
@@ -4681,7 +4681,7 @@ double Simulation::calculateLossAndGradient(LossType &lossType,
 			Vec3d targetTranslation = lossInfo.targetTranslation;
 			VecXd x_target(3 * particles.size());
 			for (const Particle &p : particles) {
-				x_target.segment(3 * p.idx, 3) = p.pos_init + targetTranslation;
+				x_target.segment(3 * p.idx, 3) = p.pos_init.toVec3d() + targetTranslation;
 			}
 			VecXd &x_current = forwardRecords[lastIdx].x;
 			int n_particles = particles.size();

--- a/src/code/simulation/Simulation.h
+++ b/src/code/simulation/Simulation.h
@@ -1031,7 +1031,7 @@ public:
 	void initializePrefactoredMatrices();
 
 private:
-	const double fillForces(Eigen::VectorXd &f_int, Eigen::VectorXd &f_ext,
+	const double fillForces(std::vector<float> &f_int, std::vector<float> &f_ext,
 			const Eigen::VectorXd &velocityVec,
 			const Eigen::VectorXd &posVec, double t_now);
 

--- a/src/code/simulation/Triangle.cpp
+++ b/src/code/simulation/Triangle.cpp
@@ -544,8 +544,8 @@ Triangle::Triangle(int p0_idx, int p1_idx, int p2_idx,
 	inv_deltaUV.setZero();
 
 	Mat3x2d edgeVec;
-	edgeVec.col(0) = p1()->pos_rest - p0()->pos_rest;
-	edgeVec.col(1) = p2()->pos_rest - p0()->pos_rest;
+	edgeVec.col(0) = p1()->pos_rest.toVec3d() - p0()->pos_rest.toVec3d();
+	edgeVec.col(1) = p2()->pos_rest.toVec3d() - p0()->pos_rest.toVec3d();
 	P.col(0) = edgeVec.col(0).normalized();
 	P.col(1) =
 			(edgeVec.col(1) - edgeVec.col(1).dot(P.col(0)) * P.col(0)).normalized();

--- a/src/code/simulation/TriangleBending.cpp
+++ b/src/code/simulation/TriangleBending.cpp
@@ -228,7 +228,7 @@ TriangleBending::TriangleBending(int p0_idx, int p1_idx, int p2_idx, int p3_idx,
 	Mat3x4d pos(3, 4);
 	pos.setZero();
 	for (int i = 0; i < 4; i++)
-		pos.col(i) = pArr[idx_arr[i]].pos_rest;
+		pos.col(i) = pArr[idx_arr[i]].pos_rest.toVec3d();
 
 	double l01 = (pos.col(1) - pos.col(0)).norm();
 	double l02 = (pos.col(2) - pos.col(0)).norm();


### PR DESCRIPTION
## Summary

Three of CHI-11's five subtasks. Together: the PD-only init kernels skip when AVBD drives, the per-step external-force buffer drops to fp32, and Particle's per-vertex state moves to in-house Vec3f.

- `c7d6ff9` **Subtask 1** — gate PD-only state behind `pdForwardActive()`. Skips `Msolver` factorization and the `M*s_n` / `P*x_n` / `b` kernels when AVBD drives. Strict no-op in both paths (gated kernels were inputs to a zero-iteration loop).
- `3654f7c` **Subtask 4** — local `f_int`/`f_ext` `VecXd(3N)` → `std::vector<float>(3N, 0)`. Inertial predictor `s_n = x_n + h·v_n + h²·M⁻¹·f_ext` rewritten as per-vertex scale (M⁻¹ is diagonal, no matvec needed).
- `a6e5e05` **Subtask 2** — Particle's 6 Vec3d members (pos, pos_rest, pos_init, velocity, velocity_init, normal) → in-house Vec3f. New header `src/code/engine/Vec3f.h`; implicit conversion to/from Eigen with explicit `.toVec3d()` at 13 ambiguity sites.

Subtasks 3 (Triangle/Spring/TriangleBending Eigen members) and 5 (`#include` removal, gated on 3) are deferred — see [CHI-11](https://linear.app/chibifire/issue/CHI-11/rip-out-eigen-in-v-sekaitool-cloth-dynamics) comments for the two attempted approaches and why they need a separate 4-6 hour pass.

## Test plan

Default AVBD path, first LBFGS evaluation:

| Demo | First loss (CHI-11) | Notes |
|---|---|---|
| sphere  | 0.00000000  | Matches main — pre-existing "no tangent force from vertical contact" behavior |
| sock    | 56.92476339 | vs. subtask-1 baseline 56.92410604 (within LBFGS line-search noise) |
| hat     | 64.37873766 | Clean forward+backward, no NaN |
| dress   | ⏳ in-progress | Forward (400 steps) + start of backward both clean; LBFGS iter 1 not yet timed-out completion |
| tshirt  | ⚠️ pre-existing crash | `Assertion failed: aLhs.rows() == aRhs.rows() … (CwiseBinaryOp.h:119)` at ~step 251 — verified identical crash on `main` (commit `7442dad`). NOT a CHI-11 regression. |

Subtask 4 alone (without subtask 2): sock first loss 57.01134097 (+0.15% from fp32 in `f_ext`). Subtask 2 brings it back to ~baseline because the larger fp32 surface on Particle state averages out.

- [x] Build clean (single pre-existing warning: `-Wdeprecated-this-capture` in Simulation.cpp:3649)
- [x] sphere / sock / hat: forward + backward run to completion, no NaN, no explosion
- [x] tshirt crash predates this branch
- [ ] dress: full LBFGS iteration takes > 4 min; not bench-blocked but should be re-verified before merge